### PR TITLE
refactor(cardinal): allow for early termination of queries

### DIFF
--- a/cardinal/ecs/component.go
+++ b/cardinal/ecs/component.go
@@ -25,7 +25,7 @@ func NewComponentType[T any](opts ...ComponentOption[T]) *ComponentType[T] {
 }
 
 // ComponentType represents a type of component. It is used to identify
-// a component when getting or setting componentStore of an entity.
+// a component when getting or setting the component of an entity.
 type ComponentType[T any] struct {
 	isIDSet    bool
 	id         component.TypeID
@@ -92,7 +92,8 @@ func (c *ComponentType[T]) Set(w *World, id storage.EntityID, component T) error
 	return nil
 }
 
-// Each iterates over the entityLocationStore that have the component.
+// Each iterates over the entities that have the component.
+// If you would like to stop the iteration, return false to the callback. To continue iterating, return true.
 func (c *ComponentType[T]) Each(w *World, callback QueryCallBackFn) {
 	c.query.Each(w, callback)
 }

--- a/cardinal/ecs/component.go
+++ b/cardinal/ecs/component.go
@@ -93,7 +93,7 @@ func (c *ComponentType[T]) Set(w *World, id storage.EntityID, component T) error
 }
 
 // Each iterates over the entityLocationStore that have the component.
