### PR TITLE
feat(cardinal): Implement an endpoint to read transaction receipts fr… CAR-130 CAR-135

### DIFF
--- a/cardinal/ecs/receipt/receipt.go
+++ b/cardinal/ecs/receipt/receipt.go
@@ -48,6 +48,10 @@ func NewHistory(currentTick uint64, ticksToStore int) *History {
 	return h
 }
 
+func (h *History) Size() uint64 {
+	return h.ticksToStore
+}
+
 // NextTick advances the internal History tick by 1. Errors and results can only be set on the current tick. Receipts
 // from ticks in the past are read only.
 func (h *History) NextTick() {

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -216,6 +216,10 @@ func (w *World) CurrentTick() uint64 {
 	return w.tick
 }
 
+func (w *World) ReceiptHistorySize() uint64 {
+	return w.receiptHistory.Size()
+}
+
 func (w *World) CreateMany(num int, components ...component.IComponentType) ([]storage.EntityID, error) {
 	archetypeID := w.getArchetypeForComponents(components)
 	entities := make([]storage.EntityID, 0, num)

--- a/cardinal/server/handler.go
+++ b/cardinal/server/handler.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+
+	"github.com/argus-labs/world-engine/cardinal/ecs"
+	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
+	"github.com/invopop/jsonschema"
+)
+
+func registerReadHandlers(w *ecs.World, th *Handler) error {
+	var readEndpoints []string
+
+	// Register user defined read endpoints
+	reads := w.ListReads()
+	for _, r := range reads {
+		endpoint := readPrefix + r.Name()
+		schemaEndpoint := schemaEndpointPrefix + readPrefix + r.Name()
+		readEndpoints = append(readEndpoints, endpoint, schemaEndpoint)
+
+		th.mux.HandleFunc(conformPath(endpoint), th.makeReadHandler(r))
+		th.mux.HandleFunc(conformPath(schemaEndpoint), th.makeSchemaHandler(r.Schema()))
+	}
+
+	// Register persona read endpoints
+	readPersonaSignerEndpoint := readPrefix + "persona-signer"
+	readPersonaSignerSchemaEndpoint := schemaEndpointPrefix + readPrefix + "persona-signer"
+	readEndpoints = append(readEndpoints, readPersonaSignerEndpoint, readPersonaSignerSchemaEndpoint)
+	th.mux.HandleFunc(conformPath(readPersonaSignerEndpoint), th.handleReadPersonaSigner)
+	th.mux.HandleFunc(conformPath(readPersonaSignerSchemaEndpoint), th.handleReadPersonaSignerSchema)
+
+	// Register list read endpoints
+	listReadHandler, err := makeWriteHandler(readEndpoints)
+	if err != nil {
+		return err
+	}
+	th.mux.HandleFunc(conformPath(listReadEndpoint), listReadHandler)
+
+	return nil
+}
+
+func registerTxHandlers(w *ecs.World, th *Handler) error {
+	var txEndpoints []string
+
+	// Register tx endpoints
+	txs, err := w.ListTransactions()
+	if err != nil {
+		return err
+	}
+	for _, tx := range txs {
+		endpoint := txPrefix + tx.Name()
+		schemaEndpoint := schemaEndpointPrefix + txPrefix + tx.Name()
+		txEndpoints = append(txEndpoints, endpoint, schemaEndpoint)
+
+		if tx.Name() == ecs.CreatePersonaTx.Name() {
+			// Register persona tx endpoint
+			// Note: The CreatePersonaTx is different from normal transactions because it doesn't look up a signer
+			// address from the world to verify the transaction.
+			th.mux.HandleFunc(conformPath(endpoint), th.makeCreatePersonaHandler(tx))
+		} else {
+			// Register user defined tx endpoints
+			th.mux.HandleFunc(conformPath(endpoint), th.makeTxHandler(tx))
+		}
+		th.mux.HandleFunc(conformPath(schemaEndpoint), th.makeSchemaHandler(tx.Schema()))
+	}
+
+	// Register list tx endpoints
+	listTxHandler, err := makeWriteHandler(txEndpoints)
+	if err != nil {
+		return err
+	}
+	th.mux.HandleFunc(conformPath(listTxEndpoint), listTxHandler)
+
+	return nil
+}
+
+func registerReceiptEndpoints(world *ecs.World, th *Handler) error {
+	th.mux.HandleFunc(conformPath(listTxReceipts), handleListTxReceipts(world))
+	return nil
+}
+
+func (t *Handler) makeSchemaHandler(inSchema, outSchema *jsonschema.Schema) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		requestAndReply := map[string]*jsonschema.Schema{
+			"request": inSchema,
+			"reply":   outSchema,
+		}
+		res, err := json.Marshal(requestAndReply)
+		if err != nil {
+			writeError(writer, "unable to marshal response", err)
+			return
+		}
+
+		writeResult(writer, res)
+	}
+}
+
+func (t *Handler) makeTxHandler(tx transaction.ITransaction) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		payload, sp, err := t.verifySignature(request, true)
+		if errors.Is(err, ErrorInvalidSignature) {
+			writeUnauthorized(writer, err)
+			return
+		} else if err != nil {
+			writeError(writer, "unable to verify signature", err)
+			return
+		}
+		txVal, err := tx.Decode(payload)
+		if err != nil {
+			writeError(writer, "unable to decode transaction", err)
+			return
+		}
+
+		submitTx := func() uint64 {
+			tick, _ := t.w.AddTransaction(tx.ID(), txVal, sp)
+
+			res, err := json.Marshal("ok")
+			if err != nil {
+				writeError(writer, "unable to marshal response", err)
+				return 0
+			}
+			writeResult(writer, res)
+			return tick
+		}
+
+		// check if we have an adapter
+		if t.adapter != nil {
+			// if the world is recovering via adapter, we shouldn't accept transactions.
+			if t.w.IsRecovering() {
+				writeError(writer, "unable to submit transactions: game world is recovering state", nil)
+			} else {
+				tick := submitTx()
+				err = t.adapter.Submit(context.Background(), sp, uint64(tx.ID()), tick)
+				if err != nil {
+					writeError(writer, "error submitting transaction to blockchain", err)
+				}
+			}
+		} else {
+			// if there is no adapter, then we can just put the tx in the queue.
+			submitTx()
+		}
+	}
+}
+
+func (t *Handler) makeReadHandler(r ecs.IRead) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		buf, err := io.ReadAll(request.Body)
+		if err != nil {
+			writeError(writer, "unable to read request body", err)
+			return
+		}
+		res, err := r.HandleReadRaw(t.w, buf)
+		if err != nil {
+			writeError(writer, "error handling read", err)
+			return
+		}
+		writeResult(writer, res)
+	}
+}

