### PR TITLE
feat(cardinal): AddSystems function

### DIFF
--- a/cardinal/ecs/tests/world_test.go
+++ b/cardinal/ecs/tests/world_test.go
@@ -1,0 +1,27 @@
+package tests
+
+import (
+	"context"
+	"github.com/argus-labs/world-engine/cardinal/ecs"
+	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
+	"gotest.tools/v3/assert"
+	"testing"
+)
+
+func TestAddSystems(t *testing.T) {
+	count := 0
+	sys := func(w *ecs.World, txq *ecs.TransactionQueue) error {
+		count++
+		return nil
+	}
+
+	w := inmem.NewECSWorldForTest(t)
+	w.AddSystems(sys, sys, sys)
+	err := w.LoadGameState()
+	assert.NilError(t, err)
+
+	err = w.Tick(context.Background())
+	assert.NilError(t, err)
+
+	assert.Equal(t, count, 3)
+}

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -102,10 +102,14 @@ func (w *World) Archetype(archID storage.ArchetypeID) storage.ArchetypeStorage {
 }
 
 func (w *World) AddSystem(s System) {
+	w.AddSystems(s)
+}
+
+func (w *World) AddSystems(s ...System) {
 	if w.stateIsLoaded {
 		panic("cannot register systems after loading game state")
 	}
-	w.systems = append(w.systems, s)
+	w.systems = append(w.systems, s...)
 }
 
 // RegisterComponents attempts to initialize the given slice of components with a WorldAccessor.


### PR DESCRIPTION
## What is the purpose of the change

we have variadic functions for all our other register type methods, so adding one for systems.

## Brief Changelog

- adds variadic AddSystems function
- changes the original AddSystem function to just call into AddSystems.

## Testing and Verifying
`cardinal/ecs/tests/world_test.go`