### PR TITLE
feat: abstract game loop into world.StartTicks()

### DIFF
--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"sort"
 	"sync"
+	"time"
 
 	"github.com/argus-labs/world-engine/chain/x/shard/types"
 	"github.com/argus-labs/world-engine/sign"
+	"github.com/rs/zerolog/log"
 
 	"github.com/argus-labs/world-engine/cardinal/chain"
 	"github.com/argus-labs/world-engine/cardinal/ecs/component"
@@ -457,6 +459,17 @@ func (w *World) Tick(ctx context.Context) error {
 		w.submitToChain(ctx, *txQueue, uint64(prevTick))
 	}
 	return nil
+}
+
+func (w *World) StartTicks(ctx context.Context, loopInterval time.Duration) {
+	log.Info().Msg("Game loop started")
+	go func() {
+		for range time.Tick(loopInterval) {
+			if err := w.Tick(context.Background()); err != nil {
+				panic(err)
+			}
+		}
+	}()
 }
 
 type TxBatch struct {

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -467,7 +467,6 @@ func (w *World) StartGameLoop(ctx context.Context, loopInterval time.Duration) {
 		for range time.Tick(loopInterval) {
 			if err := w.Tick(ctx); err != nil {
 				log.Panic().Err(err).Msg("Error running Tick in Game Loop.")
-				panic(err)
 			}
 		}
 	}()

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -461,11 +461,12 @@ func (w *World) Tick(ctx context.Context) error {
 	return nil
 }
 
-func (w *World) StartTicks(ctx context.Context, loopInterval time.Duration) {
+func (w *World) StartGameLoop(ctx context.Context, loopInterval time.Duration) {
 	log.Info().Msg("Game loop started")
 	go func() {
 		for range time.Tick(loopInterval) {
 			if err := w.Tick(ctx); err != nil {
+				log.Panic().Err(err).Msg("Error running Tick in Game Loop.")
 				panic(err)
 			}
 		}

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -465,7 +465,7 @@ func (w *World) StartTicks(ctx context.Context, loopInterval time.Duration) {
 	log.Info().Msg("Game loop started")
 	go func() {
 		for range time.Tick(loopInterval) {
-			if err := w.Tick(context.Background()); err != nil {
+			if err := w.Tick(ctx); err != nil {
 				panic(err)
 			}
 		}


### PR DESCRIPTION
Fixes: CAR-109

## What is the purpose of the change

Cardinal users currently have to manually spin out a go routine that runs the game loop like so:

```go
go func() {
  	for range time.Tick(time.Second) {
		if err := world.Tick(context.Background()); err != nil {
			panic(err)
		}
	}
}
```

We should abstract this away and let the user pass in their preferred tick time, to something like this:

```go
world.StartTicks(ctx, time.Millisecond * 100)
```

## Brief Changelog

- _Add a function called `StartTicks(ctx, loopInterval)` in `world.go` that would be called in the user's `main.go`_

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage.
