### PR TITLE
refactor: use gob encoding instead of unsafe.Pointers

### DIFF
--- a/cardinal/component/component.go
+++ b/cardinal/component/component.go
@@ -1,9 +1,5 @@
 package component
 
-import (
-	"unsafe"
-)
-
 type (
 	TypeID int
 
@@ -13,7 +9,7 @@ type (
 		ID() TypeID
 		// New creates a new pointer to the component struct. It will set the struct being pointed to with the default
 		//value if the component was created with one. Otherwise, the struct being pointed to will be empty.
-		New() unsafe.Pointer
+		New() ([]byte, error)
 		// Name returns the name of the component.
 		Name() string
 	}

--- a/cardinal/ecs_test.go
+++ b/cardinal/ecs_test.go
@@ -19,9 +19,15 @@ type OwnableComponent struct {
 
 func UpdateEnergySystem(w World) {
 	Energy.Each(w, func(entry *Entry) {
-		energyPlanet := Energy.Get(entry)
+		energyPlanet, err := Energy.Get(entry)
+		if err != nil {
+			panic(err)
+		}
 		energyPlanet.Amt += 10 // bs whatever
-
+		err = Energy.Set(entry, &energyPlanet)
+		if err != nil {
+			panic(err)
+		}
 	})
 }
 
@@ -43,7 +49,8 @@ func Test_ECS(t *testing.T) {
 	world.Update()
 
 	Energy.Each(world, func(entry *Entry) {
-		energyPlanet := Energy.Get(entry)
+		energyPlanet, err := Energy.Get(entry)
+		assert.NilError(t, err)
 		assert.Equal(t, int64(10), energyPlanet.Amt)
 	})
 

--- a/cardinal/go.mod
+++ b/cardinal/go.mod
@@ -1,6 +1,6 @@
 module github.com/argus-labs/cardinal
 
-go 1.20
+go 1.19
 
 require (
 	github.com/alicebob/miniredis/v2 v2.30.1

--- a/cardinal/internal/storage/components.go
+++ b/cardinal/internal/storage/components.go
@@ -36,7 +36,7 @@ func (cs *Components) PushComponents(components []component.IComponentType, arch
 	return cs.componentIndices[archetypeIndex]
 }
 
-// Move moves the pointer to data of the component in the archetype.
+// Move moves the bytes of data of the component in the archetype.
 func (cs *Components) Move(src ArchetypeIndex, dst ArchetypeIndex) {
 	cs.componentIndices[src]--
 	cs.componentIndices[dst]++

--- a/cardinal/internal/storage/components_test.go
+++ b/cardinal/internal/storage/components_test.go
@@ -11,8 +11,8 @@ func TestComponents(t *testing.T) {
 		ID string
 	}
 	var (
-		ca = NewMockComponentType(ComponentData{}, nil)
-		cb = NewMockComponentType(ComponentData{}, nil)
+		ca = NewMockComponentType(ComponentData{}, ComponentData{ID: "foo"})
+		cb = NewMockComponentType(ComponentData{}, ComponentData{ID: "bar"})
 	)
 
 	components := NewComponents()
@@ -47,8 +47,10 @@ func TestComponents(t *testing.T) {
 			if !st.Contains(tt.archIdx, tt.compIdx) {
 				t.Errorf("storage should contain the component at %d, %d", tt.archIdx, tt.compIdx)
 			}
-			dat := (*ComponentData)(st.Component(tt.archIdx, tt.compIdx))
+			bz := st.Component(tt.archIdx, tt.compIdx)
+			dat := decodeComponent[ComponentData](t, bz)
 			dat.ID = tt.ID
+			st.SetComponent(tt.archIdx, tt.compIdx, encodeComponent[ComponentData](t, dat))
 		}
 	}
 
@@ -73,8 +75,9 @@ func TestComponents(t *testing.T) {
 		t.Errorf("storage should contain the component at %d, %d", dstArchIdx, target.compIdx)
 	}
 
-	dat := (*ComponentData)(storage.Component(dstArchIdx, newCompIdx))
+	bz := storage.Component(dstArchIdx, newCompIdx)
+	dat := decodeComponent[ComponentData](t, bz)
 	if dat.ID != target.ID {
-		t.Errorf("component should have ID %s", target.ID)
+		t.Errorf("component should have ID '%s', got ID '%s'", target.ID, dat.ID)
 	}
 }

--- a/cardinal/internal/storage/mock.go
+++ b/cardinal/internal/storage/mock.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"bytes"
+	"encoding/gob"
 	"fmt"
 	"reflect"
 	"unsafe"
@@ -32,14 +34,15 @@ func (m *MockComponentType[T]) ID() component.TypeID {
 	return m.id
 }
 
-func (m *MockComponentType[T]) New() unsafe.Pointer {
-	val := reflect.New(m.typ)
-	v := reflect.Indirect(val)
-	ptr := unsafe.Pointer(v.UnsafeAddr())
+func (m *MockComponentType[T]) New() ([]byte, error) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	var comp T
 	if m.defaultVal != nil {
-		m.setDefaultVal(ptr)
+		comp = m.defaultVal.(T)
 	}
-	return ptr
+	err := enc.Encode(comp)
+	return buf.Bytes(), err
 }
 
 func (m *MockComponentType[T]) setDefaultVal(ptr unsafe.Pointer) {

--- a/cardinal/internal/storage/storage_test.go
+++ b/cardinal/internal/storage/storage_test.go
@@ -1,17 +1,21 @@
 package storage
 
 import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
 	"testing"
-	"unsafe"
+
+	"gotest.tools/v3/assert"
 )
 
-func TestStorage(t *testing.T) {
+func TestStorage_Bytes(t *testing.T) {
 	type Component struct{ ID string }
 	var (
-		componentType = NewMockComponentType[any](Component{}, nil)
+		componentType = NewMockComponentType[any](Component{}, Component{ID: "foo"})
 	)
 
-	st := NewStorage()
+	store := NewStorage()
 
 	tests := []struct {
 		ID       string
@@ -24,28 +28,32 @@ func TestStorage(t *testing.T) {
 
 	var archIdx ArchetypeIndex = 0
 	var compIdx ComponentIndex = 0
-	for _, tt := range tests {
-		st.PushComponent(componentType, archIdx)
-		st.SetComponent(archIdx, compIdx, unsafe.Pointer(&Component{ID: tt.ID}))
+	for _, test := range tests {
+		err := store.PushComponent(componentType, archIdx)
+		assert.NilError(t, err)
+		bz := encodeComponent(t, Component{ID: test.ID})
+		fmt.Println(string(bz))
+		store.SetComponent(archIdx, compIdx, bz)
 		compIdx++
 	}
 
 	compIdx = 0
-	for _, tt := range tests {
-		if c := (*Component)(st.Component(archIdx, compIdx)); c.ID != tt.expected {
-			t.Errorf("component should have ID %s", tt.expected)
-		}
+	for _, test := range tests {
+		bz := store.Component(archIdx, compIdx)
+		var buf bytes.Buffer
+		buf.Write(bz)
+		dec := gob.NewDecoder(&buf)
+		c := &Component{}
+		err := dec.Decode(c)
+		assert.NilError(t, err)
+		assert.Equal(t, c.ID, test.expected)
 		compIdx++
 	}
 
-	// SwapRemove component
-	removed := (*Component)(st.SwapRemove(archIdx, 1))
-	if removed == nil {
-		t.Fatalf("removed component should not be nil")
-	}
-	if removed.ID != "b" {
-		t.Errorf("removed component should have ID b")
-	}
+	removed := store.SwapRemove(archIdx, 1)
+	assert.Assert(t, removed != nil, "removed component should not be nil")
+	comp := decodeComponent[Component](t, removed)
+	assert.Equal(t, comp.ID, "b", "removed component should have ID 'b'")
 
 	tests2 := []struct {
 		archIdx    ArchetypeIndex
@@ -56,10 +64,28 @@ func TestStorage(t *testing.T) {
 		{archIdx: 0, cmpIdx: 1, expectedID: "c"},
 	}
 
-	for _, tt := range tests2 {
-		if c := (*Component)(st.Component(tt.archIdx, tt.cmpIdx)); c.ID != tt.expectedID {
-			t.Errorf("component should have ID %s but got %s", tt.expectedID, c.ID)
-		}
+	for _, test := range tests2 {
+		compBz := store.Component(test.archIdx, test.cmpIdx)
+		comp := decodeComponent[Component](t, compBz)
+		assert.Equal(t, comp.ID, test.expectedID)
 		compIdx++
 	}
+}
+
+func decodeComponent[T any](t *testing.T, bz []byte) T {
+	var buf bytes.Buffer
+	buf.Write(bz)
+	dec := gob.NewDecoder(&buf)
+	comp := new(T)
+	err := dec.Decode(comp)
+	assert.NilError(t, err)
+	return *comp
+}
+
+func encodeComponent[T any](t *testing.T, comp T) []byte {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	err := enc.Encode(comp)
+	assert.NilError(t, err)
+	return buf.Bytes()
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

refactors the storage model of the ECS to use binary encodings, rather than `unsafe.Pointer`. This opens the door for us to use different storage models. 
