### PR TITLE
refactor(cardinal): Only expose the EntityID type in the public facing…

### DIFF
--- a/cardinal/ecs/query.go
+++ b/cardinal/ecs/query.go
@@ -31,18 +31,14 @@ func NewQuery(filter filter.LayoutFilter) *Query {
 }
 
 // Each iterates over all entityLocationStore that match the query.
-func (q *Query) Each(w *World, callback func(storage.Entity)) {
+func (q *Query) Each(w *World, callback func(storage.EntityID)) {
 	accessor := w.StorageAccessor()
 	result := q.evaluateQuery(w, &accessor)
 	iter := storage.NewEntityIterator(0, accessor.Archetypes, result)
-	f := func(id storage.EntityID) {
-		entity, _ := w.Entity(id)
-		callback(entity)
-	}
 	for iter.HasNext() {
 		entities := iter.Next()
-		for _, e := range entities {
-			f(e)
+		for _, id := range entities {
+			callback(id)
 		}
 	}
 }
@@ -61,24 +57,20 @@ func (q *Query) Count(w *World) int {
 }
 
 // First returns the first entity that matches the query.
-func (q *Query) First(w *World) (entity storage.Entity, ok bool, err error) {
+func (q *Query) First(w *World) (id storage.EntityID, ok bool, err error) {
 	accessor := w.StorageAccessor()
 	result := q.evaluateQuery(w, &accessor)
 	iter := storage.NewEntityIterator(0, accessor.Archetypes, result)
 	if !iter.HasNext() {
-		return storage.BadEntity, false, err
+		return storage.BadID, false, err
 	}
 	for iter.HasNext() {
 		entities := iter.Next()
 		if len(entities) > 0 {
-			ent, err := w.Entity(entities[0])
-			if err != nil {
-				return storage.BadEntity, false, err
-			}
-			return ent, true, err
+			return entities[0], true, nil
 		}
 	}
-	return storage.BadEntity, false, err
+	return storage.BadID, false, err
 }
 
 func (q *Query) evaluateQuery(world *World, accessor *StorageAccessor) []storage.ArchetypeIndex {

--- a/cardinal/ecs/storage/entity.go
+++ b/cardinal/ecs/storage/entity.go
@@ -78,8 +78,12 @@ var (
 )
 
 // Get returns the component from the entity
-func Get[T any](w WorldAccessor, e Entity, cType component.IComponentType) (*T, error) {
+func Get[T any](w WorldAccessor, id EntityID, cType component.IComponentType) (*T, error) {
 	var comp *T
+	e, err := w.Entity(id)
+	if err != nil {
+		return nil, err
+	}
 	compBz, err := e.Component(w, cType)
 	if err != nil {
 		return nil, err
@@ -92,7 +96,11 @@ func Get[T any](w WorldAccessor, e Entity, cType component.IComponentType) (*T, 
 }
 
 // Add adds the component to the entity.
-func Add[T any](w WorldAccessor, e Entity, cType component.IComponentType, component *T) error {
+func Add[T any](w WorldAccessor, id EntityID, cType component.IComponentType, component *T) error {
+	e, err := w.Entity(id)
+	if err != nil {
+		return err
+	}
 	bz, err := Encode(component)
 	if err != nil {
 		return err
@@ -102,7 +110,11 @@ func Add[T any](w WorldAccessor, e Entity, cType component.IComponentType, compo
 }
 
 // Set sets the component of the entity.
-func Set[T any](w WorldAccessor, e Entity, ctype component.IComponentType, component *T) error {
+func Set[T any](w WorldAccessor, id EntityID, ctype component.IComponentType, component *T) error {
+	e, err := w.Entity(id)
+	if err != nil {
+		return err
+	}
 	bz, err := Encode(component)
 	if err != nil {
 		return err
@@ -112,8 +124,8 @@ func Set[T any](w WorldAccessor, e Entity, ctype component.IComponentType, compo
 }
 
 // SetValue sets the value of the component.
-func SetValue[T any](w WorldAccessor, e Entity, ctype component.IComponentType, value T) error {
-	c, err := Get[T](w, e, ctype)
+func SetValue[T any](w WorldAccessor, id EntityID, ctype component.IComponentType, value T) error {
+	c, err := Get[T](w, id, ctype)
 	if err != nil {
 		return err
 	}
@@ -122,14 +134,22 @@ func SetValue[T any](w WorldAccessor, e Entity, ctype component.IComponentType, 
 }
 
 // Remove removes the component from the entity.
-func Remove[T any](w WorldAccessor, e Entity, ctype component.IComponentType) {
-	e.RemoveComponent(w, ctype)
+func Remove[T any](w WorldAccessor, id EntityID, ctype component.IComponentType) error {
+	e, err := w.Entity(id)
+	if err != nil {
+		return err
+	}
+	return e.RemoveComponent(w, ctype)
 }
 
 // Valid returns true if the entity is valid.
-func Valid(w WorldAccessor, e Entity) (bool, error) {
-	if e == BadEntity {
+func Valid(w WorldAccessor, id EntityID) (bool, error) {
+	if id == BadID {
 		return false, nil
+	}
+	e, err := w.Entity(id)
+	if err != nil {
+		return false, err
 	}
 	ok, err := e.Valid(w)
 	return ok, err


### PR DESCRIPTION
… API; users do not need to know about Location information

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #[WORLD-154](https://linear.app/arguslabs/issue/WORLD-154/simplify-the-exposed-entity-data-model)

## What is the purpose of the change

Currently, cardinal users are expected to convert storage.EntityIDs to storage.Entity using the world.Entity() method. storage.Entity has a "Location" field which is implementation detail information that the cardinal user doesn't need to know. This PR makes it so all commonly used ECS methods only take in EntityIDs and return EntityIDs.

Ideally the world.Entity method would be removed and the Entity struct would be completely hidden from end users, however I think that will be a more complicated refactoring job.

## Brief Changelog

- Replace instances of storage.Entity in methods with storage.EntityID

## Testing and Verifying

This change is already covered by ecs_test.go.

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? (yes)
- Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
- How is the feature or change documented? (not documented)
