### PR TITLE
feat(cardinal): Create helpers to create ecs.World objects that use i…

### DIFF
--- a/cardinal/ecs/inmem/inmem.go
+++ b/cardinal/ecs/inmem/inmem.go
@@ -1,0 +1,48 @@
+// Package inmem is a helper package that allows for the creation of an *ecs.World object
+// that uses an in-memory redis DB as the storage layer. This is useful for local development
+// or for tests. Data will not be persisted between runs, so this is not suitable for any
+// kind of prodcution or staging environemnts.
+package inmem
+
+import (
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/argus-labs/world-engine/cardinal/ecs"
+	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+)
+
+// NewECSWorld creates an ecs.World that uses an in-memory redis DB as the storage
+// layer. This is only suitable for local development. If you are creating an ecs.World for
+// unit tests, use NewECSWorldForTest.
+func NewECSWorld() *ecs.World {
+	s, err := miniredis.Run()
+	if err != nil {
+		panic("Unable to initialize in-memory redis")
+	}
+	return newInMemoryWorld(s)
+}
+
+// NewECSWorldForTest creates an ecs.World suitable for running in tests. Relevant resources
+// are automatically cleaned up at the completion of each test.
+func NewECSWorldForTest(t testing.TB) *ecs.World {
+	s := miniredis.RunT(t)
+	return newInMemoryWorld(s)
+}
+
+func newInMemoryWorld(s *miniredis.Miniredis) *ecs.World {
+	rs := storage.NewRedisStorage(storage.Options{
+		Addr:     s.Addr(),
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	}, "in-memory-world")
+	worldStorage := storage.NewWorldStorage(
+		storage.Components{Store: &rs, ComponentIndices: &rs},
+		&rs,
+		storage.NewArchetypeComponentIndex(),
+		storage.NewArchetypeAccessor(),
+		&rs,
+		&rs)
+
+	return ecs.NewWorld(worldStorage)
+}

--- a/cardinal/ecs/tests/components_test.go
+++ b/cardinal/ecs/tests/components_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/argus-labs/world-engine/cardinal/ecs"
 	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
 	storage2 "github.com/argus-labs/world-engine/cardinal/ecs/storage"
 	"gotest.tools/v3/assert"
 )
