### PR TITLE
feat(cardinal): Allow for the saving and loading of archetype data

### DIFF
--- a/cardinal/cmd/test/app.go
+++ b/cardinal/cmd/test/app.go
@@ -36,7 +36,7 @@ func main() {
 		fmt.Println("connection to redis established")
 	}
 	worldStorage := storage.NewWorldStorage(
-		storage.Components{Store: &rs, ComponentIndices: &rs}, &rs, storage.NewArchetypeComponentIndex(), storage.NewArchetypeAccessor(), &rs, &rs)
+		storage.Components{Store: &rs, ComponentIndices: &rs}, &rs, storage.NewArchetypeComponentIndex(), storage.NewArchetypeAccessor(), &rs, &rs, &rs)
 	gs := server.NewGameServer(worldStorage)
 	grpcServer := grpc.NewServer()
 	ecsv1grpc.RegisterGameServer(grpcServer, gs)

--- a/cardinal/ecs/component/component.go
+++ b/cardinal/ecs/component/component.go
@@ -5,6 +5,8 @@ type (
 
 	// IComponentType is a high level representation of a user defined component struct.
 	IComponentType interface {
+		// SetID sets the ID of this component. It must only be set once
+		SetID(TypeID) error
 		// ID returns the ID of the component.
 		ID() TypeID
 		// New returns the marshaled bytes of the default value for the component struct.

--- a/cardinal/ecs/storage/engine.go
+++ b/cardinal/ecs/storage/engine.go
@@ -44,13 +44,23 @@ type EntityLocationStorage interface {
 	Len() (int, error)
 }
 
+// ComponentMarshaler is an interface that can marshal and unmarshal itself to bytes. Since
+// IComponentType are interfaces (and not easily serilizable) a list of instantiated 
+// components is required to unmarshal the data.
+type ComponentMarshaler interface {
+	Marshal() ([]byte, error)
+	UnmarshalWithComps([]byte, []component.IComponentType) error
+}
+
 type ArchetypeComponentIndex interface {
+	ComponentMarshaler
 	Push(layout *Layout)
 	SearchFrom(filter filter.LayoutFilter, start int) *ArchetypeIterator
 	Search(layoutFilter filter.LayoutFilter) *ArchetypeIterator
 }
 
 type ArchetypeAccessor interface {
+	ComponentMarshaler
 	PushArchetype(index ArchetypeIndex, layout *Layout)
 	Archetype(index ArchetypeIndex) ArchetypeStorage
 	Count() int
@@ -74,4 +84,9 @@ type EntityStorage interface {
 type EntityManager interface {
 	Destroy(EntityID)
 	NewEntity() (EntityID, error)
+}
+
+type StateStorage interface {
+	Save(key string, data []byte) error
+	Load(key string) (data []byte, ok bool, err error)
 }

--- a/cardinal/ecs/storage/entity.go
+++ b/cardinal/ecs/storage/entity.go
@@ -281,5 +281,26 @@ func (e Entity) StringXY(w WorldAccessor) string {
 
 func (e Entity) StringXX() string {
 	return fmt.Sprintf("ID: %d, Loc: %+v", e.ID, e.Loc)
+}
 
+var _ StateStorage = &stateStorageImpl{}
+
+func NewStateStorage() StateStorage {
+	return &stateStorageImpl{
+		data: map[string][]byte{},
+	}
+}
+
+type stateStorageImpl struct {
+	data map[string][]byte
+}
+
+func (s stateStorageImpl) Save(key string, data []byte) error {
+	s.data[key] = data
+	return nil
+}
+
+func (s stateStorageImpl) Load(key string) (data []byte, ok bool, err error) {
+	buf, ok := s.data[key]
+	return buf, ok, nil
 }

--- a/cardinal/ecs/storage/keys.go
+++ b/cardinal/ecs/storage/keys.go
@@ -15,6 +15,7 @@ define keys for redis storage
 - 	ARCH COMP INDEX:    ACI:WORLD-1
 - 	ENTITY STORAGE:     ENTITY:WORLD-1:ID  		-> entity struct bytes
 - 	ENTITY MGR: 		ENTITY:WORLD-1:NEXTID 	-> uint64 id
+-	STATE STORAGE:      STATE:WORLD-1:<sub-key> -> arbitrary bytes to save world state
 */
 
 func (r *RedisStorage) componentDataKey(index ArchetypeIndex) string {
@@ -43,4 +44,8 @@ func (r *RedisStorage) entityStorageKey(id EntityID) string {
 
 func (r *RedisStorage) nextEntityIDKey() string {
 	return fmt.Sprintf("ENTITY:WORLD-%s:NEXTID", r.WorldID)
+}
+
+func (r *RedisStorage) stateStorageKey(subKey string) string {
+	return fmt.Sprintf("STATE:WORLD-%s:%s", r.WorldID, subKey)
 }

--- a/cardinal/ecs/storage/mock.go
+++ b/cardinal/ecs/storage/mock.go
@@ -30,6 +30,11 @@ func NewMockComponentType[T any](t T, defaultVal interface{}) *MockComponentType
 	return m
 }
 
+func (m *MockComponentType[T]) SetID(id component.TypeID) error {
+	m.id = id
+	return nil
+}
+
 func (m *MockComponentType[T]) ID() component.TypeID {
 	return m.id
 }

--- a/cardinal/ecs/storage/storage.go
+++ b/cardinal/ecs/storage/storage.go
@@ -7,6 +7,7 @@ type WorldStorage struct {
 	ArchAccessor     ArchetypeAccessor
 	EntityStore      EntityStorage
 	EntityMgr        EntityManager
+	StateStore       StateStorage
 }
 
 func NewWorldStorage(
@@ -15,7 +16,9 @@ func NewWorldStorage(
 	acis ArchetypeComponentIndex,
 	aa ArchetypeAccessor,
 	es EntityStorage,
-	em EntityManager) WorldStorage {
+	em EntityManager,
+	ss StateStorage,
+) WorldStorage {
 	return WorldStorage{
 		CompStore:        cs,
 		EntityLocStore:   els,
@@ -23,5 +26,6 @@ func NewWorldStorage(
 		ArchAccessor:     aa,
 		EntityStore:      es,
 		EntityMgr:        em,
+		StateStore:       ss,
 	}
 }

--- a/cardinal/ecs/system.go
+++ b/cardinal/ecs/system.go
@@ -6,4 +6,4 @@ type TransactionQueue struct {
 	queue map[string][]any
 }
 
-type System func(*TransactionQueue)
+type System func(*World, *TransactionQueue)

--- a/cardinal/ecs/tests/components_test.go
+++ b/cardinal/ecs/tests/components_test.go
@@ -108,6 +108,6 @@ func TestErrorWhenAccessingComponentNotOnEntity(t *testing.T) {
 
 	id, err := world.Create(foundComp)
 	assert.NilError(t, err)
-	_, err = notFoundComp.Get(id)
+	_, err = notFoundComp.Get(world, id)
 	assert.ErrorIs(t, err, storage2.ErrorComponentNotOnEntity)
 }

--- a/cardinal/ecs/tests/filter_test.go
+++ b/cardinal/ecs/tests/filter_test.go
@@ -34,7 +34,7 @@ func TestCanFilterByArchetype(t *testing.T) {
 	ecs.NewQuery(filter.Exact(alpha, beta)).Each(world, func(id storage.EntityID) {
 		count++
 		// Make sure the gamma component is not on this entity
-		_, err := gamma.Get(id)
+		_, err := gamma.Get(world, id)
 		assert.ErrorIs(t, err, storage.ErrorComponentNotOnEntity)
 	})
 

--- a/cardinal/ecs/tests/state_test.go
+++ b/cardinal/ecs/tests/state_test.go
@@ -1,0 +1,208 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/argus-labs/world-engine/cardinal/ecs"
+	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
+	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"gotest.tools/v3/assert"
+)
+
+// initWorldWithRedis sets up an ecs.World using the given redis DB. ecs.NewECSWorldForTest is not used
+// because these tests need to reuse the incoming *miniredis.Miniredis
+func initWorldWithRedis(t *testing.T, s *miniredis.Miniredis) *ecs.World {
+	rs := storage.NewRedisStorage(storage.Options{
+		Addr:     s.Addr(),
+		Password: "", // no password set
+		DB:       0,  // use default DB
+	}, "in-memory-world")
+	worldStorage := storage.NewWorldStorage(
+		storage.Components{Store: &rs, ComponentIndices: &rs},
+		&rs,
+		storage.NewArchetypeComponentIndex(),
+		storage.NewArchetypeAccessor(),
+		&rs,
+		&rs,
+		&rs)
+	w, err := ecs.NewWorld(worldStorage)
+	assert.NilError(t, err)
+	return w
+}
+
+// comps reduces the typing needed to create a slice of IComponentTypes
+// []component.IComponentType{a, b, c} becomes:
+// comps(a, b, c)
+func comps(cs ...component.IComponentType) []component.IComponentType {
+	return cs
+}
+
+type NumberComponent struct {
+	Num int
+}
+
+func TestComponentsCanOnlyBeRegisteredOnce(t *testing.T) {
+	world := inmem.NewECSWorldForTest(t)
+	assert.NilError(t, world.RegisterComponents())
+	assert.ErrorIs(t, world.RegisterComponents(), ecs.ErrorComponentRegistrationMustHappenOnce)
+}
+
+func TestErrorWhenSavedStateDoesNotMatchComponentTypes(t *testing.T) {
+	// This redisStore will be used to create multiple worlds to ensure state is consistent across the worlds.
+	redisStore := miniredis.RunT(t)
+
+	oneWorld := initWorldWithRedis(t, redisStore)
+	oneAlphaNum := ecs.NewComponentType[NumberComponent]()
+	assert.NilError(t, oneWorld.RegisterComponents(oneAlphaNum))
+
+	_, err := oneWorld.Create(oneAlphaNum)
+	assert.NilError(t, err)
+
+	assert.NilError(t, oneWorld.SaveGameState())
+
+	// Too few components registered
+	twoWorld := initWorldWithRedis(t, redisStore)
+	err = twoWorld.RegisterComponents()
+	assert.ErrorContains(t, err, storage.ErrorComponentMismatchWithSavedState.Error())
+
+	// It's ok to register extra components.
+	threeWorld := initWorldWithRedis(t, redisStore)
+	threeAlphaNum := ecs.NewComponentType[NumberComponent]()
+	threeBetaNum := ecs.NewComponentType[NumberComponent]()
+	err = threeWorld.RegisterComponents(threeAlphaNum, threeBetaNum)
+	assert.NilError(t, err)
+
+	// Just the right number of components registered
+	fourWorld := initWorldWithRedis(t, redisStore)
+	fourAlphaNum := ecs.NewComponentType[NumberComponent]()
+	err = fourWorld.RegisterComponents(fourAlphaNum)
+	assert.NilError(t, err)
+}
+
+func TestArchetypeIndexIsConsistentAfterSaveAndLoad(t *testing.T) {
+	redisStore := miniredis.RunT(t)
+	oneWorld := initWorldWithRedis(t, redisStore)
+	oneNum := ecs.NewComponentType[NumberComponent]()
+	oneWorld.RegisterComponents(oneNum)
+
+	_, err := oneWorld.Create(oneNum)
+	assert.NilError(t, err)
+
+	wantIndex := oneWorld.GetArchetypeForComponents(comps(oneNum))
+	wantLayout := oneWorld.Archetype(wantIndex).Layout()
+	assert.Equal(t, 1, len(wantLayout.Components()))
+	assert.Check(t, wantLayout.HasComponent(oneNum))
+
+	assert.NilError(t, oneWorld.SaveGameState())
+
+	// Make a second instance of the world using the same storage.
+	twoWorld := initWorldWithRedis(t, redisStore)
+	twoNum := ecs.NewComponentType[NumberComponent]()
+	twoWorld.RegisterComponents(twoNum)
+
+	gotIndex := twoWorld.GetArchetypeForComponents(comps(twoNum))
+	gotLayout := twoWorld.Archetype(gotIndex).Layout()
+	assert.Equal(t, 1, len(gotLayout.Components()))
+	assert.Check(t, gotLayout.HasComponent(twoNum))
+
+	// Archetype indices should be the same across save/load cycles
+	assert.Equal(t, wantIndex, gotIndex)
+}
+
+func TestCanRecoverArchetypeInformationAfterLoad(t *testing.T) {
+	redisStore := miniredis.RunT(t)
+
+	oneWorld := initWorldWithRedis(t, redisStore)
+	oneAlphaNum := ecs.NewComponentType[NumberComponent]()
+	oneBetaNum := ecs.NewComponentType[NumberComponent]()
+	oneWorld.RegisterComponents(oneAlphaNum, oneBetaNum)
+	_, err := oneWorld.Create(oneAlphaNum)
+	assert.NilError(t, err)
+	_, err = oneWorld.Create(oneBetaNum)
+	assert.NilError(t, err)
+	_, err = oneWorld.Create(oneAlphaNum, oneBetaNum)
+	assert.NilError(t, err)
+	// At this point 3 archetypes exist:
+	// oneAlphaNum
+	// oneBetaNum
+	// oneAlphaNum, oneBetaNum
+	oneJustAlphaArchIndex := oneWorld.GetArchetypeForComponents(comps(oneAlphaNum))
+	oneJustBetaArchIndex := oneWorld.GetArchetypeForComponents(comps(oneBetaNum))
+	oneBothArchIndex := oneWorld.GetArchetypeForComponents(comps(oneAlphaNum, oneBetaNum))
+	// These archetype indices should be preserved between a state save/load
+
+	assert.NilError(t, oneWorld.SaveGameState())
+
+	// Create a brand new world, but use the original redis store. We should be able to load
+	// the game state from the redis store (including archetype indices).
+	twoWorld := initWorldWithRedis(t, redisStore)
+	twoAlphaNum := ecs.NewComponentType[NumberComponent]()
+	twoBetaNum := ecs.NewComponentType[NumberComponent]()
+	// The ordering of registering these components is important. It must match the ordering above.
+	twoWorld.RegisterComponents(twoAlphaNum, twoBetaNum)
+
+	// Don't create any entities like above; they should already exist
+
+	// The order that we FETCH archetypes shouldn't matter, so this order is intentionally
+	// different from the setup step
+	twoBothArchIndex := oneWorld.GetArchetypeForComponents(comps(oneBetaNum, oneAlphaNum))
+	assert.Equal(t, oneBothArchIndex, twoBothArchIndex)
+	twoJustAlphaArchIndex := oneWorld.GetArchetypeForComponents(comps(oneAlphaNum))
+	assert.Equal(t, oneJustAlphaArchIndex, twoJustAlphaArchIndex)
+	twoJustBetaArchIndex := oneWorld.GetArchetypeForComponents(comps(oneBetaNum))
+	assert.Equal(t, oneJustBetaArchIndex, twoJustBetaArchIndex)
+
+	// Save and load again to make sure the "two" world correctly saves its state even though
+	// it never created any entities
+	assert.NilError(t, twoWorld.SaveGameState())
+
+	threeWorld := initWorldWithRedis(t, redisStore)
+	threeAlphaNum := ecs.NewComponentType[NumberComponent]()
+	threeBetaNum := ecs.NewComponentType[NumberComponent]()
+	// Again, the ordering of registering these components is important. It must match the ordering above
+	threeWorld.RegisterComponents(threeAlphaNum, threeBetaNum)
+
+	// And again, the loading of archetypes is intentionally different from the above two steps
+	threeJustBetaArchIndex := oneWorld.GetArchetypeForComponents(comps(oneBetaNum))
+	assert.Equal(t, oneJustBetaArchIndex, threeJustBetaArchIndex)
+	threeBothArchIndex := oneWorld.GetArchetypeForComponents(comps(oneBetaNum, oneAlphaNum))
+	assert.Equal(t, oneBothArchIndex, threeBothArchIndex)
+	threeJustAlphaArchIndex := oneWorld.GetArchetypeForComponents(comps(oneAlphaNum))
+	assert.Equal(t, oneJustAlphaArchIndex, threeJustAlphaArchIndex)
+}
+
+func TestCanReloadState(t *testing.T) {
+	redisStore := miniredis.RunT(t)
+	alphaWorld := initWorldWithRedis(t, redisStore)
+	oneAlphaNum := ecs.NewComponentType[NumberComponent]()
+	alphaWorld.RegisterComponents(oneAlphaNum)
+
+	_, err := alphaWorld.CreateMany(10, oneAlphaNum)
+	assert.NilError(t, err)
+	alphaWorld.AddSystem(func(w *ecs.World, queue *ecs.TransactionQueue) {
+		oneAlphaNum.Each(w, func(id storage.EntityID) {
+			err := oneAlphaNum.Set(w, id, &NumberComponent{int(id)})
+			assert.Check(t, err == nil)
+		})
+	})
+
+	// Start a tick with executes the above system which initializes the number components.
+	alphaWorld.Tick()
+	assert.NilError(t, alphaWorld.SaveGameState())
+
+	// Make a new world, using the original redis DB that (hopefully) has our data
+	betaWorld := initWorldWithRedis(t, redisStore)
+	oneBetaNum := ecs.NewComponentType[NumberComponent]()
+	betaWorld.RegisterComponents(oneBetaNum)
+	count := 0
+	oneBetaNum.Each(betaWorld, func(id storage.EntityID) {
+		count++
+		num, err := oneBetaNum.Get(betaWorld, id)
+		assert.NilError(t, err)
+		assert.Equal(t, int(id), num.Num)
+	})
+	// Make sure we actually have 10 entities
+	assert.Equal(t, 10, count)
+}

--- a/cardinal/net/server/svr.go
+++ b/cardinal/net/server/svr.go
@@ -22,7 +22,10 @@ type gameServer struct {
 }
 
 func (i *gameServer) StartGameLoop(ctx context.Context, loop *ecsv1.MsgStartGameLoop) (*ecsv1.MsgStartGameLoopResponse, error) {
-	world := ecs.NewWorld(i.backend)
+	world, err := ecs.NewWorld(i.backend)
+	if err != nil {
+		return nil, err
+	}
 	i.world = world
 	// from here.. we need to initialize the world in the ECS system. loading components, making entities, etc etc..
 	// how will that look?


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- Allow for the saving and loading of archetype information between game ticks.
- Remove the *World reference from components. Instead, it's the *World's responsibility to set each component's ID on component registration
- Pass in the *World object to Systems.
- Added a StateStorage interface that can save arbitrary bytes to some key.

## Brief Changelog

## Testing and Verifying

- Added unit test that validates the saving and loading of archetype information.
- Existing unit tests verify components and systems still work after removing the *World reference from components.

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? (no)
- Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
- How is the feature or change documented? (not documented)
