### PR TITLE
refactor(cardinal): improve keys.go documentation, remove a key that …

### DIFF
--- a/cardinal/cmd/test/app.go
+++ b/cardinal/cmd/test/app.go
@@ -36,7 +36,7 @@ func main() {
 		fmt.Println("connection to redis established")
 	}
 	worldStorage := storage.NewWorldStorage(
-		storage.Components{Store: &rs, ComponentIndices: &rs}, &rs, storage.NewArchetypeComponentIndex(), storage.NewArchetypeAccessor(), &rs, &rs, &rs)
+		storage.Components{Store: &rs, ComponentIndices: &rs}, &rs, storage.NewArchetypeComponentIndex(), storage.NewArchetypeAccessor(), &rs, &rs)
 	gs := server.NewGameServer(worldStorage)
 	grpcServer := grpc.NewServer()
 	ecsv1grpc.RegisterGameServer(grpcServer, gs)

--- a/cardinal/ecs/inmem/inmem.go
+++ b/cardinal/ecs/inmem/inmem.go
@@ -52,7 +52,6 @@ func newInMemoryWorld(s *miniredis.Miniredis) (*ecs.World, error) {
 		storage.NewArchetypeComponentIndex(),
 		storage.NewArchetypeAccessor(),
 		&rs,
-		&rs,
 		&rs)
 
 	return ecs.NewWorld(worldStorage)