-func (c *ComponentType[T]) Each(w *World, callback func(storage.EntityID)) {
+func (c *ComponentType[T]) Each(w *World, callback QueryCallBackFn) {
 	c.query.Each(w, callback)
 }
 

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -33,13 +33,14 @@ func RegisterPersonaSystem(world *World, queue *TransactionQueue) error {
 	}
 	personaTagToAddress := map[string]string{}
 	var errs []error
-	NewQuery(filter.Exact(SignerComp)).Each(world, func(id storage.EntityID) {
+	NewQuery(filter.Exact(SignerComp)).Each(world, func(id storage.EntityID) bool {
 		sc, err := SignerComp.Get(world, id)
 		if err != nil {
 			errs = append(errs, err)
-			return
+			return true
 		}
 		personaTagToAddress[sc.PersonaTag] = sc.SignerAddress
+		return true
 	})
 	if len(errs) != 0 {
 		return errors.Join(errs...)
@@ -78,17 +79,16 @@ func (w *World) GetSignerForPersonaTag(personaTag string, tick int) (addr string
 		return "", ErrorCreatePersonaTxsNotProcessed
 	}
 	var errs []error
-	NewQuery(filter.Exact(SignerComp)).Each(w, func(id storage.EntityID) {
-		if addr != "" {
-			return
-		}
+	NewQuery(filter.Exact(SignerComp)).Each(w, func(id storage.EntityID) bool {
 		sc, err := SignerComp.Get(w, id)
 		if err != nil {
 			errs = append(errs, err)
 		}
 		if sc.PersonaTag == personaTag {
 			addr = sc.SignerAddress
+			return false
 		}
+		return true
 	})
 	if len(errs) > 0 {
 		return "", errors.Join(errs...)

--- a/cardinal/ecs/query.go
+++ b/cardinal/ecs/query.go
@@ -30,15 +30,20 @@ func NewQuery(filter filter.LayoutFilter) *Query {
 	}
 }
 
+type QueryCallBackFn func(storage.EntityID) bool
+
 // Each iterates over all entityLocationStore that match the query.
-func (q *Query) Each(w *World, callback func(storage.EntityID)) {
+func (q *Query) Each(w *World, callback QueryCallBackFn) {
 	accessor := w.StorageAccessor()
 	result := q.evaluateQuery(w, &accessor)
 	iter := storage.NewEntityIterator(0, accessor.Archetypes, result)
 	for iter.HasNext() {
 		entities := iter.Next()
 		for _, id := range entities {
-			callback(id)
+			cont := callback(id)
+			if !cont {
+				return
+			}
 		}
 	}
 }

--- a/cardinal/ecs/query.go
+++ b/cardinal/ecs/query.go
@@ -10,19 +10,19 @@ type cache struct {
 	seen       int
 }
 
-// Query represents a query for entityLocationStore.
-// It is used to filter entityLocationStore based on their componentStore.
-// It receives arbitrary filters that are used to filter entityLocationStore.
+// Query represents a query for entities.
+// It is used to filter entities based on their components.
+// It receives arbitrary filters that are used to filter entities.
 // It contains a cache that is used to avoid re-evaluating the query.
 // So it is not recommended to create a new query every time you want
-// to filter entityLocationStore with the same query.
+// to filter entities with the same query.
 type Query struct {
 	layoutMatches map[WorldId]*cache
 	filter        filter.LayoutFilter
 }
 
 // NewQuery creates a new query.
-// It receives arbitrary filters that are used to filter entityLocationStore.
+// It receives arbitrary filters that are used to filter entities.
 func NewQuery(filter filter.LayoutFilter) *Query {
 	return &Query{
 		layoutMatches: make(map[WorldId]*cache),
@@ -32,7 +32,8 @@ func NewQuery(filter filter.LayoutFilter) *Query {
 
 type QueryCallBackFn func(storage.EntityID) bool
 
-// Each iterates over all entityLocationStore that match the query.
+// Each iterates over all entities that match the query.
+// If you would like to stop the iteration, return false to the callback. To continue iterating, return true.
 func (q *Query) Each(w *World, callback QueryCallBackFn) {
 	accessor := w.StorageAccessor()
 	result := q.evaluateQuery(w, &accessor)
@@ -48,7 +49,7 @@ func (q *Query) Each(w *World, callback QueryCallBackFn) {
 	}
 }
 
-// Count returns the number of entityLocationStore that match the query.
+// Count returns the number of entities that match the query.
 func (q *Query) Count(w *World) int {
 	accessor := w.StorageAccessor()
 	result := q.evaluateQuery(w, &accessor)

--- a/cardinal/ecs/tests/filter_test.go
+++ b/cardinal/ecs/tests/filter_test.go
@@ -32,11 +32,12 @@ func TestCanFilterByArchetype(t *testing.T) {
 	count := 0
 	// Loop over every entity that has exactly the alpha and beta components. There should
 	// only be subsetCount entities.
-	ecs.NewQuery(filter.Exact(alpha, beta)).Each(world, func(id storage.EntityID) {
+	ecs.NewQuery(filter.Exact(alpha, beta)).Each(world, func(id storage.EntityID) bool {
 		count++
 		// Make sure the gamma component is not on this entity
 		_, err := gamma.Get(world, id)
 		assert.ErrorIs(t, err, storage.ErrorComponentNotOnEntity)
+		return true
 	})
 
 	assert.Equal(t, count, subsetCount)
@@ -56,36 +57,41 @@ func TestExactVsContains(t *testing.T) {
 	assert.NilError(t, err)
 	count := 0
 	// Contains(alpha) should return all entities
-	ecs.NewQuery(filter.Contains(alpha)).Each(world, func(id storage.EntityID) {
+	ecs.NewQuery(filter.Contains(alpha)).Each(world, func(id storage.EntityID) bool {
 		count++
+		return true
 	})
 	assert.Equal(t, count, alphaCount+bothCount)
 
 	count = 0
 	// Contains(beta) should only return the entities that have both components
-	ecs.NewQuery(filter.Contains(beta)).Each(world, func(id storage.EntityID) {
+	ecs.NewQuery(filter.Contains(beta)).Each(world, func(id storage.EntityID) bool {
 		count++
+		return true
 	})
 	assert.Equal(t, count, bothCount)
 
 	count = 0
 	// Exact(alpha) should not return the entities that have both alpha and beta
-	ecs.NewQuery(filter.Exact(alpha)).Each(world, func(id storage.EntityID) {
+	ecs.NewQuery(filter.Exact(alpha)).Each(world, func(id storage.EntityID) bool {
 		count++
+		return true
 	})
 	assert.Equal(t, count, alphaCount)
 
 	count = 0
 	// Exact(alpha, beta) should not return the entities that only have alpha
-	ecs.NewQuery(filter.Exact(alpha, beta)).Each(world, func(id storage.EntityID) {
+	ecs.NewQuery(filter.Exact(alpha, beta)).Each(world, func(id storage.EntityID) bool {
 		count++
+		return true
 	})
 	assert.Equal(t, count, bothCount)
 
 	count = 0
 	// Make sure the order of alpha/beta doesn't matter
-	ecs.NewQuery(filter.Exact(beta, alpha)).Each(world, func(id storage.EntityID) {
+	ecs.NewQuery(filter.Exact(beta, alpha)).Each(world, func(id storage.EntityID) bool {
 		count++
+		return true
 	})
 	assert.Equal(t, count, bothCount)
 }
@@ -109,8 +115,9 @@ func TestCanGetArchetypeFromEntity(t *testing.T) {
 	assert.NilError(t, err)
 
 	count := 0
-	ecs.NewQuery(filter.Exact(comps...)).Each(world, func(id storage.EntityID) {
+	ecs.NewQuery(filter.Exact(comps...)).Each(world, func(id storage.EntityID) bool {
 		count++
+		return true
 	})
 	assert.Equal(t, count, wantCount)
 
@@ -154,8 +161,9 @@ func helperArchetypeFilter(b *testing.B, relevantCount, ignoreCount int) {
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {
 		count := 0
-		ecs.NewQuery(filter.Exact(alpha, beta)).Each(world, func(id storage.EntityID) {
+		ecs.NewQuery(filter.Exact(alpha, beta)).Each(world, func(id storage.EntityID) bool {
 			count++
+			return true
 		})
 		assert.Equal(b, count, relevantCount)
 	}

--- a/cardinal/ecs/tests/persona_test.go
+++ b/cardinal/ecs/tests/persona_test.go
@@ -34,12 +34,13 @@ func TestCreatePersonaTransactionAutomaticallyCreated(t *testing.T) {
 	assert.NilError(t, world.Tick(context.Background()))
 
 	count := 0
-	ecs.NewQuery(filter.Exact(ecs.SignerComp)).Each(world, func(id storage.EntityID) {
+	ecs.NewQuery(filter.Exact(ecs.SignerComp)).Each(world, func(id storage.EntityID) bool {
 		count++
 		sc, err := ecs.SignerComp.Get(world, id)
 		assert.NilError(t, err)
 		assert.Equal(t, sc.PersonaTag, wantTag)
 		assert.Equal(t, sc.SignerAddress, wantAddress)
+		return true
 	})
 	assert.Equal(t, 1, count)
 }

--- a/cardinal/ecs/tests/query_test.go
+++ b/cardinal/ecs/tests/query_test.go
@@ -1,0 +1,40 @@
+package tests
+
+import (
+	"github.com/argus-labs/world-engine/cardinal/ecs"
+	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
+	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
+	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"gotest.tools/v3/assert"
+	"testing"
+)
+
+func TestQueryEarlyTermination(t *testing.T) {
+	type FooComponent struct {
+		Data string
+	}
+	foo := ecs.NewComponentType[FooComponent]()
+	world := inmem.NewECSWorldForTest(t)
+	assert.NilError(t, world.RegisterComponents(foo))
+
+	total := 10
+	count := 0
+	stop := 5
+	_, err := world.CreateMany(total, foo)
+	assert.NilError(t, err)
+	ecs.NewQuery(filter.Exact(foo)).Each(world, func(id storage.EntityID) bool {
+		count++
+		if count == stop {
+			return false
+		}
+		return true
+	})
+	assert.Equal(t, count, stop)
+
+	count = 0
+	ecs.NewQuery(filter.Exact(foo)).Each(world, func(id storage.EntityID) bool {
+		count++
+		return true
+	})
+	assert.Equal(t, count, total)
+}

--- a/cardinal/ecs/tests/state_test.go
+++ b/cardinal/ecs/tests/state_test.go
@@ -171,9 +171,10 @@ func TestCanReloadState(t *testing.T) {
 	_, err := alphaWorld.CreateMany(10, oneAlphaNum)
 	assert.NilError(t, err)
 	alphaWorld.AddSystem(func(w *ecs.World, queue *ecs.TransactionQueue) error {
-		oneAlphaNum.Each(w, func(id storage.EntityID) {
+		oneAlphaNum.Each(w, func(id storage.EntityID) bool {
 			err := oneAlphaNum.Set(w, id, NumberComponent{int(id)})
 			assert.Check(t, err == nil)
+			return true
 		})
 		return nil
 	})
@@ -189,11 +190,12 @@ func TestCanReloadState(t *testing.T) {
 	assert.NilError(t, betaWorld.LoadGameState())
 
 	count := 0
-	oneBetaNum.Each(betaWorld, func(id storage.EntityID) {
+	oneBetaNum.Each(betaWorld, func(id storage.EntityID) bool {
 		count++
 		num, err := oneBetaNum.Get(betaWorld, id)
 		assert.NilError(t, err)
 		assert.Equal(t, int(id), num.Num)
+		return true
 	})
 	// Make sure we actually have 10 entities
 	assert.Equal(t, 10, count)

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -368,7 +368,7 @@ func (w *World) TransferArchetype(from storage.ArchetypeID, to storage.Archetype
 		}
 	}
 
-	// move componentStore
+	// move component
 	for _, componentType := range fromLayout.Components() {
 		store := w.store.CompStore.Storage(componentType)
 		if toLayout.HasComponent(componentType) {
@@ -647,7 +647,7 @@ func (w *World) getArchetypeForComponents(components []component.IComponentType)
 }
 
 func (w *World) noDuplicates(components []component.IComponentType) bool {
-	// check if there are duplicate values inside componentStore slice
+	// check if there are duplicate values inside component slice
 	for i := 0; i < len(components); i++ {
 		for j := i + 1; j < len(components); j++ {
 			if components[i] == components[j] {

--- a/game/sample_game/server/main.go
+++ b/game/sample_game/server/main.go
@@ -110,16 +110,16 @@ func getPlayerInfoFromWorld(world *ecs.World) ([]playerInfo, error) {
 	var players []playerInfo
 	var errs []error
 
-	queryPlayers(world).Each(world, func(id storage.EntityID) {
+	queryPlayers(world).Each(world, func(id storage.EntityID) bool {
 		currPos, err := component.Position.Get(world, id)
 		if err != nil {
 			errs = append(errs, err)
-			return
+			return true
 		}
 		currHealth, err := component.Health.Get(world, id)
 		if err != nil {
 			errs = append(errs, err)
-			return
+			return true
 		}
 		players = append(players, playerInfo{
 			ID:     id,
@@ -127,6 +127,7 @@ func getPlayerInfoFromWorld(world *ecs.World) ([]playerInfo, error) {
 			XPos:   currPos.X,
 			YPos:   currPos.Y,
 		})
+		return true
 	})
 	return players, errors.Join(errs...)
 }

--- a/game/sample_game/server/system/burn.go
+++ b/game/sample_game/server/system/burn.go
@@ -11,34 +11,36 @@ import (
 
 func BurnSystem(world *ecs.World, tq *ecs.TransactionQueue) error {
 	fires := map[comp.PositionComponent]bool{}
-	ecs.NewQuery(filter.Exact(comp.Position)).Each(world, func(id storage.EntityID) {
+	ecs.NewQuery(filter.Exact(comp.Position)).Each(world, func(id storage.EntityID) bool {
 		pos, err := comp.Position.Get(world, id)
 		if err != nil {
 			log.Print(err)
-			return
+			return true
 		}
 		fires[pos] = true
+		return true
 	})
-	ecs.NewQuery(filter.Exact(comp.Health, comp.Position)).Each(world, func(id storage.EntityID) {
+	ecs.NewQuery(filter.Exact(comp.Health, comp.Position)).Each(world, func(id storage.EntityID) bool {
 		pos, err := comp.Position.Get(world, id)
 		if err != nil {
 			log.Print(err)
-			return
+			return true
 		}
 		if !fires[pos] {
-			return
+			return true
 		}
 
 		health, err := comp.Health.Get(world, id)
 		if err != nil {
 			log.Print(err)
-			return
+			return true
 		}
 		health.Val -= 10
 		if err := comp.Health.Set(world, id, health); err != nil {
 			log.Print(err)
-			return
+			return true
 		}
+		return true
 	})
 	return nil
 }


### PR DESCRIPTION
## What is the purpose of the change

in queries, there was no way to cause early termination when iterating over entities. this PR allows for early termination so we don't have to sit around and wait for iteration to complete.

## Brief Changelog

- change function signature of the Query callback function to return a `bool`
- returning `true` continues the iteration, returning `false` stops it.

## Testing and Verifying

`cardinal/ecs/tests/query_test.go`
