### PR TITLE
fix(cardinal): the namespace of a world should be a string version of the ID, not a rune

### DIFF
--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -760,7 +760,7 @@ func (w *World) getITx(id transaction.TypeID) transaction.ITransaction {
 }
 
 func (w *World) GetNamespace() string {
-	return string(rune(w.id))
+	return fmt.Sprintf("%d", w.id)
 }
 
 func (w *World) LogError(err error) {


### PR DESCRIPTION

<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->


## What is the purpose of the change

Converting the world ID to a rune, and then a string results in namespaces like "\x00", which is weird. This PR creates more intuitive looking namespace.