--- a/cardinal/ecs/storage/engine.go
+++ b/cardinal/ecs/storage/engine.go
@@ -23,7 +23,8 @@ type ComponentIndexStorage interface {
 	// ComponentIndex returns the current index for this ArchetypeIndex. If the index doesn't currently
 	// exist then "0, false, nil" is returned
 	ComponentIndex(ArchetypeIndex) (ComponentIndex, bool, error)
-	// SetIndex sets the index to the given calue.
+	// SetIndex sets the index of the given archerype index. This is the next index that will be assigned to a new
+	// entity in this archetype.
 	SetIndex(ArchetypeIndex, ComponentIndex) error
 	// IncrementIndex increments an index for this archetype and returns the new value. If the index
 	// does not yet exist, set the index to 0 and return 0.
@@ -37,15 +38,15 @@ type EntityLocationStorage interface {
 	ContainsEntity(EntityID) (bool, error)
 	Remove(EntityID) error
 	Insert(EntityID, ArchetypeIndex, ComponentIndex) error
-	Set(EntityID, Location) error
-	Location(EntityID) (Location, error)
+	SetLocation(EntityID, Location) error
+	GetLocation(EntityID) (Location, error)
 	ArchetypeIndex(id EntityID) (ArchetypeIndex, error)
 	ComponentIndexForEntity(EntityID) (ComponentIndex, error)
 	Len() (int, error)
 }
 
 // ComponentMarshaler is an interface that can marshal and unmarshal itself to bytes. Since
-// IComponentType are interfaces (and not easily serilizable) a list of instantiated 
+// IComponentType are interfaces (and not easily serilizable) a list of instantiated
 // components is required to unmarshal the data.
 type ComponentMarshaler interface {
 	Marshal() ([]byte, error)
@@ -73,12 +74,6 @@ type ArchetypeStorage interface {
 	LayoutMatches(components []component.IComponentType) bool
 	PushEntity(entity EntityID)
 	Count() int
-}
-
-type EntityStorage interface {
-	SetEntity(EntityID, Entity) error
-	GetEntity(EntityID) (Entity, error)
-	SetLocation(EntityID, Location) error
 }
 
 type EntityManager interface {

--- a/cardinal/ecs/storage/legacy_storage.go
+++ b/cardinal/ecs/storage/legacy_storage.go
@@ -12,11 +12,10 @@ func NewLegacyStorage() WorldStorage {
 	eloStore := NewLocationMap()
 	archIdxStore := NewArchetypeComponentIndex()
 	archAcc := NewArchetypeAccessor()
-	entityStore := NewEntityStorage()
 	entityMgr := NewEntityManager()
 	stateStore := NewStateStorage()
 
-	return NewWorldStorage(componentsStore, eloStore, archIdxStore, archAcc, entityStore, entityMgr, stateStore)
+	return NewWorldStorage(componentsStore, eloStore, archIdxStore, archAcc, entityMgr, stateStore)
 }
 
 var _ ComponentStorageManager = &ComponentsSliceStorage{}
@@ -214,13 +213,13 @@ func (lm *LocationMap) Insert(id EntityID, archetype ArchetypeIndex, component C
 }
 
 // Set sets the given entity ID and archetype Index to the storage.
-func (lm *LocationMap) Set(id EntityID, loc Location) error {
+func (lm *LocationMap) SetLocation(id EntityID, loc Location) error {
 	lm.Insert(id, loc.ArchIndex, loc.CompIndex)
 	return nil
 }
 
 // Location returns the location of the given entity ID.
-func (lm *LocationMap) Location(id EntityID) (Location, error) {
+func (lm *LocationMap) GetLocation(id EntityID) (Location, error) {
 	return lm.locations[id].loc, nil
 }
 
@@ -270,34 +269,6 @@ func (idx *Index) SearchFrom(f filter.LayoutFilter, start int) *ArchetypeIterato
 // Search searches for archetypes that match the given filter.
 func (idx *Index) Search(filter filter.LayoutFilter) *ArchetypeIterator {
 	return idx.SearchFrom(filter, 0)
-}
-
-type entityStorageImpl struct {
-	entries []Entity
-}
-
-func (e *entityStorageImpl) SetLocation(id EntityID, location Location) error {
-	e.entries[id].Loc = location
-
-	return nil
-}
-
-var _ EntityStorage = &entityStorageImpl{}
-
-func NewEntityStorage() EntityStorage {
-	return &entityStorageImpl{entries: make([]Entity, 1, 256)}
-}
-
-func (e *entityStorageImpl) SetEntity(id EntityID, entity Entity) error {
-	if int(id) >= len(e.entries) {
-		e.entries = append(e.entries, Entity{})
-	}
-	e.entries[id] = entity
-	return nil
-}
-
-func (e entityStorageImpl) GetEntity(id EntityID) (Entity, error) {
-	return e.entries[id], nil
 }
 
 func (idx *Index) Marshal() ([]byte, error) {

--- a/cardinal/ecs/storage/storage.go
+++ b/cardinal/ecs/storage/storage.go
@@ -5,7 +5,6 @@ type WorldStorage struct {
 	EntityLocStore   EntityLocationStorage
 	ArchCompIdxStore ArchetypeComponentIndex
 	ArchAccessor     ArchetypeAccessor
-	EntityStore      EntityStorage
 	EntityMgr        EntityManager
 	StateStore       StateStorage
 }
@@ -15,7 +14,6 @@ func NewWorldStorage(
 	els EntityLocationStorage,
 	acis ArchetypeComponentIndex,
 	aa ArchetypeAccessor,
-	es EntityStorage,
 	em EntityManager,
 	ss StateStorage,
 ) WorldStorage {
@@ -24,7 +22,6 @@ func NewWorldStorage(
 		EntityLocStore:   els,
 		ArchCompIdxStore: acis,
 		ArchAccessor:     aa,
-		EntityStore:      es,
 		EntityMgr:        em,
 		StateStore:       ss,
 	}

--- a/cardinal/ecs/tests/state_test.go
+++ b/cardinal/ecs/tests/state_test.go
@@ -25,7 +25,6 @@ func initWorldWithRedis(t *testing.T, s *miniredis.Miniredis) *ecs.World {
 		storage.NewArchetypeComponentIndex(),
 		storage.NewArchetypeAccessor(),
 		&rs,
-		&rs,
 		&rs)
 	w, err := ecs.NewWorld(worldStorage)
 	assert.NilError(t, err)


### PR DESCRIPTION
…contains duplicate data, and fix a bug

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #WORLD-190

## What is the purpose of the change

- Improve documentation in the key.go file.
- Rename the componentIndexKey method to archetypeIndexKey. This key keeps track of the next index within an archetype that should be assigned to a new entity. The component ID not used.
- Remove the EntityStorage interface which is just a duplicate of the EntityLocationStorage interface.

## Testing and Verifying

This change added tests and can be verified as follows:

- _Added unit test that validates that archetype indexes can be assigned to entities and component ids don't get in the way.
- Existing unit tests verify the removal of Entity Storage is safe.

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? (no)
- Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (no)
- How is the feature or change documented? [figma doc](https://www.figma.com/file/GjaTcSXSkH4Sa9VfOep6ZI/Server-ECS-with-Redis?type=whiteboard&node-id=0-1&t=84eD7R03DeagXjxN-0)