### PR TITLE
feat(cardinal): automatic query registration system

### DIFF
--- a/cardinal/ecs/ecs_query.go
+++ b/cardinal/ecs/ecs_query.go
@@ -1,0 +1,90 @@
+package ecs
+
+import (
+	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
+	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+)
+
+type cache struct {
+	archetypes []storage.ArchetypeID
+	seen       int
+}
+
+// Query represents a query for entityLocationStore.
+// It is used to filter entityLocationStore based on their componentStore.
+// It receives arbitrary filters that are used to filter entityLocationStore.
+// It contains a cache that is used to avoid re-evaluating the query.
+// So it is not recommended to create a new query every time you want
+// to filter entityLocationStore with the same query.
+type Query struct {
+	layoutMatches map[WorldId]*cache
+	filter        filter.LayoutFilter
+}
+
+// NewQuery creates a new query.
+// It receives arbitrary filters that are used to filter entityLocationStore.
+func NewQuery(filter filter.LayoutFilter) *Query {
+	return &Query{
+		layoutMatches: make(map[WorldId]*cache),
+		filter:        filter,
+	}
+}
+
+// Each iterates over all entityLocationStore that match the query.
+func (q *Query) Each(w *World, callback func(storage.EntityID)) {
+	accessor := w.StorageAccessor()
+	result := q.evaluateQuery(w, &accessor)
+	iter := storage.NewEntityIterator(0, accessor.Archetypes, result)
+	for iter.HasNext() {
+		entities := iter.Next()
+		for _, id := range entities {
+			callback(id)
+		}
+	}
+}
+
+// Count returns the number of entityLocationStore that match the query.
+func (q *Query) Count(w *World) int {
+	accessor := w.StorageAccessor()
+	result := q.evaluateQuery(w, &accessor)
+	iter := storage.NewEntityIterator(0, accessor.Archetypes, result)
+	ret := 0
+	for iter.HasNext() {
+		entities := iter.Next()
+		ret += len(entities)
+	}
+	return ret
+}
+
+// First returns the first entity that matches the query.
+func (q *Query) First(w *World) (id storage.EntityID, ok bool, err error) {
+	accessor := w.StorageAccessor()
+	result := q.evaluateQuery(w, &accessor)
+	iter := storage.NewEntityIterator(0, accessor.Archetypes, result)
+	if !iter.HasNext() {
+		return storage.BadID, false, err
+	}
+	for iter.HasNext() {
+		entities := iter.Next()
+		if len(entities) > 0 {
+			return entities[0], true, nil
+		}
+	}
+	return storage.BadID, false, err
+}
+
+func (q *Query) evaluateQuery(world *World, accessor *StorageAccessor) []storage.ArchetypeID {
+	w := world.ID()
+	if _, ok := q.layoutMatches[w]; !ok {
+		q.layoutMatches[w] = &cache{
+			archetypes: make([]storage.ArchetypeID, 0),
+			seen:       0,
+		}
+	}
+	cache := q.layoutMatches[w]
+	for it := accessor.Index.SearchFrom(q.filter, cache.seen); it.HasNext(); {
+		cache.archetypes = append(cache.archetypes, it.Next())
+	}
+	cache.seen = accessor.Archetypes.Count()
+	return cache.archetypes
+}

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -14,7 +14,7 @@ type CreatePersonaTransaction struct {
 }
 
 // CreatePersonaTx is a concrete ECS transaction.
