### PR TITLE
refactor(sample_game_server): Update the cardinal dependency

### DIFF
--- a/game/sample_game_server/server/go.mod
+++ b/game/sample_game_server/server/go.mod
@@ -2,13 +2,11 @@ module github.com/argus-labs/world-engine/game/sample_game_server/server
 
 go 1.20
 
-require (
-	github.com/alicebob/miniredis/v2 v2.30.2
-	github.com/argus-labs/world-engine/cardinal v0.0.0-20230515223758-87080d50943b
-)
+require github.com/argus-labs/world-engine/cardinal v0.0.0-20230525212614-007160ff59f4
 
 require (
 	github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a // indirect
+	github.com/alicebob/miniredis/v2 v2.30.2 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/mattn/go-colorable v0.1.12 // indirect

--- a/game/sample_game_server/server/go.sum
+++ b/game/sample_game_server/server/go.sum
@@ -2,8 +2,8 @@ github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a h1:HbKu58rmZp
 github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGnFV6hVsYE877CKEZ6tDNTjaSXYUk6QqoIK6PrAtcc=
 github.com/alicebob/miniredis/v2 v2.30.2 h1:lc1UAUT9ZA7h4srlfBmBt2aorm5Yftk9nBjxz7EyY9I=
 github.com/alicebob/miniredis/v2 v2.30.2/go.mod h1:b25qWj4fCEsBeAAR2mlb0ufImGC6uH3VlUfb/HS5zKg=
-github.com/argus-labs/world-engine/cardinal v0.0.0-20230515223758-87080d50943b h1:z1OXcC7hHQmCpH2GBacWT6LpfYSevcI/rUfApeoGtNw=
-github.com/argus-labs/world-engine/cardinal v0.0.0-20230515223758-87080d50943b/go.mod h1:m7mWfRwoptVhEckdlr+13/Y7qoUz0l6AR/OqN0cSAME=
+github.com/argus-labs/world-engine/cardinal v0.0.0-20230525212614-007160ff59f4 h1:RbzxDFOcCLDgKT5gJG/9EhQoMSvnHZ+5xmaXEu++wKA=
+github.com/argus-labs/world-engine/cardinal v0.0.0-20230525212614-007160ff59f4/go.mod h1:m7mWfRwoptVhEckdlr+13/Y7qoUz0l6AR/OqN0cSAME=
 github.com/bsm/ginkgo/v2 v2.5.0 h1:aOAnND1T40wEdAtkGSkvSICWeQ8L3UASX7YVCqQx+eQ=
 github.com/bsm/gomega v1.20.0 h1:JhAwLmtRzXFTx2AkALSLa8ijZafntmhSoU63Ok18Uq8=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=


### PR DESCRIPTION
Update the sample_game_server to use the newest version of the cardinal library which 1) has a helper for creating an in-memory redis DB and 2) makes use of EntityIDs instead of Entitys.