@@ -100,7 +101,7 @@ func TestComponents(t *testing.T) {
 }
 
 func TestErrorWhenAccessingComponentNotOnEntity(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	foundComp := ecs.NewComponentType[string]()
 	notFoundComp := ecs.NewComponentType[string]()
 	world.RegisterComponents(foundComp, notFoundComp)

--- a/cardinal/ecs/tests/ecs_test.go
+++ b/cardinal/ecs/tests/ecs_test.go
@@ -1,9 +1,9 @@
 package tests
 
 import (
+	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
 	"testing"
 
-	"github.com/alicebob/miniredis/v2"
 	"github.com/argus-labs/world-engine/cardinal/ecs"
 	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
 	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
@@ -38,21 +38,8 @@ var (
 	Ownable = ecs.NewComponentType[OwnableComponent]()
 )
 
-func newWorldForTest(t testing.TB) *ecs.World {
-	s := miniredis.RunT(t)
-	rs := storage.NewRedisStorage(storage.Options{
-		Addr:     s.Addr(),
-		Password: "", // no password set
-		DB:       0,  // use default DB
-	}, "0")
-	worldStorage := storage.NewWorldStorage(
-		storage.Components{Store: &rs, ComponentIndices: &rs}, &rs, storage.NewArchetypeComponentIndex(), storage.NewArchetypeAccessor(), &rs, &rs)
-
-	return ecs.NewWorld(worldStorage)
-}
-
 func TestECS(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	world.RegisterComponents(Energy, Ownable)
 
 	// create a bunch of planets!
@@ -79,7 +66,7 @@ func TestECS(t *testing.T) {
 }
 
 func TestVelocitySimulation(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	type Pos struct {
 		X, Y float64
 	}
@@ -111,7 +98,7 @@ func TestVelocitySimulation(t *testing.T) {
 }
 
 func TestCanSetDefaultValue(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	type Owner struct {
 		Name string
 	}
@@ -134,7 +121,7 @@ func TestCanSetDefaultValue(t *testing.T) {
 }
 
 func TestCanRemoveEntity(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	type Tuple struct {
 		A, B int
 	}
@@ -187,7 +174,7 @@ func TestCanRemoveEntity(t *testing.T) {
 }
 
 func TestCanRemoveEntriesDuringCallToEach(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	type CountComponent struct {
 		Val int
 	}
@@ -225,7 +212,7 @@ func TestCanRemoveEntriesDuringCallToEach(t *testing.T) {
 }
 
 func TestAddingAComponentThatAlreadyExistsIsError(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	energy := ecs.NewComponentType[EnergyComponent]()
 	world.RegisterComponents(energy)
 
@@ -235,7 +222,7 @@ func TestAddingAComponentThatAlreadyExistsIsError(t *testing.T) {
 }
 
 func TestRemovingAMissingComponentIsError(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	reactorEnergy := ecs.NewComponentType[EnergyComponent]()
 	weaponsEnergy := ecs.NewComponentType[EnergyComponent]()
 	world.RegisterComponents(reactorEnergy, weaponsEnergy)
@@ -246,7 +233,7 @@ func TestRemovingAMissingComponentIsError(t *testing.T) {
 }
 
 func TestVerifyAutomaticCreationOfArchetypesWorks(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	type Foo struct{}
 	type Bar struct{}
 	a, b := ecs.NewComponentType[Foo](), ecs.NewComponentType[Bar]()
@@ -271,7 +258,7 @@ func TestVerifyAutomaticCreationOfArchetypesWorks(t *testing.T) {
 }
 
 func TestEntriesCanChangeTheirArchetype(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	type Label struct {
 		Name string
 	}
@@ -318,7 +305,7 @@ func TestEntriesCanChangeTheirArchetype(t *testing.T) {
 }
 
 func TestCannotSetComponentThatDoesNotBelongToEntity(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 
 	alpha := ecs.NewComponentType[EnergyComponent]()
 	beta := ecs.NewComponentType[EnergyComponent]()
@@ -332,7 +319,7 @@ func TestCannotSetComponentThatDoesNotBelongToEntity(t *testing.T) {
 }
 
 func TestQueriesAndFiltersWorks(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	a, b, c, d := ecs.NewComponentType[int](), ecs.NewComponentType[int](), ecs.NewComponentType[int](), ecs.NewComponentType[int]()
 	world.RegisterComponents(a, b, c, d)
 

--- a/cardinal/ecs/tests/filter_test.go
+++ b/cardinal/ecs/tests/filter_test.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/argus-labs/world-engine/cardinal/ecs"
 	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
+	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
 	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
 	"gotest.tools/v3/assert"
 )
 
 func TestCanFilterByArchetype(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 
 	alpha := ecs.NewComponentType[string]()
 	beta := ecs.NewComponentType[string]()
@@ -43,7 +44,7 @@ func TestCanFilterByArchetype(t *testing.T) {
 // TestExactVsContains ensures the Exact filter will return a subset of a Contains filter when called
 // with the same parameters.
 func TestExactVsContains(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	alpha := ecs.NewComponentType[string]()
 	beta := ecs.NewComponentType[string]()
 	alphaCount := 75
@@ -89,7 +90,7 @@ func TestExactVsContains(t *testing.T) {
 }
 
 func TestCanGetArchetypeFromEntity(t *testing.T) {
-	world := newWorldForTest(t)
+	world := inmem.NewECSWorldForTest(t)
 	alpha := ecs.NewComponentType[string]()
 	beta := ecs.NewComponentType[string]()
 	world.RegisterComponents(alpha, beta)
@@ -115,7 +116,7 @@ func TestCanGetArchetypeFromEntity(t *testing.T) {
 
 func BenchmarkEntityCreation(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		world := newWorldForTest(b)
+		world := inmem.NewECSWorldForTest(b)
 		alpha := ecs.NewComponentType[string]()
 		world.RegisterComponents(alpha)
 		_, err := world.CreateMany(100000, alpha)
@@ -124,7 +125,7 @@ func BenchmarkEntityCreation(b *testing.B) {
 }
 
 // BenchmarkFilterByArchetypeIsNotImpactedByTotalEntityCount verifies that the time it takes to filter
-// by a specific archetype depends on the number of entities that have that archetype and NOT the 
+// by a specific archetype depends on the number of entities that have that archetype and NOT the
 // total number of entities that have been created.
 func BenchmarkFilterByArchetypeIsNotImpactedByTotalEntityCount(b *testing.B) {
 	relevantCount := 100
@@ -138,7 +139,7 @@ func BenchmarkFilterByArchetypeIsNotImpactedByTotalEntityCount(b *testing.B) {
 
 func helperArchetypeFilter(b *testing.B, relevantCount, ignoreCount int) {
 	b.StopTimer()
-	world := newWorldForTest(b)
+	world := inmem.NewECSWorldForTest(b)
 	alpha := ecs.NewComponentType[string]()
 	beta := ecs.NewComponentType[string]()
 	world.RegisterComponents(alpha, beta)


### PR DESCRIPTION
…n-memory redis DBs

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #WORLD-165

## What is the purpose of the change

Create helper functions for creating *ecs.World objects that use in-memory redis DBs. This will simplify testing code and local development.

## Brief Changelog

- Create the inmem package
- Update tests to use the inmem package.

## Testing and Verifying

This change is already covered by existing tests.

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? (no)
- Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
- How is the feature or change documented? (not documented)