--- a/cardinal/server/handler.go
+++ b/cardinal/server/handler.go
@@ -79,7 +79,7 @@ func registerTxHandlers(w *ecs.World, th *Handler) error {
 }
 
 func registerReceiptEndpoints(world *ecs.World, th *Handler) error {
-	th.mux.HandleFunc(conformPath(listTxReceipts), handleListTxReceipts(world))
+	th.mux.HandleFunc(conformPath(txReceiptsEndpoint), handleListTxReceipts(world))
 	return nil
 }
 

--- a/cardinal/server/receipt.go
+++ b/cardinal/server/receipt.go
@@ -18,15 +18,16 @@ type ListTxReceiptsRequest struct {
 // Meaning StartTick is included and EndTick is not. To iterate over all ticks in the future, use the returned
 // EndTick as the StartTick in the next request. If StartTick == EndTick, the receipts list will be empty.
 type ListTxReceiptsReply struct {
-	StartTick uint64        `json:"start_tick"`
-	EndTick   uint64        `json:"end_tick"`
-	Receipts  []jsonReceipt `json:"receipts"`
+	StartTick uint64    `json:"start_tick"`
+	EndTick   uint64    `json:"end_tick"`
+	Receipts  []Receipt `json:"receipts"`
 }
 
-type jsonReceipt struct {
-	ID     transaction.TxID
-	Result any
-	Errs   []string
+// Receipt represents a single transaction receipt. It contains an ID, a result, and a list of errors.
+type Receipt struct {
+	ID     transaction.TxID `json:"id"`
+	Result any              `json:"result"`
+	Errors []string         `json:"errors"`
 }
 
 // errsToStringSlice convert a slice of errors into a slice of strings. This is needed as json.Marshal does not
@@ -74,10 +75,10 @@ func handleListTxReceipts(world *ecs.World) http.HandlerFunc {
 				continue
 			}
 			for _, r := range currReceipts {
-				reply.Receipts = append(reply.Receipts, jsonReceipt{
+				reply.Receipts = append(reply.Receipts, Receipt{
 					ID:     r.ID,
 					Result: r.Result,
-					Errs:   errsToStringSlice(r.Errs),
+					Errors: errsToStringSlice(r.Errs),
 				})
 			}
 		}

--- a/cardinal/server/receipt.go
+++ b/cardinal/server/receipt.go
@@ -1,0 +1,92 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+
+	"github.com/argus-labs/world-engine/cardinal/ecs"
+	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
+)
+
+type ListTxReceiptsRequest struct {
+	StartTick uint64 `json:"start_tick"`
+}
+
+// ListTxReceiptsReply returns the transaction receipts for the given range of ticks. The interval is closed on
+// StartTick and open on EndTick: i.e. [StartTick, EndTick)
+// Meaning StartTick is included and EndTick is not. To iterate over all ticks in the future, use the returned
+// EndTick as the StartTick in the next request. If StartTick == EndTick, the receipts list will be empty.
+type ListTxReceiptsReply struct {
+	StartTick uint64        `json:"start_tick"`
+	EndTick   uint64        `json:"end_tick"`
+	Receipts  []jsonReceipt `json:"receipts"`
+}
+
+type jsonReceipt struct {
+	ID     transaction.TxID
+	Result any
+	Errs   []string
+}
+
+// errsToStringSlice convert a slice of errors into a slice of strings. This is needed as json.Marshal does not
+// extract the Error string from errors when marshalling.
+func errsToStringSlice(errs []error) []string {
+	r := make([]string, 0, len(errs))
+	for _, err := range errs {
+		r = append(r, err.Error())
+	}
+	return r
+}
+
+func handleListTxReceipts(world *ecs.World) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		buf, err := io.ReadAll(request.Body)
+		if err != nil {
+			writeError(writer, "unable to ready body", err)
+			return
+		}
+		req, err := decode[ListTxReceiptsRequest](buf)
+		if err != nil {
+			writeBadRequest(writer, "unable to decode list receipts request", err)
+			return
+		}
+		reply := ListTxReceiptsReply{}
+		reply.EndTick = world.CurrentTick()
+		size := world.ReceiptHistorySize()
+		if size > reply.EndTick {
+			reply.StartTick = 0
+		} else {
+			reply.StartTick = reply.EndTick - size
+		}
+		// StartTick and EndTick are now at the largest possible range of ticks.
+		// Check to see if we should narrow down the range at all.
+		if req.StartTick > reply.EndTick {
+			// User is asking for ticks in the future.
+			reply.StartTick = reply.EndTick
+		} else if req.StartTick > reply.StartTick {
+			reply.StartTick = req.StartTick
+		}
+
+		for t := reply.StartTick; t < reply.EndTick; t++ {
+			currReceipts, err := world.GetTransactionReceiptsForTick(t)
+			if err != nil || len(currReceipts) == 0 {
+				continue
+			}
+			for _, r := range currReceipts {
+				reply.Receipts = append(reply.Receipts, jsonReceipt{
+					ID:     r.ID,
+					Result: r.Result,
+					Errs:   errsToStringSlice(r.Errs),
+				})
+			}
+		}
+
+		res, err := json.Marshal(reply)
+		if err != nil {
+			writeError(writer, "unable to marshal response", err)
+			return
+		}
+		writeResult(writer, res)
+	}
+}

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -30,7 +30,9 @@ var (
 const (
 	listTxEndpoint   = "list/tx-endpoints"
 	listReadEndpoint = "list/read-endpoints"
-	listTxReceipts   = "list/tx-receipts"
+
+	// Don't name this tx-receipts to ensure it doesn't match the prefix for normal transactions
+	txReceiptsEndpoint = "transaction-receipts"
 
 	schemaEndpointPrefix = "schema/"
 

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -1,20 +1,13 @@
 package server
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"log"
 	"net/http"
 
-	"github.com/argus-labs/world-engine/cardinal/shard"
-	"github.com/invopop/jsonschema"
-
 	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
-	"github.com/argus-labs/world-engine/sign"
+	"github.com/argus-labs/world-engine/cardinal/shard"
 )
 
 // Handler is a type that contains endpoints for transactions and queries in a given ecs world.
@@ -35,10 +28,11 @@ var (
 )
 
 const (
-	listTxEndpoint   = "/list/tx-endpoints"
-	listReadEndpoint = "/list/read-endpoints"
+	listTxEndpoint   = "list/tx-endpoints"
+	listReadEndpoint = "list/read-endpoints"
+	listTxReceipts   = "list/tx-receipts"
 
-	schemaEndpointPrefix = "/schema/"
+	schemaEndpointPrefix = "schema/"
 
 	readPrefix = "read-"
 	txPrefix   = "tx-"
@@ -59,212 +53,21 @@ func NewHandler(w *ecs.World, opts ...Option) (*Handler, error) {
 		opt(th)
 	}
 
-	// make the transaction endpoints
-	txs, err := w.ListTransactions()
-	if err != nil {
-		return nil, err
+	// register tx endpoints
+	if err := registerTxHandlers(w, th); err != nil {
+		return nil, fmt.Errorf("failed to register tx handlers: %w", err)
 	}
-	txEndpoints := make([]string, 0, len(txs)*2)
-	for _, tx := range txs {
-		endpoint := conformPath(txPrefix + tx.Name())
-		schemaEndpoint := conformPath(schemaEndpointPrefix + txPrefix + tx.Name())
-		if tx.Name() == ecs.CreatePersonaTx.Name() {
-			// The CreatePersonaTx is different from normal transactions because it doesn't look up a signer
-			// address from the world to verify the transaction.
-			th.mux.HandleFunc(endpoint, th.makeCreatePersonaHandler(tx))
-		} else {
-			th.mux.HandleFunc(endpoint, th.makeTxHandler(tx))
-		}
-		th.mux.HandleFunc(schemaEndpoint, th.makeSchemaHandler(tx.Schema()))
-		txEndpoints = append(txEndpoints, endpoint, schemaEndpoint)
+
+	// register read endpoints
+	if err := registerReadHandlers(w, th); err != nil {
+		return nil, fmt.Errorf("failed to register read handlers: %w", err)
 	}
-	th.mux.HandleFunc(listTxEndpoint, func(writer http.ResponseWriter, request *http.Request) {
-		// marshall txEndpoints to JSON and write to writer
-		res, err := json.Marshal(txEndpoints)
-		if err != nil {
-			writeError(writer, "unable to marshal response", err)
-			return
-		}
 
-		writeResult(writer, res)
-	})
-
-	// make the read endpoints
-	reads := w.ListReads()
-	readEndpoints := make([]string, 0, len(reads)*2)
-	for _, r := range reads {
-		endpoint := conformPath(readPrefix + r.Name())
-		schemaEndpoint := conformPath(schemaEndpointPrefix + readPrefix + r.Name())
-		th.mux.HandleFunc(endpoint, th.makeReadHandler(r))
-		th.mux.HandleFunc(schemaEndpoint, th.makeSchemaHandler(r.Schema()))
-		readEndpoints = append(readEndpoints, endpoint, schemaEndpoint)
+	if err := registerReceiptEndpoints(w, th); err != nil {
+		return nil, fmt.Errorf("failed to register receipt handlers: %w", err)
 	}
-	readPersonaSignerEndpoint := conformPath(readPrefix + "persona-signer")
-	readPersonaSignerSchemaEndpoint := conformPath(schemaEndpointPrefix + readPrefix + "persona-signer")
-	th.mux.HandleFunc(readPersonaSignerEndpoint, th.handleReadPersonaSigner)
-	th.mux.HandleFunc(readPersonaSignerSchemaEndpoint, th.handleReadPersonaSignerSchema)
-	readEndpoints = append(readEndpoints, readPersonaSignerEndpoint, readPersonaSignerSchemaEndpoint)
-	th.mux.HandleFunc(listReadEndpoint, func(writer http.ResponseWriter, request *http.Request) {
-		res, err := json.Marshal(readEndpoints)
-		if err != nil {
-			writeError(writer, "unable to marshal response", err)
-			return
-		}
-
-		writeResult(writer, res)
-	})
 
 	return th, nil
-}
-
-func getSignerAddressFromPayload(sp sign.SignedPayload) (string, error) {
-	createPersonaTx, err := decode[ecs.CreatePersonaTransaction](sp.Body)
-	if err != nil {
-		return "", err
-	}
-	return createPersonaTx.SignerAddress, nil
-}
-
-func (t *Handler) verifySignature(request *http.Request, getSignedAddressFromWorld bool) (payload []byte, sig *sign.SignedPayload, err error) {
-	buf, err := io.ReadAll(request.Body)
-	if err != nil {
-		return nil, nil, errors.New("unable to read body")
-	}
-
-	sp, err := sign.UnmarshalSignedPayload(buf)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	if sp.PersonaTag == "" {
-		return nil, nil, errors.New("PersonaTag must not be empty")
-	}
-
-	// Handle the case where signature is disabled
-	if t.disableSigVerification {
-		return sp.Body, sp, nil
-	}
-	///////////////////////////////////////////////
-
-	// Check that the namespace is correct
-	if sp.Namespace != t.w.GetNamespace() {
-		return nil, nil, fmt.Errorf("%w: got namespace %q but it must be %q", ErrorInvalidSignature, sp.Namespace, t.w.GetNamespace())
-	}
-
-	var signerAddress string
-	if getSignedAddressFromWorld {
-		// Use 0 as the tick. We don't care about any pending CreatePersonaTxs, we just want to know the
-		// current signer address for the given persona. Any error will fail this request.
-		signerAddress, err = t.w.GetSignerForPersonaTag(sp.PersonaTag, 0)
-	} else {
-		signerAddress, err = getSignerAddressFromPayload(*sp)
-	}
-	if err != nil {
-		return nil, nil, err
-	}
-
-	// Check the nonce
-	nonce, err := t.w.GetNonce(signerAddress)
-	if err != nil {
-		return nil, nil, err
-	}
-	if sp.Nonce <= nonce {
-		return nil, nil, fmt.Errorf("%w: got nonce %d, but must be greater than %d",
-			ErrorInvalidSignature, sp.Nonce, nonce)
-	}
-
-	// Verify signature
-	if err := sp.Verify(signerAddress); err != nil {
-		return nil, nil, fmt.Errorf("%w: %w", ErrorInvalidSignature, err)
-	}
-	// Update nonce
-	if err := t.w.SetNonce(signerAddress, sp.Nonce); err != nil {
-		return nil, nil, err
-	}
-
-	if len(sp.Body) == 0 {
-		return buf, sp, nil
-	}
-	return sp.Body, sp, nil
-}
-
-func (t *Handler) makeTxHandler(tx transaction.ITransaction) http.HandlerFunc {
-	return func(writer http.ResponseWriter, request *http.Request) {
-		payload, sp, err := t.verifySignature(request, true)
-		if errors.Is(err, ErrorInvalidSignature) {
-			writeUnauthorized(writer, err)
-			return
-		} else if err != nil {
-			writeError(writer, "unable to verify signature", err)
-			return
-		}
-		txVal, err := tx.Decode(payload)
-		if err != nil {
-			writeError(writer, "unable to decode transaction", err)
-			return
-		}
-
-		submitTx := func() uint64 {
-			tick, _ := t.w.AddTransaction(tx.ID(), txVal, sp)
-
-			res, err := json.Marshal("ok")
-			if err != nil {
-				writeError(writer, "unable to marshal response", err)
-				return 0
-			}
-			writeResult(writer, res)
-			return uint64(tick)
-		}
-
-		// check if we have an adapter
-		if t.adapter != nil {
-			// if the world is recovering via adapter, we shouldn't accept transactions.
-			if t.w.IsRecovering() {
-				writeError(writer, "unable to submit transactions: game world is recovering state", nil)
-			} else {
-				tick := submitTx()
-				err = t.adapter.Submit(context.Background(), sp, uint64(tx.ID()), tick)
-				if err != nil {
-					writeError(writer, "error submitting transaction to blockchain", err)
-				}
-			}
-		} else {
-			// if there is no adapter, then we can just put the tx in the queue.
-			submitTx()
-		}
-	}
-}
-
-func (t *Handler) makeReadHandler(r ecs.IRead) http.HandlerFunc {
-	return func(writer http.ResponseWriter, request *http.Request) {
-		buf, err := io.ReadAll(request.Body)
-		if err != nil {
-			writeError(writer, "unable to read request body", err)
-			return
-		}
-		res, err := r.HandleReadRaw(t.w, buf)
-		if err != nil {
-			writeError(writer, "error handling read", err)
-			return
-		}
-		writeResult(writer, res)
-	}
-}
-
-func (t *Handler) makeSchemaHandler(inSchema, outSchema *jsonschema.Schema) http.HandlerFunc {
-	return func(writer http.ResponseWriter, request *http.Request) {
-		requestAndReply := map[string]*jsonschema.Schema{
-			"request": inSchema,
-			"reply":   outSchema,
-		}
-		res, err := json.Marshal(requestAndReply)
-		if err != nil {
-			writeError(writer, "unable to marshal response", err)
-			return
-		}
-
-		writeResult(writer, res)
-	}
 }
 
 // Serve sets up the endpoints passed in by the user, as well as a special "/list" endpoint, that informs consumers

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -436,7 +436,7 @@ func TestMalformedRequestToGetTransactionReceiptsProducesError(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 	assert.NilError(t, world.LoadGameState())
 	txh := makeTestTransactionHandler(t, world, DisableSignatureVerification())
-	res := txh.post(listTxReceipts, map[string]any{
+	res := txh.post(txReceiptsEndpoint, map[string]any{
 		"missing_start_tick": 0,
 	})
 	assert.Check(t, 400 <= res.StatusCode && res.StatusCode <= 499)
@@ -448,9 +448,9 @@ func TestTransactionReceiptReturnCorrectTickWindows(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 	txh := makeTestTransactionHandler(t, world, DisableSignatureVerification())
 
-	// getReceipts is a helper that hits the listTxReceipts endpoint.
+	// getReceipts is a helper that hits the txReceiptsEndpoint endpoint.
 	getReceipts := func(start uint64) ListTxReceiptsReply {
-		res := txh.post(listTxReceipts, ListTxReceiptsRequest{
+		res := txh.post(txReceiptsEndpoint, ListTxReceiptsRequest{
 			StartTick: start,
 		})
 		assert.Equal(t, 200, res.StatusCode)
@@ -573,7 +573,7 @@ func TestCanGetTransactionReceipts(t *testing.T) {
 
 	// We're going to be getting the list of receipts a lot, so make a helper to fetch the receipts
 	getReceipts := func(start uint64) ListTxReceiptsReply {
-		res := txh.post(listTxReceipts, ListTxReceiptsRequest{
+		res := txh.post(txReceiptsEndpoint, ListTxReceiptsRequest{
 			StartTick: start,
 		})
 		assert.Equal(t, 200, res.StatusCode)

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -4,18 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/argus-labs/world-engine/sign"
-	"gotest.tools/v3/assert"
-
 	"github.com/argus-labs/world-engine/cardinal/ecs"
 	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
+	"github.com/argus-labs/world-engine/sign"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
+	"gotest.tools/v3/assert"
 )
 
 type SendEnergyTx struct {
@@ -33,7 +32,16 @@ type testTransactionHandler struct {
 }
 
 func (t *testTransactionHandler) makeURL(path string) string {
-	return t.urlPrefix + path
+	return t.urlPrefix + "/" + path
+}
+
+func (t *testTransactionHandler) post(path string, payload any) *http.Response {
+	bz, err := json.Marshal(payload)
+	assert.NilError(t.t, err)
+
+	res, err := http.Post(t.makeURL(path), "application/json", bytes.NewReader(bz))
+	assert.NilError(t.t, err)
+	return res
 }
 
 func makeTestTransactionHandler(t *testing.T, world *ecs.World, opts ...Option) *testTransactionHandler {
@@ -69,9 +77,9 @@ func TestCanListTransactionEndpoints(t *testing.T) {
 
 	// Make sure the gotEndpoints contains alpha, beta and gamma. It's ok to have extra endpoints
 	foundEndpoints := map[string]bool{
-		"/tx-alpha": false,
-		"/tx-beta":  false,
-		"/tx-gamma": false,
+		"tx-alpha": false,
+		"tx-beta":  false,
+		"tx-gamma": false,
 	}
 
 	for _, e := range gotEndpoints {
@@ -129,7 +137,7 @@ func TestHandleTransactionWithNoSignatureVerification(t *testing.T) {
 
 	txh := makeTestTransactionHandler(t, w, DisableSignatureVerification())
 
-	resp, err := http.Post(txh.makeURL("/tx-"+endpoint), "application/json", bytes.NewReader(bogusSignatureBz))
+	resp, err := http.Post(txh.makeURL("tx-"+endpoint), "application/json", bytes.NewReader(bogusSignatureBz))
 	assert.NilError(t, err)
 	assert.Equal(t, 200, resp.StatusCode, "request failed with body: %v", mustReadBody(t, resp))
 
@@ -177,7 +185,7 @@ func TestHandleWrappedTransactionWithNoSignatureVerification(t *testing.T) {
 
 	bz, err = json.Marshal(&signedTx)
 	assert.NilError(t, err)
-	_, err = http.Post(txh.makeURL("/tx-"+endpoint), "application/json", bytes.NewReader(bz))
+	_, err = http.Post(txh.makeURL("tx-"+endpoint), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 
 	assert.NilError(t, w.LoadGameState())
@@ -210,7 +218,7 @@ func TestCanCreateAndVerifyPersonaSigner(t *testing.T) {
 	bz, err := signedPayload.Marshal()
 	assert.NilError(t, err)
 
-	resp, err := http.Post(txh.makeURL("/tx-create-persona"), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.makeURL("tx-create-persona"), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	body := mustReadBody(t, resp)
 	assert.Equal(t, 200, resp.StatusCode, "request failed with body: %s", body)
@@ -227,7 +235,7 @@ func TestCanCreateAndVerifyPersonaSigner(t *testing.T) {
 			Tick:       tick,
 		})
 		assert.NilError(t, err)
-		resp, err = http.Post(txh.makeURL("/"+readPrefix+"persona-signer"), "application/json", bytes.NewReader(bz))
+		resp, err = http.Post(txh.makeURL(readPrefix+"persona-signer"), "application/json", bytes.NewReader(bz))
 		assert.NilError(t, err)
 		assert.Equal(t, resp.StatusCode, 200)
 		var readPersonaSignerResponse ReadPersonaSignerResponse
@@ -272,7 +280,7 @@ func TestSigVerificationChecksNamespace(t *testing.T) {
 
 	bz, err := sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err := http.Post(txh.makeURL("/tx-create-persona"), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.makeURL("tx-create-persona"), "application/json", bytes.NewReader(bz))
 	// This should fail because the namespace does not match the world's namespace
 	assert.Equal(t, resp.StatusCode, 401)
 
@@ -281,7 +289,7 @@ func TestSigVerificationChecksNamespace(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err = http.Post(txh.makeURL("/tx-create-persona"), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.makeURL("tx-create-persona"), "application/json", bytes.NewReader(bz))
 	assert.Equal(t, resp.StatusCode, 200)
 }
 
@@ -307,11 +315,11 @@ func TestSigVerificationChecksNonce(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Register a persona. This should succeed
-	resp, err := http.Post(txh.makeURL("/tx-create-persona"), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.makeURL("tx-create-persona"), "application/json", bytes.NewReader(bz))
 	assert.Equal(t, resp.StatusCode, 200)
 
 	// Repeat the request. Since the nonce is the same, this should fail
-	resp, err = http.Post(txh.makeURL("/tx-create-persona"), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.makeURL("tx-create-persona"), "application/json", bytes.NewReader(bz))
 	assert.Equal(t, resp.StatusCode, 401)
 
 	// Using an old nonce should fail
@@ -319,7 +327,7 @@ func TestSigVerificationChecksNonce(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err = http.Post(txh.makeURL("/tx-create-persona"), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.makeURL("tx-create-persona"), "application/json", bytes.NewReader(bz))
 	assert.Equal(t, resp.StatusCode, 401)
 
 	// But increasing the nonce should work
@@ -327,7 +335,7 @@ func TestSigVerificationChecksNonce(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err = http.Post(txh.makeURL("/tx-create-persona"), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.makeURL("tx-create-persona"), "application/json", bytes.NewReader(bz))
 	assert.Equal(t, resp.StatusCode, 200)
 }
 
@@ -365,7 +373,15 @@ func TestCanListReads(t *testing.T) {
 	var gotEndpoints []string
 	assert.NilError(t, json.NewDecoder(resp.Body).Decode(&gotEndpoints))
 
-	endpoints := []string{"/read-foo", "/schema/read-foo", "/read-bar", "/schema/read-bar", "/read-baz", "/schema/read-baz", "/read-persona-signer", "/schema/read-persona-signer"}
+	endpoints := []string{"read-foo",
+		"schema/read-foo",
+		"read-bar",
+		"schema/read-bar",
+		"read-baz",
+		"schema/read-baz",
+		"read-persona-signer",
+		"schema/read-persona-signer",
+	}
 	for i, e := range gotEndpoints {
 		assert.Equal(t, e, endpoints[i])
 	}
@@ -403,7 +419,7 @@ func TestReadEncodeDecode(t *testing.T) {
 	bz, err := json.Marshal(req)
 	assert.NilError(t, err)
 
-	res, err := http.Post(txh.makeURL("/"+readPrefix+endpoint), "application/json", bytes.NewReader(bz))
+	res, err := http.Post(txh.makeURL(readPrefix+endpoint), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 
 	buf, err := io.ReadAll(res.Body)
@@ -414,4 +430,211 @@ func TestReadEncodeDecode(t *testing.T) {
 	assert.NilError(t, err)
 
 	assert.Equal(t, fooRes.Meow, req.Meow)
+}
+
+func TestMalformedRequestToGetTransactionReceiptsProducesError(t *testing.T) {
+	world := inmem.NewECSWorldForTest(t)
+	assert.NilError(t, world.LoadGameState())
+	txh := makeTestTransactionHandler(t, world, DisableSignatureVerification())
+	res := txh.post(listTxReceipts, map[string]any{
+		"missing_start_tick": 0,
+	})
+	assert.Check(t, 400 <= res.StatusCode && res.StatusCode <= 499)
+}
+
+func TestTransactionReceiptReturnCorrectTickWindows(t *testing.T) {
+	historySize := uint64(10)
+	world := inmem.NewECSWorldForTest(t, ecs.WithReceiptHistorySize(int(historySize)))
+	assert.NilError(t, world.LoadGameState())
+	txh := makeTestTransactionHandler(t, world, DisableSignatureVerification())
+
+	// getReceipts is a helper that hits the listTxReceipts endpoint.
+	getReceipts := func(start uint64) ListTxReceiptsReply {
+		res := txh.post(listTxReceipts, ListTxReceiptsRequest{
+			StartTick: start,
+		})
+		assert.Equal(t, 200, res.StatusCode)
+		var reply ListTxReceiptsReply
+		assert.NilError(t, json.NewDecoder(res.Body).Decode(&reply))
+		return reply
+	}
+	tick := world.CurrentTick()
+	// Attempting to get receipt data for the current tick should return no valid ticks as the
+	// transactions have not yet been processed.
+	reply := getReceipts(tick)
+	tickCount := reply.EndTick - reply.StartTick
+	assert.Equal(t, uint64(0), tickCount)
+
+	// Attempting to get ticks in the future should also produce no valid ticks.
+	reply = getReceipts(tick + 10000)
+	tickCount = reply.EndTick - reply.StartTick
+	assert.Equal(t, uint64(0), tickCount)
+
+	// Tick once
+	ctx := context.Background()
+	assert.NilError(t, world.Tick(ctx))
+
+	// The world ticked one time, so we should find 1 valid tick.
+	reply = getReceipts(tick)
+	tickCount = reply.EndTick - reply.StartTick
+	assert.Equal(t, uint64(1), tickCount)
+	assert.Equal(t, tick, reply.StartTick)
+
+	// tick a bunch so that the tick history becomes fully populated
+	jumpAhead := historySize * 2
+	for i := uint64(0); i < jumpAhead; i++ {
+		assert.NilError(t, world.Tick(ctx))
+	}
+
+	reply = getReceipts(tick)
+	// We should find at most historySize valid ticks
+	tickCount = reply.EndTick - reply.StartTick
+	// EndTick is not actually included in the results. e.g. if StartTick and EndTick are equal,
+	// tickCount will be 0, meaning no ticks are included in the results.
+	assert.Equal(t, historySize, tickCount-1)
+	// We jumped ahead quite a bit, so the returned StartTick should be ahead of the tick we asked for
+	wantStartTick := tick + jumpAhead - historySize
+	assert.Equal(t, wantStartTick, reply.StartTick)
+
+	// Another way to figure out what StartTick should be is to subtract historySize from the current tick.
+	// This is the oldest tick available to us.
+	wantStartTick = world.CurrentTick() - historySize - 1
+	assert.Equal(t, wantStartTick, reply.StartTick)
+
+	// assuming wantStartTick is the oldest tick we can ask for if we ask for 3 ticks after that we
+	// should get the remaining of historySize.
+	tick = wantStartTick + 3
+	reply = getReceipts(tick)
+	tickCount = reply.EndTick - reply.StartTick - 1
+	assert.Equal(t, historySize-3, tickCount)
+}
+
+func TestCanGetTransactionReceipts(t *testing.T) {
+	// IncRequest in a transaction that increments the given number by 1.
+	type IncRequest struct {
+		Number int
+	}
+	type IncReply struct {
+		Number int
+	}
+
+	// DupeRequest is a transaction that appends a copy of the given string to itself.
+	type DupeRequest struct {
+		Str string
+	}
+	type DupeReply struct {
+		Str string
+	}
+
+	// ErrRequest is a transaction that will produce an error
+	type ErrRequest struct{}
+	type ErrReply struct{}
+
+	incTx := ecs.NewTransactionType[IncRequest, IncReply]("increment")
+	dupeTx := ecs.NewTransactionType[DupeRequest, DupeReply]("duplicate")
+	errTx := ecs.NewTransactionType[ErrRequest, ErrReply]("error")
+
+	world := inmem.NewECSWorldForTest(t)
+	assert.NilError(t, world.RegisterTransactions(incTx, dupeTx, errTx))
+	// System to handle incrementing numbers
+	world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue) error {
+		for _, tx := range incTx.In(queue) {
+			incTx.SetResult(world, tx.ID, IncReply{
+				Number: tx.Value.Number + 1,
+			})
+		}
+		return nil
+	})
+	// System to handle duplicating strings
+	world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue) error {
+		for _, tx := range dupeTx.In(queue) {
+			dupeTx.SetResult(world, tx.ID, DupeReply{
+				Str: tx.Value.Str + tx.Value.Str,
+			})
+		}
+		return nil
+	})
+	wantError := errors.New("some error")
+	// System to handle error production
+	world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue) error {
+		for _, tx := range errTx.In(queue) {
+			errTx.AddError(world, tx.ID, wantError)
+			errTx.AddError(world, tx.ID, wantError)
+		}
+		return nil
+	})
+	assert.NilError(t, world.LoadGameState())
+
+	// World setup is done. First check that there are no transactions.
+	ctx := context.Background()
+	assert.NilError(t, world.Tick(ctx))
+
+	txh := makeTestTransactionHandler(t, world, DisableSignatureVerification())
+
+	// We're going to be getting the list of receipts a lot, so make a helper to fetch the receipts
+	getReceipts := func(start uint64) ListTxReceiptsReply {
+		res := txh.post(listTxReceipts, ListTxReceiptsRequest{
+			StartTick: start,
+		})
+		assert.Equal(t, 200, res.StatusCode)
+
+		var txReceipts ListTxReceiptsReply
+		assert.NilError(t, json.NewDecoder(res.Body).Decode(&txReceipts))
+		return txReceipts
+	}
+
+	txReceipts := getReceipts(0)
+	// Receipts should start out empty
+	assert.Equal(t, uint64(0), txReceipts.StartTick)
+	assert.Equal(t, 0, len(txReceipts.Receipts))
+
+	nonce := uint64(0)
+	nextSig := func() *sign.SignedPayload {
+		nonce++
+		return &sign.SignedPayload{
+			PersonaTag: "some-persona-tag",
+			Nonce:      nonce,
+		}
+	}
+
+	incTx.AddToQueue(world, IncRequest{99}, nextSig())
+	dupeTx.AddToQueue(world, DupeRequest{"foobar"}, nextSig())
+	errTx.AddToQueue(world, ErrRequest{}, nextSig())
+
+	assert.NilError(t, world.Tick(ctx))
+
+	txReceipts = getReceipts(0)
+	assert.Equal(t, uint64(0), txReceipts.StartTick)
+	assert.Equal(t, uint64(2), txReceipts.EndTick)
+	assert.Equal(t, 3, len(txReceipts.Receipts))
+
+	foundInc, foundDupe, foundErr := false, false, false
+	for _, r := range txReceipts.Receipts {
+		if len(r.Errs) > 0 {
+			foundErr = true
+			assert.Equal(t, 2, len(r.Errs))
+			assert.Equal(t, wantError.Error(), r.Errs[0])
+			assert.Equal(t, wantError.Error(), r.Errs[1])
+			continue
+		}
+		m, ok := r.Result.(map[string]any)
+		assert.Check(t, ok)
+		if _, ok := m["Number"]; ok {
+			foundInc = true
+			num, ok := m["Number"].(float64)
+			assert.Check(t, ok)
+			assert.Equal(t, 100, int(num))
+		} else if _, ok := m["Str"]; ok {
+			foundDupe = true
+			str, ok := m["Str"].(string)
+			assert.Check(t, ok)
+			assert.Equal(t, "foobarfoobar", str)
+		} else {
+			assert.Assert(t, false, "unknown transaction result", r.Result)
+		}
+	}
+
+	assert.Check(t, foundInc)
+	assert.Check(t, foundDupe)
+	assert.Check(t, foundErr)
 }

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -610,11 +610,11 @@ func TestCanGetTransactionReceipts(t *testing.T) {
 
 	foundInc, foundDupe, foundErr := false, false, false
 	for _, r := range txReceipts.Receipts {
-		if len(r.Errs) > 0 {
+		if len(r.Errors) > 0 {
 			foundErr = true
-			assert.Equal(t, 2, len(r.Errs))
-			assert.Equal(t, wantError.Error(), r.Errs[0])
-			assert.Equal(t, wantError.Error(), r.Errs[1])
+			assert.Equal(t, 2, len(r.Errors))
+			assert.Equal(t, wantError.Error(), r.Errors[0])
+			assert.Equal(t, wantError.Error(), r.Errors[1])
 			continue
 		}
 		m, ok := r.Result.(map[string]any)

--- a/cardinal/server/utils.go
+++ b/cardinal/server/utils.go
@@ -3,9 +3,14 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/rs/zerolog/log"
+	"io"
 	"net/http"
+
+	"github.com/argus-labs/world-engine/cardinal/ecs"
+	"github.com/argus-labs/world-engine/sign"
+	"github.com/rs/zerolog/log"
 )
 
 // fixes a path to contain a leading slash.
@@ -18,13 +23,19 @@ func conformPath(p string) string {
 }
 
 func writeUnauthorized(w http.ResponseWriter, err error) {
-	w.WriteHeader(401)
+	w.WriteHeader(http.StatusUnauthorized)
 	_, _ = fmt.Fprintf(w, "unauthorized: %v", err)
 	log.Info().Msgf("unauthorized: %v", err)
 }
 
 func writeError(w http.ResponseWriter, msg string, err error) {
-	w.WriteHeader(500)
+	w.WriteHeader(http.StatusInternalServerError)
+	_, _ = fmt.Fprintf(w, "%s: %v", msg, err)
+	log.Info().Msgf("%s: %v", msg, err)
+}
+
+func writeBadRequest(w http.ResponseWriter, msg string, err error) {
+	w.WriteHeader(http.StatusBadRequest)
 	_, _ = fmt.Fprintf(w, "%s: %v", msg, err)
 	log.Info().Msgf("%s: %v", msg, err)
 }
@@ -53,4 +64,85 @@ func decode[T any](buf []byte) (T, error) {
 		return val, err
 	}
 	return val, nil
+}
+
+func makeWriteHandler(payload interface{}) (http.HandlerFunc, error) {
+	res, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("unable to marshal payload: %w", err)
+	}
+	return func(writer http.ResponseWriter, request *http.Request) {
+		writeResult(writer, res)
+	}, nil
+}
+
+func getSignerAddressFromPayload(sp sign.SignedPayload) (string, error) {
+	createPersonaTx, err := decode[ecs.CreatePersonaTransaction](sp.Body)
+	if err != nil {
+		return "", err
+	}
+	return createPersonaTx.SignerAddress, nil
+}
+
+func (t *Handler) verifySignature(request *http.Request, getSignedAddressFromWorld bool) (payload []byte, sig *sign.SignedPayload, err error) {
+	buf, err := io.ReadAll(request.Body)
+	if err != nil {
+		return nil, nil, errors.New("unable to read body")
+	}
+
+	sp, err := sign.UnmarshalSignedPayload(buf)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if sp.PersonaTag == "" {
+		return nil, nil, errors.New("PersonaTag must not be empty")
+	}
+
+	// Handle the case where signature is disabled
+	if t.disableSigVerification {
+		return sp.Body, sp, nil
+	}
+	///////////////////////////////////////////////
+
+	// Check that the namespace is correct
+	if sp.Namespace != t.w.GetNamespace() {
+		return nil, nil, fmt.Errorf("%w: got namespace %q but it must be %q", ErrorInvalidSignature, sp.Namespace, t.w.GetNamespace())
+	}
+
+	var signerAddress string
+	if getSignedAddressFromWorld {
+		// Use 0 as the tick. We don't care about any pending CreatePersonaTxs, we just want to know the
+		// current signer address for the given persona. Any error will fail this request.
+		signerAddress, err = t.w.GetSignerForPersonaTag(sp.PersonaTag, 0)
+	} else {
+		signerAddress, err = getSignerAddressFromPayload(*sp)
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	// Check the nonce
+	nonce, err := t.w.GetNonce(signerAddress)
+	if err != nil {
+		return nil, nil, err
+	}
+	if sp.Nonce <= nonce {
+		return nil, nil, fmt.Errorf("%w: got nonce %d, but must be greater than %d",
+			ErrorInvalidSignature, sp.Nonce, nonce)
+	}
+
+	// Verify signature
+	if err := sp.Verify(signerAddress); err != nil {
+		return nil, nil, fmt.Errorf("%w: %w", ErrorInvalidSignature, err)
+	}
+	// Update nonce
+	if err := t.w.SetNonce(signerAddress, sp.Nonce); err != nil {
+		return nil, nil, err
+	}
+
+	if len(sp.Body) == 0 {
+		return buf, sp, nil
+	}
+	return sp.Body, sp, nil
 }


### PR DESCRIPTION
…om cardinal; remove leading slahes from cardinal http endpoints

Closes: #CAR-135, #CAR-130

## What is the purpose of the change

- Add an HTTP endpoint that will return a list of transactions that have been processed over a range of ticks. 
- Update the HTTP endpoints to NOT have a leading slash.
- Code refactor: read and tx handler definitions have been moved to the handler.go file. 
- Some functions have been moved to the util.go file.
- NOTE: handler.go's code has mainly been moved from server.go
- NOTE: receipt.go's code is new

## Testing and Verifying

- Unit tests added to verify ranges of ticks are returned correctly
- Uint tests added to verify transaction errors and results are returned from the receipt endpoint
- Calling http://localhost:3333/list/tx-endpoints should now list tx endpoints without leading slash
- Calling http://localhost:3333/list/read-endpoints should now list read endpoints without leading slash
