### PR TITLE
feat(cardinal): Implement ability in ECS to save transaction receipts…

### DIFF
--- a/cardinal/ecs/options.go
+++ b/cardinal/ecs/options.go
@@ -1,11 +1,20 @@
 package ecs
 
-import "github.com/argus-labs/world-engine/cardinal/shard"
+import (
+	"github.com/argus-labs/world-engine/cardinal/ecs/receipt"
+	"github.com/argus-labs/world-engine/cardinal/shard"
+)
 
 type Option func(w *World)
 
 func WithAdapter(adapter shard.Adapter) Option {
 	return func(w *World) {
 		w.chain = adapter
+	}
+}
+
+func WithReceiptHistorySize(size int) Option {
+	return func(w *World) {
+		w.receiptHistory = receipt.NewHistory(uint64(w.CurrentTick()), size)
 	}
 }

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -13,8 +13,12 @@ type CreatePersonaTransaction struct {
 	SignerAddress string
 }
 
+type CreatePersonaTransactionResult struct {
+	Success bool
+}
+
 // CreatePersonaTx is a concrete ECS transaction.
-var CreatePersonaTx = NewTransactionType[CreatePersonaTransaction]("create-persona")
+var CreatePersonaTx = NewTransactionType[CreatePersonaTransaction, CreatePersonaTransactionResult]("create-persona")
 
 type SignerComponent struct {
 	PersonaTag    string
@@ -45,22 +49,28 @@ func RegisterPersonaSystem(world *World, queue *TransactionQueue) error {
 	if len(errs) != 0 {
 		return errors.Join(errs...)
 	}
-	for _, tx := range createTxs {
+	for _, txData := range createTxs {
+		tx := txData.Value
 		if _, ok := personaTagToAddress[tx.PersonaTag]; ok {
 			// This PersonaTag has already been registered. Don't do anything
 			continue
 		}
 		id, err := world.Create(SignerComp)
 		if err != nil {
-			return err
+			CreatePersonaTx.AddError(world, txData.ID, err)
+			continue
 		}
 		if err := SignerComp.Set(world, id, SignerComponent{
 			PersonaTag:    tx.PersonaTag,
 			SignerAddress: tx.SignerAddress,
 		}); err != nil {
-			return err
+			CreatePersonaTx.AddError(world, txData.ID, err)
+			continue
 		}
 		personaTagToAddress[tx.PersonaTag] = tx.SignerAddress
+		CreatePersonaTx.SetResult(world, txData.ID, CreatePersonaTransactionResult{
+			Success: true,
+		})
 	}
 
 	return nil

--- a/cardinal/ecs/read.go
+++ b/cardinal/ecs/read.go
@@ -3,6 +3,7 @@ package ecs
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/invopop/jsonschema"
 )
 
@@ -13,7 +14,7 @@ type IRead interface {
 	// and is expected to return a json encoded response struct.
 	HandleRead(*World, []byte) ([]byte, error)
 	// Schema returns the json schema of the read request.
-	Schema() *jsonschema.Schema
+	Schema() (request, reply *jsonschema.Schema)
 }
 
 type ReadType[Request any, Reply any] struct {
@@ -37,8 +38,8 @@ func (r *ReadType[req, rep]) Name() string {
 	return r.name
 }
 
-func (r *ReadType[req, rep]) Schema() *jsonschema.Schema {
-	return jsonschema.Reflect(new(req))
+func (r *ReadType[req, rep]) Schema() (request, reply *jsonschema.Schema) {
+	return jsonschema.Reflect(new(req)), jsonschema.Reflect(new(rep))
 }
 
 func (r *ReadType[req, rep]) HandleRead(w *World, bz []byte) ([]byte, error) {

--- a/cardinal/ecs/receipt/receipt.go
+++ b/cardinal/ecs/receipt/receipt.go
@@ -1,0 +1,91 @@
+// Package receipt keeps track of transaction receipts for a number of ticks. A receipt consists
+// of any errors that were encountered while processing a transaction, as well as the transactions
+// result.
+package receipt
+
+import (
+	"errors"
+	"sync/atomic"
+
+	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
+)
+
+var (
+	ErrorTickHasNotBeenProcessed = errors.New("tick is still in progress")
+	ErrorOldTickHasBeenDiscarded = errors.New("the requested tick has been discarded due to age")
+)
+
+type History struct {
+	currTick     *atomic.Uint64
+	ticksToStore uint64
+	history      []map[transaction.TxID]Receipt
+}
+
+type Receipt struct {
+	ID    transaction.TxID
+	Value any
+	Errs  []error
+}
+
+// NewHistory creates a object that can track transaction receipts over a number of ticks.
+func NewHistory(currentTick uint64, ticksToStore int) *History {
+	// Add an extra tick for the "current" tick.
+	ticksToStore++
+	h := &History{
+		currTick: &atomic.Uint64{},
+		// Store ticksToStore plus the "current" tick
+		ticksToStore: uint64(ticksToStore),
+	}
+	for i := 0; i < ticksToStore; i++ {
+		h.history = append(h.history, map[transaction.TxID]Receipt{})
+	}
+	h.currTick.Store(currentTick)
+	return h
+}
+
+func (h *History) NextTick() {
+	newCurr := h.currTick.Add(1)
+	mod := newCurr % h.ticksToStore
+	h.history[mod] = map[transaction.TxID]Receipt{}
+}
+
+func (h *History) AddError(id transaction.TxID, err error) {
+	tick := int(h.currTick.Load() % h.ticksToStore)
+	rec := h.history[tick][id]
+	rec.ID = id
+	rec.Errs = append(rec.Errs, err)
+	h.history[tick][id] = rec
+}
+
+func (h *History) SetResult(id transaction.TxID, a any) {
+	tick := int(h.currTick.Load() % h.ticksToStore)
+	rec := h.history[tick][id]
+	rec.ID = id
+	rec.Value = a
+	h.history[tick][id] = rec
+}
+
+func (h *History) GetReceipt(id transaction.TxID) (rec Receipt, ok bool) {
+	tick := int(h.currTick.Load() % h.ticksToStore)
+	rec, ok = h.history[tick][id]
+	return rec, ok
+}
+
+func (h *History) GetReceiptsForTick(tick uint64) ([]Receipt, error) {
+	currTick := h.currTick.Load()
+	// The requested tick is either in the future, or it is currently being processed. We don't yet know
+	// what the results of this tick will be.
+	if currTick <= tick {
+		return nil, ErrorTickHasNotBeenProcessed
+	}
+	if currTick-tick >= h.ticksToStore {
+		return nil, ErrorOldTickHasBeenDiscarded
+	}
+	mod := tick % h.ticksToStore
+	recs := make([]Receipt, 0, len(h.history[mod]))
+	for _, rec := range h.history[mod] {
+		recs = append(recs, rec)
+	}
+
+	return recs, nil
+}

--- a/cardinal/ecs/receipt/receipt_test.go
+++ b/cardinal/ecs/receipt/receipt_test.go
@@ -1,0 +1,147 @@
+package receipt
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
+	"gotest.tools/v3/assert"
+)
+
+func txID(name string, index uint64) transaction.TxID {
+	return transaction.TxID{
+		PersonaTag: name,
+		Index:      index,
+	}
+}
+
+func TestCanSaveAndGetAnError(t *testing.T) {
+	rh := NewHistory(100, 10)
+	id := txID("foobar", 99)
+	wantError := errors.New("some error")
+
+	rh.AddError(id, wantError)
+
+	rec, ok := rh.GetReceipt(id)
+	assert.Check(t, ok)
+	assert.Equal(t, 1, len(rec.Errs))
+	assert.ErrorIs(t, wantError, rec.Errs[0])
+	assert.Equal(t, nil, rec.Value)
+}
+
+func TestCanSaveAndGetManyErrors(t *testing.T) {
+	rh := NewHistory(99, 5)
+	id := txID("xyzzy", 10)
+	errA, errB := errors.New("a error"), errors.New("b error")
+	rh.AddError(id, errA)
+	rh.AddError(id, errB)
+	rec, ok := rh.GetReceipt(id)
+	assert.Check(t, ok)
+	assert.Equal(t, 2, len(rec.Errs))
+	assert.ErrorIs(t, errA, rec.Errs[0])
+	assert.ErrorIs(t, errB, rec.Errs[1])
+	assert.Equal(t, nil, rec.Value)
+}
+
+func TestCanSaveAndGetResult(t *testing.T) {
+	type myStruct struct {
+		X string
+		Y int
+	}
+
+	rh := NewHistory(99, 5)
+	id := txID("xyzzy", 10)
+	wantStruct := myStruct{"woo", 100}
+	rh.SetResult(id, wantStruct)
+
+	rec, ok := rh.GetReceipt(id)
+	assert.Check(t, ok)
+	assert.Equal(t, 0, len(rec.Errs))
+	assert.Check(t, rec.Value != nil)
+	gotStruct, ok := rec.Value.(myStruct)
+	assert.Check(t, ok)
+	assert.Equal(t, wantStruct, gotStruct)
+}
+
+func TestCanReplaceResult(t *testing.T) {
+	type toBeReplaced struct {
+		Name string
+	}
+
+	rh := NewHistory(99, 5)
+	id := txID("xyzzy", 10)
+
+	doNotWant := toBeReplaced{"replaceme"}
+	rh.SetResult(id, doNotWant)
+
+	want := toBeReplaced{"I actually want this result"}
+	rh.SetResult(id, want)
+
+	rec, ok := rh.GetReceipt(id)
+	assert.Check(t, ok)
+	assert.Equal(t, 0, len(rec.Errs))
+	assert.Check(t, rec.Value != nil)
+
+	got, ok := rec.Value.(toBeReplaced)
+	assert.Check(t, ok)
+	assert.Equal(t, want, got)
+
+}
+
+func TestMissingIDReturnsNotOK(t *testing.T) {
+	rh := NewHistory(99, 5)
+	id := txID("does not exist", 10)
+
+	_, ok := rh.GetReceipt(id)
+	assert.Check(t, !ok)
+}
+
+func TestErrorWhenGettingReceiptsInNonFinishedTick(t *testing.T) {
+	currTick := uint64(99)
+	rh := NewHistory(currTick, 5)
+
+	_, err := rh.GetReceiptsForTick(currTick)
+	assert.ErrorIs(t, ErrorTickHasNotBeenProcessed, err)
+
+	rh.NextTick()
+
+	recs, err := rh.GetReceiptsForTick(currTick)
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(recs))
+}
+
+func TestOldTicksAreDiscarded(t *testing.T) {
+	type MyStruct struct {
+		Number int
+	}
+
+	tickToGet := uint64(99)
+	historyLength := 3
+	// ticksToStore is 3, so at most 3 ticks from the past will be remembered.
+	rh := NewHistory(tickToGet, historyLength)
+	id := txID("an-old-id", 10)
+	wantResult := MyStruct{1234}
+	wantError := errors.New("some error")
+	rh.SetResult(id, wantResult)
+	rh.AddError(id, wantError)
+
+	// We should be able to call NextTick 3 times and still be able to get the relevant tick
+	for i := 0; i < historyLength; i++ {
+		rh.NextTick()
+		recs, err := rh.GetReceiptsForTick(tickToGet)
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(recs), "failed to get receipts in step %d", i)
+		rec := recs[0]
+		assert.Equal(t, 1, len(rec.Errs))
+		assert.ErrorIs(t, wantError, rec.Errs[0])
+		gotResult, ok := rec.Value.(MyStruct)
+		assert.Check(t, ok)
+		assert.Equal(t, wantResult, gotResult)
+	}
+
+	// tickToGet is now 4 ticks in the past, and since our historyLength is only 3, the tick
+	// should no longer be stored
+	rh.NextTick()
+	_, err := rh.GetReceiptsForTick(tickToGet)
+	assert.ErrorIs(t, ErrorOldTickHasBeenDiscarded, err)
+}

--- a/cardinal/ecs/storage/engine.go
+++ b/cardinal/ecs/storage/engine.go
@@ -89,9 +89,9 @@ type StateStorage interface {
 
 type TickStorage interface {
 	GetTickNumbers() (start, end uint64, err error)
-	StartNextTick(txs []transaction.ITransaction, queues map[transaction.TypeID][]any) error
+	StartNextTick(txs []transaction.ITransaction, queues transaction.TxMap) error
 	FinalizeTick() error
-	Recover(txs []transaction.ITransaction) (map[transaction.TypeID][]any, error)
+	Recover(txs []transaction.ITransaction) (transaction.TxMap, error)
 }
 
 type NonceStorage interface {

--- a/cardinal/ecs/tests/chain_recover_test.go
+++ b/cardinal/ecs/tests/chain_recover_test.go
@@ -1,14 +1,15 @@
 package tests
 
 import (
-	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"
 	"context"
 	"encoding/binary"
+	"sort"
+	"testing"
+
+	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"
 	"github.com/argus-labs/world-engine/sign"
 	"github.com/cometbft/cometbft/libs/rand"
 	"google.golang.org/protobuf/proto"
-	"sort"
-	"testing"
 
 	"gotest.tools/v3/assert"
 
@@ -82,6 +83,8 @@ type SendEnergyTransaction struct {
 	Amount   uint64
 }
 
+type SendEnergyTransactionResponse struct{}
+
 // TestWorld_RecoverFromChain tests that after submitting transactions to the chain, they can be queried, re-ran,
 // and end up with the same game state as before.
 func TestWorld_RecoverFromChain(t *testing.T) {
@@ -89,7 +92,7 @@ func TestWorld_RecoverFromChain(t *testing.T) {
 	ctx := context.Background()
 	adapter := &DummyAdapter{txs: make(map[uint64][]*types.Transaction, 0)}
 	w := inmem.NewECSWorldForTest(t, ecs.WithAdapter(adapter))
-	SendEnergyTx := ecs.NewTransactionType[SendEnergyTransaction]("send_energy")
+	SendEnergyTx := ecs.NewTransactionType[SendEnergyTransaction, SendEnergyTransactionResponse]("send_energy")
 	err := w.RegisterTransactions(SendEnergyTx)
 	assert.NilError(t, err)
 
@@ -123,7 +126,7 @@ func TestWorld_RecoverFromChain(t *testing.T) {
 	assert.Equal(t, len(payloads), timesSendEnergyRan)
 }
 
-func generateRandomTransaction(t *testing.T, ns string, tx *ecs.TransactionType[SendEnergyTransaction]) *sign.SignedPayload {
+func generateRandomTransaction(t *testing.T, ns string, tx *ecs.TransactionType[SendEnergyTransaction, SendEnergyTransactionResponse]) *sign.SignedPayload {
 	tx1 := SendEnergyTransaction{
 		To:     rand.Str(5),
 		From:   rand.Str(4),

--- a/cardinal/ecs/tests/tick_test.go
+++ b/cardinal/ecs/tests/tick_test.go
@@ -219,7 +219,7 @@ func TestCanRecoverTransactionsFromFailedSystemRun(t *testing.T) {
 		powerComp := ecs.NewComponentType[FloatValue]()
 		assert.NilError(t, world.RegisterComponents(powerComp))
 
-		powerTx := ecs.NewTransactionType[FloatValue]("change_power")
+		powerTx := ecs.NewTransactionType[FloatValue, FloatValue]("change_power")
 		assert.NilError(t, world.RegisterTransactions(powerTx))
 
 		world.AddSystem(func(w *ecs.World, queue *ecs.TransactionQueue) error {
@@ -229,10 +229,10 @@ func TestCanRecoverTransactionsFromFailedSystemRun(t *testing.T) {
 
 			changes := powerTx.In(queue)
 			assert.Equal(t, 1, len(changes))
-			entityPower.Val += changes[0].Val
+			entityPower.Val += changes[0].Value.Val
 			assert.NilError(t, powerComp.Set(w, id, entityPower))
 
-			if isBuggyIteration && changes[0].Val == 666 {
+			if isBuggyIteration && changes[0].Value.Val == 666 {
 				return errorBadPowerChange
 			}
 			return nil

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -3,6 +3,7 @@ package ecs
 import (
 	"errors"
 	"fmt"
+
 	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
 	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
 	"github.com/argus-labs/world-engine/sign"
@@ -10,11 +11,11 @@ import (
 	"github.com/invopop/jsonschema"
 )
 
-var _ transaction.ITransaction = NewTransactionType[struct{}]("")
+var _ transaction.ITransaction = NewTransactionType[struct{}, struct{}]("")
 
 // TransactionType helps manage adding transactions (aka events) to the world transaction queue. It also assists
 // in the using of transactions inside of System functions.
-type TransactionType[T any] struct {
+type TransactionType[In, Out any] struct {
 	id      transaction.TypeID
 	isIDSet bool
 	name    string
@@ -24,26 +25,25 @@ type TransactionType[T any] struct {
 // TransactionQueue is a list of transactions that were queued since the start of the
 // last game tick.
 type TransactionQueue struct {
-	queue      map[transaction.TypeID][]any
-	signatures map[transaction.TypeID][]*sign.SignedPayload
+	queue transaction.TxMap
 }
 
-func NewTransactionType[T any](name string) *TransactionType[T] {
-	return &TransactionType[T]{
+func NewTransactionType[In, Out any](name string) *TransactionType[In, Out] {
+	return &TransactionType[In, Out]{
 		name: name,
 	}
 }
 
-func (t *TransactionType[T]) Name() string {
+func (t *TransactionType[In, Out]) Name() string {
 	return t.name
 }
 
-func (t *TransactionType[T]) Schema() *jsonschema.Schema {
-	return jsonschema.Reflect(new(T))
+func (t *TransactionType[In, Out]) Schema() (in, out *jsonschema.Schema) {
+	return jsonschema.Reflect(new(In)), jsonschema.Reflect(new(Out))
 }
 
 // DecodeEVMBytes decodes abi encoded solidity structs into Go structs of the same structure.
-func (t *TransactionType[T]) DecodeEVMBytes(bz []byte) (any, error) {
+func (t *TransactionType[In, Out]) DecodeEVMBytes(bz []byte) (any, error) {
 	if t.evmType == nil {
 		return nil, errors.New("cannot call DecodeEVMBytes without setting via SetEVMType first")
 	}
@@ -55,35 +55,38 @@ func (t *TransactionType[T]) DecodeEVMBytes(bz []byte) (any, error) {
 	if len(unpacked) < 1 {
 		return nil, fmt.Errorf("error decoding EVM bytes: no values could be unpacked into the abi type")
 	}
-	underlying, ok := unpacked[0].(T)
+	underlying, ok := unpacked[0].(In)
 	if !ok {
-		return nil, fmt.Errorf("error decoding EVM bytes: cannot cast %T to %T", unpacked[0], new(T))
+		return nil, fmt.Errorf("error decoding EVM bytes: cannot cast %T to %T", unpacked[0], new(In))
 	}
 	return underlying, nil
 }
 
-func (t *TransactionType[T]) SetEVMType(at *abi.Type) {
+func (t *TransactionType[In, Out]) SetEVMType(at *abi.Type) {
 	t.evmType = at
 }
 
-func (t *TransactionType[T]) ID() transaction.TypeID {
+func (t *TransactionType[In, Out]) ID() transaction.TypeID {
 	if !t.isIDSet {
 		panic(fmt.Sprintf("id on %v is not set", t))
 	}
 	return t.id
 }
 
+var emptySignature = &sign.SignedPayload{}
+
 // AddToQueue adds a transaction with the given data to the world object. The transaction will be executed
 // at the next game tick. An optional sign.SignedPayload can be associated with this transaction.
-func (t *TransactionType[T]) AddToQueue(world *World, data T, sigs ...*sign.SignedPayload) {
-	var sig *sign.SignedPayload
+func (t *TransactionType[In, Out]) AddToQueue(world *World, data In, sigs ...*sign.SignedPayload) transaction.TxID {
+	sig := emptySignature
 	if len(sigs) > 0 {
 		sig = sigs[0]
 	}
-	world.AddTransaction(t.ID(), data, sig)
+	_, id := world.AddTransaction(t.ID(), data, sig)
+	return id
 }
 
-func (t *TransactionType[T]) SetID(id transaction.TypeID) error {
+func (t *TransactionType[In, Out]) SetID(id transaction.TypeID) error {
 	if t.isIDSet {
 		// In games implemented with Cardinal, transactions will only be initialized one time (on startup).
 		// In tests, it's often useful to use the same transaction in multiple worlds. This check will allow for the
@@ -98,35 +101,55 @@ func (t *TransactionType[T]) SetID(id transaction.TypeID) error {
 	return nil
 }
 
+type TxData[In any] struct {
+	ID    transaction.TxID
+	Value In
+	Sig   *sign.SignedPayload
+}
+
+func (t *TransactionType[In, Out]) AddError(world *World, id transaction.TxID, err error) {
+	world.AddTransactionError(id, err)
+}
+
+func (t *TransactionType[In, Out]) SetResult(world *World, id transaction.TxID, result Out) {
+	world.SetTransactionResult(id, result)
+}
+
+func (t *TransactionType[In, Out]) GetReceipt(world *World, id transaction.TxID) (v Out, errs []error, ok bool) {
+	iface, errs, ok := world.GetTransactionReceipt(id)
+	if !ok {
+		return v, nil, false
+	}
+	// if iface is nil, maybe the result has never been set. The errors may still be valid.
+	if iface == nil {
+		return v, errs, true
+	}
+	value, ok := iface.(Out)
+	if !ok {
+		return v, nil, false
+	}
+	return value, errs, true
+}
+
 // In extracts all the transactions in the transaction queue that match this TransactionType's ID.
-func (t *TransactionType[T]) In(tq *TransactionQueue) []T {
-	var txs []T
+func (t *TransactionType[In, Out]) In(tq *TransactionQueue) []TxData[In] {
+	var txs []TxData[In]
 	for _, tx := range tq.queue[t.ID()] {
-		if val, ok := tx.(T); ok {
-			txs = append(txs, val)
+		if val, ok := tx.Value.(In); ok {
+			txs = append(txs, TxData[In]{
+				ID:    tx.ID,
+				Value: val,
+				Sig:   tx.Sig,
+			})
 		}
 	}
 	return txs
 }
 
-// TxsAndSigsIn extracts all the transactions and their related signatures in the transaction queue
-// that match this TransactionType's ID.
-func (t *TransactionType[T]) TxsAndSigsIn(tq *TransactionQueue) ([]T, []*sign.SignedPayload) {
-	var txs []T
-	var sigs []*sign.SignedPayload
-	for i, tx := range tq.queue[t.ID()] {
-		if val, ok := tx.(T); ok {
-			txs = append(txs, val)
-			sigs = append(sigs, tq.signatures[t.ID()][i])
-		}
-	}
-	return txs, sigs
-}
-
-func (t *TransactionType[T]) Encode(a any) ([]byte, error) {
+func (t *TransactionType[In, Out]) Encode(a any) ([]byte, error) {
 	return storage.Encode(a)
 }
 
-func (t *TransactionType[T]) Decode(bytes []byte) (any, error) {
-	return storage.Decode[T](bytes)
+func (t *TransactionType[In, Out]) Decode(bytes []byte) (any, error) {
+	return storage.Decode[In](bytes)
 }

--- a/cardinal/ecs/transaction/transaction.go
+++ b/cardinal/ecs/transaction/transaction.go
@@ -1,9 +1,23 @@
 package transaction
 
 import (
+	"github.com/argus-labs/world-engine/sign"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/invopop/jsonschema"
 )
+
+type TxMap map[TypeID][]TxAny
+
+type TxAny struct {
+	Value any
+	ID    TxID
+	Sig   *sign.SignedPayload
+}
+
+type TxID struct {
+	PersonaTag string
+	Index      uint64
+}
 
 type TypeID int
 
@@ -11,7 +25,7 @@ type ITransaction interface {
 	SetID(TypeID) error
 	SetEVMType(*abi.Type)
 	Name() string
-	Schema() *jsonschema.Schema
+	Schema() (in, out *jsonschema.Schema)
 	ID() TypeID
 	Encode(any) ([]byte, error)
 	Decode([]byte) (any, error)

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -1,13 +1,15 @@
 package ecs
 
 import (
-	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"
 	"context"
 	"errors"
 	"fmt"
-	"google.golang.org/protobuf/proto"
 	"sync"
 	"time"
+
+	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"
+	"github.com/argus-labs/world-engine/cardinal/ecs/receipt"
+	"google.golang.org/protobuf/proto"
 
 	"github.com/argus-labs/world-engine/chain/x/shard/types"
 	"github.com/argus-labs/world-engine/sign"
@@ -45,10 +47,11 @@ type World struct {
 	isTransactionsRegistered bool
 	stateIsLoaded            bool
 	// txQueues is a map of transaction names to the relevant list of transactions data
-	txQueues     map[transaction.TypeID][]any
-	txSignatures map[transaction.TypeID][]*sign.SignedPayload
+	txQueues transaction.TxMap
 	// txLock ensures txQueues is not modified in the middle of a tick.
 	txLock sync.Mutex
+
+	receiptHistory *receipt.History
 
 	chain shard.ReadAdapter
 	// isRecovering indicates that the world is recovering from the DA layer.
@@ -189,16 +192,18 @@ func NewWorld(s storage.WorldStorage, opts ...Option) (*World, error) {
 	worldId := nextWorldId
 	nextWorldId++
 	w := &World{
-		id:           worldId,
-		store:        s,
-		tick:         0,
-		systems:      make([]System, 0, 256), // this can just stay in memory.
-		txQueues:     map[transaction.TypeID][]any{},
-		txSignatures: map[transaction.TypeID][]*sign.SignedPayload{},
+		id:       worldId,
+		store:    s,
+		tick:     0,
+		systems:  make([]System, 0, 256), // this can just stay in memory.
+		txQueues: transaction.TxMap{},
 	}
 	w.AddSystem(RegisterPersonaSystem)
 	for _, opt := range opts {
 		opt(w)
+	}
+	if w.receiptHistory == nil {
+		w.receiptHistory = receipt.NewHistory(uint64(w.CurrentTick()), 10)
 	}
 	return w, nil
 }
@@ -399,31 +404,31 @@ func (w *World) StorageAccessor() StorageAccessor {
 }
 
 // copyTransactions makes a copy of the world txQueue, then zeroes out the txQueue.
-func (w *World) copyTransactions() (map[transaction.TypeID][]any, map[transaction.TypeID][]*sign.SignedPayload) {
+func (w *World) copyTransactions() transaction.TxMap {
 	w.txLock.Lock()
 	defer w.txLock.Unlock()
-	txsMap := make(map[transaction.TypeID][]any, len(w.txQueues))
-	sigsMap := make(map[transaction.TypeID][]*sign.SignedPayload, len(w.txSignatures))
+	txsMap := make(transaction.TxMap, len(w.txQueues))
 	for id, txs := range w.txQueues {
-		txsMap[id] = make([]interface{}, len(txs))
-		sigsMap[id] = make([]*sign.SignedPayload, len(txs))
+		txsMap[id] = make([]transaction.TxAny, len(txs))
 		copy(txsMap[id], txs)
-		copy(sigsMap[id], w.txSignatures[id])
 		w.txQueues[id] = w.txQueues[id][:0]
-		w.txSignatures[id] = w.txSignatures[id][:0]
 	}
-	return txsMap, sigsMap
+	return txsMap
 }
 
 // AddTransaction adds a transaction to the transaction queue. This should not be used directly.
 // Instead, use a TransactionType.AddToQueue to ensure type consistency. Returns the tick this transaction will be
 // executed in.
-func (w *World) AddTransaction(id transaction.TypeID, v any, sig *sign.SignedPayload) uint64 {
+func (w *World) AddTransaction(id transaction.TypeID, v any, sig *sign.SignedPayload) (tick uint64, txID transaction.TxID) {
 	w.txLock.Lock()
 	defer w.txLock.Unlock()
-	w.txQueues[id] = append(w.txQueues[id], v)
-	w.txSignatures[id] = append(w.txSignatures[id], sig)
-	return w.CurrentTick()
+	txID = transaction.TxID{PersonaTag: sig.PersonaTag, Index: sig.Nonce}
+	w.txQueues[id] = append(w.txQueues[id], transaction.TxAny{
+		ID:    txID,
+		Value: v,
+		Sig:   sig,
+	})
+	return w.CurrentTick(), txID
 }
 
 // Tick performs one game tick. This consists of taking a snapshot of all pending transactions, then calling
@@ -432,15 +437,14 @@ func (w *World) Tick(ctx context.Context) error {
 	if !w.stateIsLoaded {
 		return errors.New("must load state before first tick")
 	}
-	txs, sigs := w.copyTransactions()
+	txs := w.copyTransactions()
 
 	if err := w.store.TickStore.StartNextTick(w.registeredTransactions, txs); err != nil {
 		return err
 	}
 
 	txQueue := &TransactionQueue{
-		queue:      txs,
-		signatures: sigs,
+		queue: txs,
 	}
 
 	for _, sys := range w.systems {
@@ -448,6 +452,7 @@ func (w *World) Tick(ctx context.Context) error {
 			return err
 		}
 	}
+	w.receiptHistory.NextTick()
 
 	if err := w.saveArchetypeData(); err != nil {
 		return err
@@ -552,7 +557,7 @@ func (w *World) saveToKey(key string, cm storage.ComponentMarshaler) error {
 // a problem when running one of the Systems), the snapshotted state is recovered and the pending
 // transactions for the incomplete tick are returned. A nil recoveredTxs indicates there are no pending
 // transactions that need to be processed because the last tick was successful.
-func (w *World) recoverGameState() (recoveredTxs map[transaction.TypeID][]any, err error) {
+func (w *World) recoverGameState() (recoveredTxs transaction.TxMap, err error) {
 	start, end, err := w.store.TickStore.GetTickNumbers()
 	if err != nil {
 		return nil, err
@@ -779,4 +784,24 @@ func (w *World) GetNonce(signerAddress string) (uint64, error) {
 
 func (w *World) SetNonce(signerAddress string, nonce uint64) error {
 	return w.store.NonceStore.SetNonce(signerAddress, nonce)
+}
+
+func (w *World) AddTransactionError(id transaction.TxID, err error) {
+	w.receiptHistory.AddError(id, err)
+}
+
+func (w *World) SetTransactionResult(id transaction.TxID, a any) {
+	w.receiptHistory.SetResult(id, a)
+}
+
+func (w *World) GetTransactionReceipt(id transaction.TxID) (any, []error, bool) {
+	rec, ok := w.receiptHistory.GetReceipt(id)
+	if !ok {
+		return nil, nil, false
+	}
+	return rec.Value, rec.Errs, true
+}
+
+func (w *World) GetTransactionReceiptsForTick(tick uint64) ([]receipt.Receipt, error) {
+	return w.receiptHistory.GetReceiptsForTick(tick)
 }

--- a/cardinal/evm/server.go
+++ b/cardinal/evm/server.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"crypto/tls"
 	"fmt"
-	"github.com/argus-labs/world-engine/cardinal/ecs"
 	"net"
 	"os"
+
+	"github.com/argus-labs/world-engine/cardinal/ecs"
 
 	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
 	"github.com/argus-labs/world-engine/sign"
@@ -28,7 +29,7 @@ var _ TxHandler = &ecs.World{}
 
 // TxHandler is a type that gives access to transaction data in the ecs.World, as well as access to queue transactions.
 type TxHandler interface {
-	AddTransaction(transaction.TypeID, any, *sign.SignedPayload) uint64
+	AddTransaction(transaction.TypeID, any, *sign.SignedPayload) (uint64, transaction.TxID)
 	ListTransactions() ([]transaction.ITransaction, error)
 }
 
@@ -106,7 +107,11 @@ func (s *srv) SendMsg(ctx context.Context, msg *routerv1.MsgSend) (*routerv1.Msg
 	if err != nil {
 		return nil, err
 	}
+	sig := &sign.SignedPayload{
+		PersonaTag: "persona_tag",
+		Nonce:      99,
+	}
 	// add transaction to the world queue
-	s.txh.AddTransaction(itx.ID(), tx, nil)
+	s.txh.AddTransaction(itx.ID(), tx, sig)
 	return &routerv1.MsgSendResponse{}, nil
 }

--- a/cardinal/evm/server_test.go
+++ b/cardinal/evm/server_test.go
@@ -1,14 +1,15 @@
 package evm
 
 import (
-	routerv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/router/v1"
 	"context"
+	"reflect"
+	"testing"
+
+	routerv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/router/v1"
 	"github.com/argus-labs/world-engine/cardinal/ecs"
 	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"gotest.tools/v3/assert"
-	"reflect"
-	"testing"
 )
 
 type FooTransaction struct {
@@ -20,6 +21,8 @@ type BarTransaction struct {
 	Y uint64
 	Z bool
 }
+
+type TxReply struct{}
 
 // TestServer_SendMsg tests that when sending messages through to the EVM receiver server, they get passed along to
 // the world, and executed in systems.
@@ -42,8 +45,8 @@ func TestServer_SendMsg(t *testing.T) {
 	BarEvmTx.TupleType = reflect.TypeOf(BarTransaction{})
 
 	// create the ECS transactions
-	FooTx := ecs.NewTransactionType[FooTransaction]("footx")
-	BarTx := ecs.NewTransactionType[BarTransaction]("bartx")
+	FooTx := ecs.NewTransactionType[FooTransaction, TxReply]("footx")
+	BarTx := ecs.NewTransactionType[BarTransaction, TxReply]("bartx")
 
 	// bind them to EVM types
 	FooTx.SetEVMType(&FooEvmTX)
@@ -69,10 +72,10 @@ func TestServer_SendMsg(t *testing.T) {
 		assert.Equal(t, len(inFooTxs), len(fooTxs))
 		assert.Equal(t, len(inBarTxs), len(barTxs))
 		for i, tx := range inFooTxs {
-			assert.DeepEqual(t, tx, fooTxs[i])
+			assert.DeepEqual(t, tx.Value, fooTxs[i])
 		}
 		for i, tx := range inBarTxs {
-			assert.DeepEqual(t, tx, barTxs[i])
+			assert.DeepEqual(t, tx.Value, barTxs[i])
 		}
 		return nil
 	})

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -205,7 +205,7 @@ func (t *Handler) makeTxHandler(tx transaction.ITransaction) http.HandlerFunc {
 		}
 
 		submitTx := func() uint64 {
-			tick := t.w.AddTransaction(tx.ID(), txVal, sp)
+			tick, _ := t.w.AddTransaction(tx.ID(), txVal, sp)
 
 			res, err := json.Marshal("ok")
 			if err != nil {
@@ -251,9 +251,13 @@ func (t *Handler) makeReadHandler(r ecs.IRead) http.HandlerFunc {
 	}
 }
 
-func (t *Handler) makeSchemaHandler(schema *jsonschema.Schema) http.HandlerFunc {
+func (t *Handler) makeSchemaHandler(inSchema, outSchema *jsonschema.Schema) http.HandlerFunc {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		res, err := json.Marshal(schema)
+		requestAndReply := map[string]*jsonschema.Schema{
+			"request": inSchema,
+			"reply":   outSchema,
+		}
+		res, err := json.Marshal(requestAndReply)
 		if err != nil {
 			writeError(writer, "unable to marshal response", err)
 			return


### PR DESCRIPTION
… (errors and results)

Closes: #CAR-129

## What is the purpose of the change

- Allow for the creation of transaction receipts in ECS (A transaction receipt is a combination of the errors encountered when processing a transaction, as well as a single result).
- Create a helper library (receipt) to keep a history of transaction receipts.
- Schema endpoints now return both the input and the output for read and transaction endpoints.
- Tx Signatures are now saved to the redis DB at the start of a world Tick.

## Testing and Verifying

- Added unit test that:
  - Ensures errors can be added to transaction from systems
  - Ensures a result can be attached to a transaction
  - Errors can be fetched from other systems
  - Results can be fetched from other systems
