### PR TITLE
refactor(cardinal): change struct tag to evm to be more general

### DIFF
--- a/cardinal/ecs/abi_test.go
+++ b/cardinal/ecs/abi_test.go
@@ -47,8 +47,8 @@ func TestGenerateABIType_AllValidTypes(t *testing.T) {
 
 		Bytes []byte
 
-		BigInt      *big.Int   `solidity:"uint256"`
-		SliceBigInt []*big.Int `solidity:"int256"`
+		BigInt      *big.Int   `evm:"uint256"`
+		SliceBigInt []*big.Int `evm:"int256"`
 	}
 	at, err := GenerateABIType(BigType{})
 	assert.Nil(t, err)


### PR DESCRIPTION
## What is the purpose of the change

previously the struct tag for *big.Int was `solidity`, but the issue isn't specific to solidity. this changes the tag to `evm` to be more general.

## Brief Changelog

- change struct tag from `solidity` to `evm`

## Testing and Verifying

`cardinal/ecs/abi_test.go`
