### PR TITLE
chore: add go module for sample game magefiles

### DIFF
--- a/game/sample_game/magefiles/go.mod
+++ b/game/sample_game/magefiles/go.mod
@@ -1,0 +1,5 @@
+module github.com/argus-labs/world-engine/game/sample_game/magefiles
+
+go 1.20
+
+require github.com/magefile/mage v1.15.0 // indirect

--- a/game/sample_game/magefiles/go.sum
+++ b/game/sample_game/magefiles/go.sum
@@ -1,0 +1,2 @@
+github.com/magefile/mage v1.15.0 h1:BvGheCMAsG3bWUDbZ8AyXXpCNwU9u5CB6sM+HNb9HYg=
+github.com/magefile/mage v1.15.0/go.mod h1:z5UZb/iS3GoOSn0JgWuiw7dxlurVYTu+/jHXqQg881A=


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

Using the magefiles outside of a workspace that doesn't already have magefiles dep fails. The world engine repo has a dep from Polaris, but copying the sample game outside of the world engine workspace would cause it too fail.


## Brief Changelog

- Added a go.mod/sum in the `/magefiles` folder
**- Future: we should split out sample game into a separate repo so we can use Go workspace feature to manage multi-module projects (magefile + server + nakama)**

## Testing and Verifying

1. `mage copy` to a dir outside of the world engine folder
2. Run the mage commands from there

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
- How is the feature or change documented? (not applicable / specification (`x/<module>/spec/`) / [Osmosis docs repo](https://github.com/osmosis-labs/docs) / not documented)
