### PR TITLE
fix(cardinal): recovery test

### DIFF
--- a/cardinal/ecs/tests/chain_recover_test.go
+++ b/cardinal/ecs/tests/chain_recover_test.go
@@ -48,10 +48,6 @@ type ClaimPlanetTransaction struct {
 // TestWorld_RecoverFromChain tests that after submitting transactions to the chain, they can be queried, re-ran,
 // and end up with the same game state as before.
 func TestWorld_RecoverFromChain(t *testing.T) {
-	// CAR-96: This test is currently broken. See:
-	// https://linear.app/arguslabs/issue/CAR-96/testworld-recoverfromchain-fail-on-main
-	//t.Skip()
-
 	// setup world and transactions
 	ctx := context.Background()
 	adapter := &DummyAdapter{batches: make([]*types.TransactionBatch, 0), tick: 30}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

fixes the RecoverFromChain test. failed because we added a condition where a world is not allowed to recover if the tick is >0. (we want to enforce recovery happens only during fresh/newly created worlds).

## Brief Changelog

- fix test

## Testing and Verifying

`cardinal/ecs/tests/chain_recover_test.go`

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
- How is the feature or change documented? (not applicable / specification (`x/<module>/spec/`) / [Osmosis docs repo](https://github.com/osmosis-labs/docs) / not documented)