-var CreatePersonaTx = NewTransactionType[CreatePersonaTransaction]("create_persona")
+var CreatePersonaTx = NewTransactionType[CreatePersonaTransaction]("create-persona")
 
 type SignerComponent struct {
 	PersonaTag    string

--- a/cardinal/ecs/query.go
+++ b/cardinal/ecs/query.go
@@ -1,90 +1,27 @@
 package ecs
 
-import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
-)
-
-type cache struct {
-	archetypes []storage.ArchetypeID
-	seen       int
+type IQuery interface {
+	Name() string
+	// HandleQuery is given a reference to the world, a query request struct,
+	// and is expected to return a JSON encoded response, or an error.
+	HandleQuery(*World, []byte) ([]byte, error)
 }
 
-// Query represents a query for entityLocationStore.
-// It is used to filter entityLocationStore based on their componentStore.
-// It receives arbitrary filters that are used to filter entityLocationStore.
-// It contains a cache that is used to avoid re-evaluating the query.
-// So it is not recommended to create a new query every time you want
-// to filter entityLocationStore with the same query.
-type Query struct {
-	layoutMatches map[WorldId]*cache
-	filter        filter.LayoutFilter
+type Handler func(*World, []byte) ([]byte, error)
+
+type QueryType struct {
+	name    string
+	handler Handler
 }
 
-// NewQuery creates a new query.
-// It receives arbitrary filters that are used to filter entityLocationStore.
-func NewQuery(filter filter.LayoutFilter) *Query {
-	return &Query{
-		layoutMatches: make(map[WorldId]*cache),
-		filter:        filter,
-	}
+func NewQueryType(name string, handler Handler) *QueryType {
+	return &QueryType{name: name, handler: handler}
 }
 
-// Each iterates over all entityLocationStore that match the query.
-func (q *Query) Each(w *World, callback func(storage.EntityID)) {
-	accessor := w.StorageAccessor()
-	result := q.evaluateQuery(w, &accessor)
-	iter := storage.NewEntityIterator(0, accessor.Archetypes, result)
-	for iter.HasNext() {
-		entities := iter.Next()
-		for _, id := range entities {
-			callback(id)
-		}
-	}
+func (q *QueryType) Name() string {
+	return q.name
 }
 
-// Count returns the number of entityLocationStore that match the query.
-func (q *Query) Count(w *World) int {
-	accessor := w.StorageAccessor()
-	result := q.evaluateQuery(w, &accessor)
-	iter := storage.NewEntityIterator(0, accessor.Archetypes, result)
-	ret := 0
-	for iter.HasNext() {
-		entities := iter.Next()
-		ret += len(entities)
-	}
-	return ret
-}
-
-// First returns the first entity that matches the query.
-func (q *Query) First(w *World) (id storage.EntityID, ok bool, err error) {
-	accessor := w.StorageAccessor()
-	result := q.evaluateQuery(w, &accessor)
-	iter := storage.NewEntityIterator(0, accessor.Archetypes, result)
-	if !iter.HasNext() {
-		return storage.BadID, false, err
-	}
-	for iter.HasNext() {
-		entities := iter.Next()
-		if len(entities) > 0 {
-			return entities[0], true, nil
-		}
-	}
-	return storage.BadID, false, err
-}
-
-func (q *Query) evaluateQuery(world *World, accessor *StorageAccessor) []storage.ArchetypeID {
-	w := world.ID()
-	if _, ok := q.layoutMatches[w]; !ok {
-		q.layoutMatches[w] = &cache{
-			archetypes: make([]storage.ArchetypeID, 0),
-			seen:       0,
-		}
-	}
-	cache := q.layoutMatches[w]
-	for it := accessor.Index.SearchFrom(q.filter, cache.seen); it.HasNext(); {
-		cache.archetypes = append(cache.archetypes, it.Next())
-	}
-	cache.seen = accessor.Archetypes.Count()
-	return cache.archetypes
+func (q *QueryType) HandleQuery(w *World, req []byte) ([]byte, error) {
+	return q.handler(w, req)
 }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

- extends the Handler (previously TransactionHandler), to automatically register http queries defined by the Cardinal developer

## Brief Changelog

- implement automatic query registration via handler
- rename TransactionHandler to just Handler, as it handles more than just transactions now
- change the usage of underscores to dashes in http endpoints to conform with REST standards (https://blog.dreamfactory.com/best-practices-for-naming-rest-api-endpoints/)
- rename `query.go` to `ecs_query.go` (this is to differenciate the queries used internally against the ECS, with the new mechanism that exposes queries to the ECS to external consumers via http.
- use constants to define our internal cardinal endpoints.
- split the list endpoint into two separate endpoints for txs and queries

## Testing and Verifying

`cardinal/server/server_test.go`

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? (yes / no)
- Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`? (yes / no)
- How is the feature or change documented? (not applicable / specification (`x/<module>/spec/`) / [Osmosis docs repo](https://github.com/osmosis-labs/docs) / not documented)
