### PR TITLE
chore(ci): fix CI /docs deploy jobs

### DIFF
--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -94,17 +94,5 @@ jobs:
         id: vercel-deploy-results
         run: |
           vercel deploy --prebuilt --prod --token=${{ secrets.DOCS_VERCEL_TOKEN }} 2>&1 | tee output.txt
-          ## Randomized EOF for multiline $GITHUB_OUTPUT
-          EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
-          echo "DEPLOY_OUTPUT<<$EOF" >> $GITHUB_OUTPUT
-          echo ":mag: $(cat output.txt  | grep Inspect)" >> $GITHUB_OUTPUT
-          echo ":globe_with_meridians: $(cat output.txt  | grep Production)" >> $GITHUB_OUTPUT
-          echo "$EOF" >> $GITHUB_OUTPUT
-      - name: PR Comment Deploy Results
-        uses: thollander/actions-comment-pull-request@v2
-        with:
-          comment_tag: vercel_deploy_production
-          message: |
-            ### World Engine Docs deployed to Vercel (Production)!
-            ___
-            ${{ steps.vercel-deploy-results.outputs.DEPLOY_OUTPUT }}
+          echo ":mag: $(cat output.txt  | grep Inspect)"
+          echo ":globe_with_meridians: $(cat output.txt  | grep Production)"


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
v    If your PR doesn't close an issue, that's OK!  Just remove the Closes: #XXX line!
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

Closes: #XXX

## What is the purpose of the change

- fix CI docs deploy job: mistakenly add PR comment event on push event (main branch), `/docs` are deployed fine but CI marked as failed because of this.

## Brief Changelog

- PR comment on push event is now removed, PR comment for deployment preview link only happens on pull request event, not when it merged to main.

## Testing and Verifying

-

## Documentation and Release Note

- N/A
