### PR TITLE
refactor(cardinal)!: inject request/reply types into read handlers

### DIFF
--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -336,29 +336,15 @@ func TestCanListReads(t *testing.T) {
 		Meow string `json:"meow,omitempty"`
 	}
 
-	fooRead := ecs.NewReadType[FooRequest]("foo", func(world *ecs.World, bz []byte) ([]byte, error) {
-		var req FooRequest
-		err := json.Unmarshal(bz, &req)
-		if err != nil {
-			return nil, err
-		}
-		return json.Marshal(FooResponse{Meow: req.Meow})
+	fooRead := ecs.NewReadType[FooRequest, FooResponse]("foo", func(world *ecs.World, req FooRequest) (FooResponse, error) {
+		return FooResponse{Meow: req.Meow}, nil
 	})
-	barRead := ecs.NewReadType[FooRequest]("bar", func(world *ecs.World, bz []byte) ([]byte, error) {
-		var req FooRequest
-		err := json.Unmarshal(bz, &req)
-		if err != nil {
-			return nil, err
-		}
-		return json.Marshal(FooResponse{Meow: req.Meow})
+	barRead := ecs.NewReadType[FooRequest, FooResponse]("bar", func(world *ecs.World, req FooRequest) (FooResponse, error) {
+
+		return FooResponse{Meow: req.Meow}, nil
 	})
-	bazRead := ecs.NewReadType[FooRequest]("baz", func(world *ecs.World, bz []byte) ([]byte, error) {
-		var req FooRequest
-		err := json.Unmarshal(bz, &req)
-		if err != nil {
-			return nil, err
-		}
-		return json.Marshal(FooResponse{Meow: req.Meow})
+	bazRead := ecs.NewReadType[FooRequest, FooResponse]("baz", func(world *ecs.World, req FooRequest) (FooResponse, error) {
+		return FooResponse{Meow: req.Meow}, nil
 	})
 
 	assert.NilError(t, world.RegisterReads(fooRead, barRead, bazRead))
@@ -393,16 +379,11 @@ func TestReadEncodeDecode(t *testing.T) {
 		Meow string `json:"meow,omitempty"`
 	}
 	endpoint := "foo"
-	fq := ecs.NewReadType[FooRequest](endpoint, func(world *ecs.World, bz []byte) ([]byte, error) {
-		var req FooRequest
-		err := json.Unmarshal(bz, &req)
-		if err != nil {
-			return nil, err
-		}
-		return json.Marshal(FooResponse{Meow: req.Meow})
+	fq := ecs.NewReadType[FooRequest, FooResponse](endpoint, func(world *ecs.World, req FooRequest) (FooResponse, error) {
+		return FooResponse{Meow: req.Meow}, nil
 	})
 
-	// setup the world, register the reads, load.
+	// set up the world, register the reads, load.
 	world := inmem.NewECSWorldForTest(t)
 	assert.NilError(t, world.RegisterReads(fq))
 	assert.NilError(t, world.LoadGameState())


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## What is the purpose of the change

before, read handlers were passed raw json bytes. this PR refactors so that serialization/deserialization happens before the read handler is called, allowing devs to operate on concrete request/reply types.

## Brief Changelog

- add type parameters for request and reply types
- change read handler function to take in a request type, and return a reply type.

## Testing and Verifying

`server_test.go`

## Documentation and Release Note

- Does this pull request introduce a new feature or user-facing behavior changes? (yes)
- Is a relevant changelog entry added to the `Unreleased` section in `CHANGELOG.md`?
- How is the feature or change documented? (not applicable / specification (`x/<module>/spec/`) / [Osmosis docs repo](https://github.com/osmosis-labs/docs) / not documented)
