### PR TITLE
refactor(cardinal): Remove "RegisterComponent" function and require a…

### DIFF
--- a/cardinal/ecs/tests/components_test.go
+++ b/cardinal/ecs/tests/components_test.go
@@ -102,9 +102,8 @@ func TestComponents(t *testing.T) {
 
 func TestErrorWhenAccessingComponentNotOnEntity(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
-	foundComp := ecs.NewComponentType[string]()
-	notFoundComp := ecs.NewComponentType[string]()
-	world.RegisterComponents(foundComp, notFoundComp)
+	foundComp := ecs.NewComponentType[string](world)
+	notFoundComp := ecs.NewComponentType[string](world)
 
 	id, err := world.Create(foundComp)
 	assert.NilError(t, err)

--- a/cardinal/ecs/tests/filter_test.go
+++ b/cardinal/ecs/tests/filter_test.go
@@ -14,11 +14,9 @@ import (
 func TestCanFilterByArchetype(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 
-	alpha := ecs.NewComponentType[string]()
-	beta := ecs.NewComponentType[string]()
-	gamma := ecs.NewComponentType[string]()
-
-	world.RegisterComponents(alpha, beta, gamma)
+	alpha := ecs.NewComponentType[string](world)
+	beta := ecs.NewComponentType[string](world)
+	gamma := ecs.NewComponentType[string](world)
 
 	subsetCount := 50
 	// Make some entities that only have the alpha and beta components
@@ -45,8 +43,8 @@ func TestCanFilterByArchetype(t *testing.T) {
 // with the same parameters.
 func TestExactVsContains(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
-	alpha := ecs.NewComponentType[string]()
-	beta := ecs.NewComponentType[string]()
+	alpha := ecs.NewComponentType[string](world)
+	beta := ecs.NewComponentType[string](world)
 	alphaCount := 75
 	_, err := world.CreateMany(alphaCount, alpha)
 	assert.NilError(t, err)
@@ -91,9 +89,8 @@ func TestExactVsContains(t *testing.T) {
 
 func TestCanGetArchetypeFromEntity(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
-	alpha := ecs.NewComponentType[string]()
-	beta := ecs.NewComponentType[string]()
-	world.RegisterComponents(alpha, beta)
+	alpha := ecs.NewComponentType[string](world)
+	beta := ecs.NewComponentType[string](world)
 
 	wantCount := 50
 	ids, err := world.CreateMany(wantCount, alpha, beta)
@@ -117,8 +114,7 @@ func TestCanGetArchetypeFromEntity(t *testing.T) {
 func BenchmarkEntityCreation(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		world := inmem.NewECSWorldForTest(b)
-		alpha := ecs.NewComponentType[string]()
-		world.RegisterComponents(alpha)
+		alpha := ecs.NewComponentType[string](world)
 		_, err := world.CreateMany(100000, alpha)
 		assert.NilError(b, err)
 	}
@@ -140,9 +136,8 @@ func BenchmarkFilterByArchetypeIsNotImpactedByTotalEntityCount(b *testing.B) {
 func helperArchetypeFilter(b *testing.B, relevantCount, ignoreCount int) {
 	b.StopTimer()
 	world := inmem.NewECSWorldForTest(b)
-	alpha := ecs.NewComponentType[string]()
-	beta := ecs.NewComponentType[string]()
-	world.RegisterComponents(alpha, beta)
+	alpha := ecs.NewComponentType[string](world)
+	beta := ecs.NewComponentType[string](world)
 	_, err := world.CreateMany(relevantCount, alpha, beta)
 	assert.NilError(b, err)
 	_, err = world.CreateMany(ignoreCount, alpha)

--- a/cardinal/ecs/tests/transaction_test.go
+++ b/cardinal/ecs/tests/transaction_test.go
@@ -24,8 +24,7 @@ func TestCanQueueTransactions(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 
 	// Create an entity with a score component
-	score := ecs.NewComponentType[ScoreComponent]()
-	world.RegisterComponents(score)
+	score := ecs.NewComponentType[ScoreComponent](world)
 	id, err := world.Create(score)
 	assert.NilError(t, err)
 	modifyScoreTx := ecs.NewTransactionType[ModifyScoreTx](world, "modifyScore")
@@ -70,8 +69,7 @@ func TestSystemsAreExecutedDuringGameTick(t *testing.T) {
 	type CounterComponent struct {
 		Count int
 	}
-	count := ecs.NewComponentType[CounterComponent]()
-	world.RegisterComponents(count)
+	count := ecs.NewComponentType[CounterComponent](world)
 
 	id, err := world.Create(count)
 	assert.NilError(t, err)
@@ -92,8 +90,7 @@ func TestSystemsAreExecutedDuringGameTick(t *testing.T) {
 
 func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
-	alphaScore := ecs.NewComponentType[ScoreComponent]()
-	world.RegisterComponents(alphaScore)
+	alphaScore := ecs.NewComponentType[ScoreComponent](world)
 
 	modifyScoreTx := ecs.NewTransactionType[ModifyScoreTx](world, "modifyScore")
 

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -77,20 +77,6 @@ func (w *World) AddSystem(s System) {
 	w.systems = append(w.systems, s)
 }
 
-type Initializer interface {
-	Initialize(world *World) error
-}
-
-// RegisterComponents attempts to initialize the given slice of components with a WorldAccessor.
-// This will give components the ability to access their own data.
-func (w *World) RegisterComponents(inits ...Initializer) {
-	for _, in := range inits {
-		if err := in.Initialize(w); err != nil {
-			panic(fmt.Sprintf("cannot initialize component: %v", err))
-		}
-	}
-}
-
 var nextWorldId WorldId = 0
 
 // NewWorld creates a new world.


### PR DESCRIPTION
… World object on component creation

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #WORLD-179

## What is the purpose of the change

Remove the RegisterComponent/Initialize logic and force a world object to be passed in when a component is created. Components will always be ready to use.

## Brief Changelog


## Testing and Verifying

This change is already covered by existing tests, such as any test that creates a component.

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? (no)
- Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
- How is the feature or change documented? (not documented)
