### PR TITLE
refactor(all)!: vanity package names for cardinal, chain, contracts, & sign (CLOSES: BASE-92 & CAR-146)

### DIFF
--- a/cardinal/ecs/component.go
+++ b/cardinal/ecs/component.go
@@ -5,9 +5,9 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 // IComponentType is an interface for component types.

--- a/cardinal/ecs/filter/and.go
+++ b/cardinal/ecs/filter/and.go
@@ -1,7 +1,7 @@
 package filter
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 type and struct {

--- a/cardinal/ecs/filter/contains.go
+++ b/cardinal/ecs/filter/contains.go
@@ -1,7 +1,7 @@
 package filter
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 type contains struct {

--- a/cardinal/ecs/filter/exact.go
+++ b/cardinal/ecs/filter/exact.go
@@ -1,7 +1,7 @@
 package filter
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 type exact struct {

--- a/cardinal/ecs/filter/filter.go
+++ b/cardinal/ecs/filter/filter.go
@@ -1,7 +1,7 @@
 package filter
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 // LayoutFilter is a filter that filters entities based on their components.

--- a/cardinal/ecs/filter/helper.go
+++ b/cardinal/ecs/filter/helper.go
@@ -1,7 +1,7 @@
 package filter
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 func containsComponent(components []component.IComponentType, c component.IComponentType) bool {

--- a/cardinal/ecs/filter/not.go
+++ b/cardinal/ecs/filter/not.go
@@ -1,7 +1,7 @@
 package filter
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 type not struct {

--- a/cardinal/ecs/filter/or.go
+++ b/cardinal/ecs/filter/or.go
@@ -1,7 +1,7 @@
 package filter
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 type or struct {

--- a/cardinal/ecs/inmem/inmem.go
+++ b/cardinal/ecs/inmem/inmem.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 // NewECSWorld creates an ecs.World that uses an in-memory redis DB as the storage

--- a/cardinal/ecs/options.go
+++ b/cardinal/ecs/options.go
@@ -1,8 +1,8 @@
 package ecs
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/receipt"
-	"github.com/argus-labs/world-engine/cardinal/shard"
+	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
+	"pkg.world.dev/world-engine/cardinal/shard"
 )
 
 type Option func(w *World)

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -3,8 +3,8 @@ package ecs
 import (
 	"errors"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 // CreatePersonaTransaction allows for the associating of a persona tag with a signer address.

--- a/cardinal/ecs/query.go
+++ b/cardinal/ecs/query.go
@@ -1,8 +1,8 @@
 package ecs
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 type cache struct {

--- a/cardinal/ecs/receipt/receipt.go
+++ b/cardinal/ecs/receipt/receipt.go
@@ -7,7 +7,7 @@ import (
 	"errors"
 	"sync/atomic"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
 var (

--- a/cardinal/ecs/receipt/receipt_test.go
+++ b/cardinal/ecs/receipt/receipt_test.go
@@ -4,8 +4,8 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
 func txID(name string, index uint64) transaction.TxID {

--- a/cardinal/ecs/storage/archetype.go
+++ b/cardinal/ecs/storage/archetype.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 type ArchetypeID int

--- a/cardinal/ecs/storage/components.go
+++ b/cardinal/ecs/storage/components.go
@@ -1,7 +1,7 @@
 package storage
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 // ComponentIndex represents the Index of component in an archetype.

--- a/cardinal/ecs/storage/engine.go
+++ b/cardinal/ecs/storage/engine.go
@@ -1,9 +1,9 @@
 package storage
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
 type ComponentStorage interface {

--- a/cardinal/ecs/storage/entity.go
+++ b/cardinal/ecs/storage/entity.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"math"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 type WorldAccessor interface {

--- a/cardinal/ecs/storage/keys.go
+++ b/cardinal/ecs/storage/keys.go
@@ -3,7 +3,7 @@ package storage
 import (
 	"fmt"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 /*

--- a/cardinal/ecs/storage/layout.go
+++ b/cardinal/ecs/storage/layout.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 // Layout represents a ArchLayout of components.

--- a/cardinal/ecs/storage/legacy_storage.go
+++ b/cardinal/ecs/storage/legacy_storage.go
@@ -3,8 +3,8 @@ package storage
 import (
 	"fmt"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 )
 
 var _ ComponentStorageManager = &ComponentsSliceStorage{}

--- a/cardinal/ecs/storage/mock.go
+++ b/cardinal/ecs/storage/mock.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"unsafe"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 var (

--- a/cardinal/ecs/storage/redis_storage.go
+++ b/cardinal/ecs/storage/redis_storage.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
 	"github.com/argus-labs/world-engine/sign"
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
 // Archetypes can just be stored in program memory. It just a structure that allows us to quickly

--- a/cardinal/ecs/storage/redis_storage.go
+++ b/cardinal/ecs/storage/redis_storage.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"strings"
 
-	"github.com/argus-labs/world-engine/sign"
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
+	"pkg.world.dev/world-engine/sign"
 )
 
 // Archetypes can just be stored in program memory. It just a structure that allows us to quickly

--- a/cardinal/ecs/tests/archetype_test.go
+++ b/cardinal/ecs/tests/archetype_test.go
@@ -1,10 +1,10 @@
 package tests
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"testing"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 type (

--- a/cardinal/ecs/tests/chain_recover_test.go
+++ b/cardinal/ecs/tests/chain_recover_test.go
@@ -7,9 +7,9 @@ import (
 	"testing"
 
 	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"
-	"github.com/argus-labs/world-engine/sign"
 	"github.com/cometbft/cometbft/libs/rand"
 	"google.golang.org/protobuf/proto"
+	"pkg.world.dev/world-engine/sign"
 
 	"gotest.tools/v3/assert"
 

--- a/cardinal/ecs/tests/chain_recover_test.go
+++ b/cardinal/ecs/tests/chain_recover_test.go
@@ -13,10 +13,10 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/argus-labs/world-engine/chain/x/shard/types"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
 	"pkg.world.dev/world-engine/cardinal/shard"
+	"pkg.world.dev/world-engine/chain/x/shard/types"
 )
 
 var _ shard.Adapter = &DummyAdapter{}

--- a/cardinal/ecs/tests/chain_recover_test.go
+++ b/cardinal/ecs/tests/chain_recover_test.go
@@ -13,10 +13,10 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
-	"github.com/argus-labs/world-engine/cardinal/shard"
 	"github.com/argus-labs/world-engine/chain/x/shard/types"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
+	"pkg.world.dev/world-engine/cardinal/shard"
 )
 
 var _ shard.Adapter = &DummyAdapter{}

--- a/cardinal/ecs/tests/components_test.go
+++ b/cardinal/ecs/tests/components_test.go
@@ -3,11 +3,11 @@ package tests
 import (
 	"testing"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
-	storage2 "github.com/argus-labs/world-engine/cardinal/ecs/storage"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
+	storage2 "pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 func TestComponents(t *testing.T) {

--- a/cardinal/ecs/tests/ecs_test.go
+++ b/cardinal/ecs/tests/ecs_test.go
@@ -7,10 +7,10 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 type EnergyComponent struct {

--- a/cardinal/ecs/tests/filter_test.go
+++ b/cardinal/ecs/tests/filter_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 func TestCanFilterByArchetype(t *testing.T) {

--- a/cardinal/ecs/tests/helpers.go
+++ b/cardinal/ecs/tests/helpers.go
@@ -6,10 +6,10 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
 	"github.com/redis/go-redis/v9"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 const WorldId string = "1"

--- a/cardinal/ecs/tests/index_test.go
+++ b/cardinal/ecs/tests/index_test.go
@@ -1,11 +1,11 @@
 package tests
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"testing"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 )
 
 func TestIndex(t *testing.T) {

--- a/cardinal/ecs/tests/layout_test.go
+++ b/cardinal/ecs/tests/layout_test.go
@@ -1,10 +1,10 @@
 package tests
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"testing"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 func TestLayout(t *testing.T) {

--- a/cardinal/ecs/tests/legacy_storage_test.go
+++ b/cardinal/ecs/tests/legacy_storage_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 func TestStorage_Bytes(t *testing.T) {

--- a/cardinal/ecs/tests/persona_test.go
+++ b/cardinal/ecs/tests/persona_test.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 func TestCreatePersonaTransactionAutomaticallyCreated(t *testing.T) {

--- a/cardinal/ecs/tests/query_test.go
+++ b/cardinal/ecs/tests/query_test.go
@@ -1,11 +1,11 @@
 package tests
 
 import (
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"testing"
 )
 

--- a/cardinal/ecs/tests/read_test.go
+++ b/cardinal/ecs/tests/read_test.go
@@ -5,10 +5,10 @@ import (
 	"testing"
 
 	routerv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/router/v1"
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
-	"github.com/argus-labs/world-engine/cardinal/evm"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
+	"pkg.world.dev/world-engine/cardinal/evm"
 )
 
 func TestReadEVM(t *testing.T) {

--- a/cardinal/ecs/tests/redis_test.go
+++ b/cardinal/ecs/tests/redis_test.go
@@ -7,11 +7,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/argus-labs/world-engine/sign"
 	"github.com/ethereum/go-ethereum/crypto"
 	"gotest.tools/v3/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
+	"pkg.world.dev/world-engine/sign"
 
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 

--- a/cardinal/ecs/tests/redis_test.go
+++ b/cardinal/ecs/tests/redis_test.go
@@ -7,15 +7,15 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
 	"github.com/argus-labs/world-engine/sign"
 	"github.com/ethereum/go-ethereum/crypto"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 var _ encoding.BinaryMarshaler = Foo{}

--- a/cardinal/ecs/tests/state_test.go
+++ b/cardinal/ecs/tests/state_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"gotest.tools/v3/assert"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 // comps reduces the typing needed to create a slice of IComponentTypes

--- a/cardinal/ecs/tests/tick_test.go
+++ b/cardinal/ecs/tests/tick_test.go
@@ -8,9 +8,9 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"gotest.tools/v3/assert"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 func TestTickHappyPath(t *testing.T) {

--- a/cardinal/ecs/tests/transaction_test.go
+++ b/cardinal/ecs/tests/transaction_test.go
@@ -3,14 +3,14 @@ package tests
 import (
 	"context"
 	"errors"
-	"github.com/argus-labs/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs"
 	"testing"
 	"time"
 
 	"gotest.tools/v3/assert"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 type ScoreComponent struct {

--- a/cardinal/ecs/tests/world_test.go
+++ b/cardinal/ecs/tests/world_test.go
@@ -2,9 +2,9 @@ package tests
 
 import (
 	"context"
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
 	"testing"
 )
 

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
 	"github.com/argus-labs/world-engine/sign"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/invopop/jsonschema"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
 var (

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/argus-labs/world-engine/sign"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/invopop/jsonschema"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
+	"pkg.world.dev/world-engine/sign"
 )
 
 var (

--- a/cardinal/ecs/transaction/transaction.go
+++ b/cardinal/ecs/transaction/transaction.go
@@ -1,8 +1,8 @@
 package transaction
 
 import (
-	"github.com/argus-labs/world-engine/sign"
 	"github.com/invopop/jsonschema"
+	"pkg.world.dev/world-engine/sign"
 )
 
 type TxMap map[TypeID][]TxAny

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -11,9 +11,9 @@ import (
 	"google.golang.org/protobuf/proto"
 	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
 
-	"github.com/argus-labs/world-engine/sign"
 	"github.com/rs/zerolog/log"
 	"pkg.world.dev/world-engine/chain/x/shard/types"
+	"pkg.world.dev/world-engine/sign"
 
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -11,9 +11,9 @@ import (
 	"google.golang.org/protobuf/proto"
 	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
 
-	"github.com/argus-labs/world-engine/chain/x/shard/types"
 	"github.com/argus-labs/world-engine/sign"
 	"github.com/rs/zerolog/log"
+	"pkg.world.dev/world-engine/chain/x/shard/types"
 
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -8,18 +8,18 @@ import (
 	"time"
 
 	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"
-	"github.com/argus-labs/world-engine/cardinal/ecs/receipt"
 	"google.golang.org/protobuf/proto"
+	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
 
 	"github.com/argus-labs/world-engine/chain/x/shard/types"
 	"github.com/argus-labs/world-engine/sign"
 	"github.com/rs/zerolog/log"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/component"
-	"github.com/argus-labs/world-engine/cardinal/ecs/filter"
-	"github.com/argus-labs/world-engine/cardinal/ecs/storage"
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
-	"github.com/argus-labs/world-engine/cardinal/shard"
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
+	"pkg.world.dev/world-engine/cardinal/shard"
 )
 
 // WorldId is a unique identifier for a world.

--- a/cardinal/evm/server.go
+++ b/cardinal/evm/server.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"sync/atomic"
 
-	"github.com/argus-labs/world-engine/sign"
 	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/sign"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"

--- a/cardinal/evm/server.go
+++ b/cardinal/evm/server.go
@@ -8,12 +8,12 @@ import (
 	"os"
 	"sync/atomic"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
 	"github.com/argus-labs/world-engine/sign"
+	"pkg.world.dev/world-engine/cardinal/ecs"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 
 	"buf.build/gen/go/argus-labs/world-engine/grpc/go/router/v1/routerv1grpc"
 	"buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/router/v1"

--- a/cardinal/evm/server_test.go
+++ b/cardinal/evm/server_test.go
@@ -5,9 +5,9 @@ import (
 	"testing"
 
 	routerv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/router/v1"
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
 )
 
 type FooTransaction struct {

--- a/cardinal/go.mod
+++ b/cardinal/go.mod
@@ -5,6 +5,7 @@ go 1.20
 // external, necessary replacements
 replace (
 	pkg.world.dev/world-engine/chain => ../chain
+	pkg.world.dev/world-engine/sign => ../sign
 	github.com/cosmos/cosmos-sdk => github.com/rollkit/cosmos-sdk v0.46.0-beta2.0.20230721012257-443317a43b03
 	// We replace `go-ethereum` with `polaris-geth` in order include our required changes.
 	github.com/ethereum/go-ethereum => github.com/berachain/polaris-geth v0.0.0-20230629154458-90866dc0cf0a
@@ -18,7 +19,7 @@ require (
 	buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go v1.31.0-20230808004839-11a21a99bf62.1
 	github.com/alicebob/miniredis/v2 v2.30.2
 	pkg.world.dev/world-engine/chain v0.1.1-alpha
-	github.com/argus-labs/world-engine/sign v0.1.3-alpha
+	pkg.world.dev/world-engine/sign v0.1.3-alpha
 	github.com/cometbft/cometbft v0.38.0-rc3
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/invopop/jsonschema v0.7.0

--- a/cardinal/go.mod
+++ b/cardinal/go.mod
@@ -1,4 +1,4 @@
-module github.com/argus-labs/world-engine/cardinal
+module pkg.world.dev/world-engine/cardinal
 
 go 1.20
 

--- a/cardinal/go.mod
+++ b/cardinal/go.mod
@@ -4,7 +4,7 @@ go 1.20
 
 // external, necessary replacements
 replace (
-	github.com/argus-labs/world-engine/chain => ../chain
+	pkg.world.dev/world-engine/chain => ../chain
 	github.com/cosmos/cosmos-sdk => github.com/rollkit/cosmos-sdk v0.46.0-beta2.0.20230721012257-443317a43b03
 	// We replace `go-ethereum` with `polaris-geth` in order include our required changes.
 	github.com/ethereum/go-ethereum => github.com/berachain/polaris-geth v0.0.0-20230629154458-90866dc0cf0a
@@ -17,7 +17,7 @@ require (
 	buf.build/gen/go/argus-labs/world-engine/grpc/go v1.3.0-20230808004839-11a21a99bf62.1
 	buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go v1.31.0-20230808004839-11a21a99bf62.1
 	github.com/alicebob/miniredis/v2 v2.30.2
-	github.com/argus-labs/world-engine/chain v0.1.1-alpha
+	pkg.world.dev/world-engine/chain v0.1.1-alpha
 	github.com/argus-labs/world-engine/sign v0.1.3-alpha
 	github.com/cometbft/cometbft v0.38.0-rc3
 	github.com/ethereum/go-ethereum v1.12.0

--- a/cardinal/go.sum
+++ b/cardinal/go.sum
@@ -429,8 +429,8 @@ github.com/alicebob/gopher-json v0.0.0-20200520072559-a9ecdc9d1d3a/go.mod h1:SGn
 github.com/alicebob/miniredis/v2 v2.30.2 h1:lc1UAUT9ZA7h4srlfBmBt2aorm5Yftk9nBjxz7EyY9I=
 github.com/alicebob/miniredis/v2 v2.30.2/go.mod h1:b25qWj4fCEsBeAAR2mlb0ufImGC6uH3VlUfb/HS5zKg=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
-github.com/argus-labs/world-engine/sign v0.1.3-alpha h1:1Iaz4NudbV5p+FZ3i/c0iHJbXoEUWzhA8D0aR7GX5Q4=
-github.com/argus-labs/world-engine/sign v0.1.3-alpha/go.mod h1:PWuRoQA8n221n1ta8IuV8juhGT/AIcGFYqdK8a3SC58=
+pkg.world.dev/world-engine/sign v0.1.3-alpha h1:1Iaz4NudbV5p+FZ3i/c0iHJbXoEUWzhA8D0aR7GX5Q4=
+pkg.world.dev/world-engine/sign v0.1.3-alpha/go.mod h1:PWuRoQA8n221n1ta8IuV8juhGT/AIcGFYqdK8a3SC58=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=

--- a/cardinal/server/handler.go
+++ b/cardinal/server/handler.go
@@ -7,9 +7,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
 	"github.com/invopop/jsonschema"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
 func registerReadHandlers(w *ecs.World, th *Handler) error {

--- a/cardinal/server/option.go
+++ b/cardinal/server/option.go
@@ -1,6 +1,6 @@
 package server
 
-import "github.com/argus-labs/world-engine/cardinal/shard"
+import "pkg.world.dev/world-engine/cardinal/shard"
 
 type Option func(th *Handler)
 

--- a/cardinal/server/persona.go
+++ b/cardinal/server/persona.go
@@ -3,11 +3,11 @@ package server
 import (
 	"encoding/json"
 	"errors"
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
 	"github.com/invopop/jsonschema"
 	"io"
 	"net/http"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
 // CreatePersonaResponse is returned from a tx-create-persona request. It contains the current tick of the game

--- a/cardinal/server/receipt.go
+++ b/cardinal/server/receipt.go
@@ -5,8 +5,8 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/transaction"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
 type ListTxReceiptsRequest struct {

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -6,8 +6,8 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/shard"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/shard"
 )
 
 // Handler is a type that contains endpoints for transactions and queries in a given ecs world.

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -9,12 +9,12 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/argus-labs/world-engine/sign"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"gotest.tools/v3/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
+	"pkg.world.dev/world-engine/sign"
 )
 
 type SendEnergyTx struct {

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -9,12 +9,12 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
-	"github.com/argus-labs/world-engine/cardinal/ecs/inmem"
 	"github.com/argus-labs/world-engine/sign"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
 )
 
 type SendEnergyTx struct {

--- a/cardinal/server/utils.go
+++ b/cardinal/server/utils.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/argus-labs/world-engine/sign"
 	"github.com/rs/zerolog/log"
 	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/sign"
 )
 
 // fixes a path to contain a leading slash.

--- a/cardinal/server/utils.go
+++ b/cardinal/server/utils.go
@@ -8,9 +8,9 @@ import (
 	"io"
 	"net/http"
 
-	"github.com/argus-labs/world-engine/cardinal/ecs"
 	"github.com/argus-labs/world-engine/sign"
 	"github.com/rs/zerolog/log"
+	"pkg.world.dev/world-engine/cardinal/ecs"
 )
 
 // fixes a path to contain a leading slash.

--- a/cardinal/shard/adapter.go
+++ b/cardinal/shard/adapter.go
@@ -5,9 +5,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"fmt"
-	"github.com/argus-labs/world-engine/sign"
 	"google.golang.org/grpc/credentials"
 	"os"
+	"pkg.world.dev/world-engine/sign"
 
 	shardgrpc "buf.build/gen/go/argus-labs/world-engine/grpc/go/shard/v1/shardv1grpc"
 	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"

--- a/cardinal/shard/adapter.go
+++ b/cardinal/shard/adapter.go
@@ -13,7 +13,7 @@ import (
 	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"
 	"google.golang.org/grpc"
 
-	shardtypes "github.com/argus-labs/world-engine/chain/x/shard/types"
+	shardtypes "pkg.world.dev/world-engine/chain/x/shard/types"
 )
 
 // Adapter is a type that helps facilitate communication with the EVM base shard.

--- a/chain/app/app.go
+++ b/chain/app/app.go
@@ -26,8 +26,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/argus-labs/world-engine/chain/shard"
 	dbm "github.com/cosmos/cosmos-db"
+	"pkg.world.dev/world-engine/chain/shard"
 
 	"cosmossdk.io/depinject"
 	"cosmossdk.io/log"
@@ -70,9 +70,9 @@ import (
 	evmkeeper "pkg.berachain.dev/polaris/cosmos/x/evm/keeper"
 	evmmempool "pkg.berachain.dev/polaris/cosmos/x/evm/plugins/txpool/mempool"
 
-	"github.com/argus-labs/world-engine/chain/router"
-	routerkeeper "github.com/argus-labs/world-engine/chain/x/router/keeper"
-	shardkeeper "github.com/argus-labs/world-engine/chain/x/shard/keeper"
+	"pkg.world.dev/world-engine/chain/router"
+	routerkeeper "pkg.world.dev/world-engine/chain/x/router/keeper"
+	shardkeeper "pkg.world.dev/world-engine/chain/x/shard/keeper"
 )
 
 // DefaultNodeHome default home directories for the application daemon.

--- a/chain/app/config.go
+++ b/chain/app/config.go
@@ -43,9 +43,9 @@ import (
 	"cosmossdk.io/depinject"
 	evidencetypes "cosmossdk.io/x/evidence/types"
 	upgradetypes "cosmossdk.io/x/upgrade/types"
-	shardmodulev1 "github.com/argus-labs/world-engine/chain/api/shard/module/v1"
-	"github.com/argus-labs/world-engine/chain/shard"
-	shardmodule "github.com/argus-labs/world-engine/chain/x/shard"
+	shardmodulev1 "pkg.world.dev/world-engine/chain/api/shard/module/v1"
+	"pkg.world.dev/world-engine/chain/shard"
+	shardmodule "pkg.world.dev/world-engine/chain/x/shard"
 
 	"github.com/cosmos/cosmos-sdk/runtime"
 	"github.com/cosmos/cosmos-sdk/types/module"
@@ -88,8 +88,8 @@ import (
 	_ "pkg.berachain.dev/polaris/cosmos/x/erc20"      // import for side-effects
 	_ "pkg.berachain.dev/polaris/cosmos/x/evm"        // import for side-effects
 
-	routermodule "github.com/argus-labs/world-engine/chain/api/router/module/v1"
-	"github.com/argus-labs/world-engine/chain/x/router"
+	routermodule "pkg.world.dev/world-engine/chain/api/router/module/v1"
+	"pkg.world.dev/world-engine/chain/x/router"
 )
 
 var (

--- a/chain/app/plugins.go
+++ b/chain/app/plugins.go
@@ -1,9 +1,9 @@
 package app
 
 import (
-	"github.com/argus-labs/world-engine/chain/router"
-	"github.com/argus-labs/world-engine/chain/shard"
 	"os"
+	"pkg.world.dev/world-engine/chain/router"
+	"pkg.world.dev/world-engine/chain/shard"
 )
 
 func (app *App) setPlugins() {

--- a/chain/app/precompiles.go
+++ b/chain/app/precompiles.go
@@ -34,7 +34,7 @@ import (
 	stakingprecompile "pkg.berachain.dev/polaris/cosmos/precompile/staking"
 	ethprecompile "pkg.berachain.dev/polaris/eth/core/precompile"
 
-	"github.com/argus-labs/world-engine/chain/precompile/router"
+	"pkg.world.dev/world-engine/chain/precompile/router"
 )
 
 // PrecompilesToInject returns a function that provides the initialization of the standard

--- a/chain/cmd/world/cmd/root.go
+++ b/chain/cmd/world/cmd/root.go
@@ -65,7 +65,7 @@ import (
 	evmante "pkg.berachain.dev/polaris/cosmos/x/evm/ante"
 	evmmepool "pkg.berachain.dev/polaris/cosmos/x/evm/plugins/txpool/mempool"
 
-	"github.com/argus-labs/world-engine/chain/app"
+	"pkg.world.dev/world-engine/chain/app"
 )
 
 // NewRootCmd creates a new root command for simd. It is called once in the main function.

--- a/chain/cmd/world/cmd/root_test.go
+++ b/chain/cmd/world/cmd/root_test.go
@@ -25,8 +25,8 @@ import (
 	"os"
 	"testing"
 
-	simapp "github.com/argus-labs/world-engine/chain/app"
-	"github.com/argus-labs/world-engine/chain/cmd/world/cmd"
+	simapp "pkg.world.dev/world-engine/chain/app"
+	"pkg.world.dev/world-engine/chain/cmd/world/cmd"
 
 	"github.com/cosmos/cosmos-sdk/client/flags"
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"

--- a/chain/cmd/world/main.go
+++ b/chain/cmd/world/main.go
@@ -28,10 +28,10 @@ import (
 
 	svrcmd "github.com/cosmos/cosmos-sdk/server/cmd"
 
-	simapp "github.com/argus-labs/world-engine/chain/app"
-	"github.com/argus-labs/world-engine/chain/cmd/world/cmd"
-	"github.com/argus-labs/world-engine/chain/config"
-	"github.com/argus-labs/world-engine/chain/types"
+	simapp "pkg.world.dev/world-engine/chain/app"
+	"pkg.world.dev/world-engine/chain/cmd/world/cmd"
+	"pkg.world.dev/world-engine/chain/config"
+	"pkg.world.dev/world-engine/chain/types"
 )
 
 func main() {

--- a/chain/contracts/go.mod
+++ b/chain/contracts/go.mod
@@ -1,4 +1,4 @@
-module github.com/argus-labs/world-engine/contracts
+module pkg.world.dev/world-engine/chain/contracts
 
 go 1.20
 

--- a/chain/go.mod
+++ b/chain/go.mod
@@ -1,4 +1,4 @@
-module github.com/argus-labs/world-engine/chain
+module pkg.world.dev/world-engine/chain
 
 go 1.20
 

--- a/chain/precompile/router/router.go
+++ b/chain/precompile/router/router.go
@@ -2,12 +2,12 @@ package router
 
 import (
 	"context"
-	"github.com/argus-labs/world-engine/chain/router"
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	generated "pkg.berachain.dev/polaris/contracts/bindings/cosmos/precompile/router"
 	cosmlib "pkg.berachain.dev/polaris/cosmos/lib"
 	ethprecompile "pkg.berachain.dev/polaris/eth/core/precompile"
 	"pkg.berachain.dev/polaris/eth/core/vm"
+	"pkg.world.dev/world-engine/chain/router"
 )
 
 const name = "world_engine_router"

--- a/chain/proto/router/module/v1/module.proto
+++ b/chain/proto/router/module/v1/module.proto
@@ -6,7 +6,7 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the router module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/argus-labs/world-engine/chain/x/router"};
+  option (cosmos.app.v1alpha1.module) = {go_import: "pkg.world.dev/world-engine/chain/x/router"};
 
   // authority defines the custom module authority. If not set, defaults to the governance module.
   string authority = 1;

--- a/chain/proto/router/v1/genesis.proto
+++ b/chain/proto/router/v1/genesis.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 package router.v1;
 import "router/v1/query.proto";
 
-option go_package = "github.com/argus-labs/world-engine/chain/x/router/types";
+option go_package = "pkg.world.dev/world-engine/chain/x/router/types";
 
 
 message Genesis {

--- a/chain/proto/router/v1/query.proto
+++ b/chain/proto/router/v1/query.proto
@@ -5,7 +5,7 @@ package router.v1;
 import "gogoproto/gogo.proto";
 import "google/api/annotations.proto";
 
-option go_package = "github.com/argus-labs/world-engine/chain/x/router/types";
+option go_package = "pkg.world.dev/world-engine/chain/x/router/types";
 
 // `QueryService` provides defines the gRPC querier service.
 service QueryService {

--- a/chain/proto/router/v1/tx.proto
+++ b/chain/proto/router/v1/tx.proto
@@ -7,7 +7,7 @@ import "cosmos_proto/cosmos.proto";
 import "gogoproto/gogo.proto";
 import "router/v1/query.proto";
 
-option go_package = "github.com/argus-labs/world-engine/chain/x/router/types";
+option go_package = "pkg.world.dev/world-engine/chain/x/router/types";
 
 service Msg {
   option (cosmos.msg.v1.service) = true;

--- a/chain/proto/shard/module/v1/module.proto
+++ b/chain/proto/shard/module/v1/module.proto
@@ -6,6 +6,6 @@ import "cosmos/app/v1alpha1/module.proto";
 
 // Module is the config object of the evm module.
 message Module {
-  option (cosmos.app.v1alpha1.module) = {go_import: "github.com/argus-labs/world-engine/chain/x/shard"};
+  option (cosmos.app.v1alpha1.module) = {go_import: "pkg.world.dev/world-engine/chain/x/shard"};
   string authority = 1;
 }

--- a/chain/proto/shard/v1/genesis.proto
+++ b/chain/proto/shard/v1/genesis.proto
@@ -4,7 +4,7 @@ package shard.v1;
 
 import "shard/v1/types.proto";
 
-option go_package = "github.com/argus-labs/world-engine/chain/x/shard/types";
+option go_package = "pkg.world.dev/world-engine/chain/x/shard/types";
 
 message GenesisState {
   // namespace_transactions contains a world's namespace, and all the transactions that occurred within that world.

--- a/chain/proto/shard/v1/query.proto
+++ b/chain/proto/shard/v1/query.proto
@@ -10,7 +10,7 @@ import "shard/v1/types.proto";
 
 
 
-option go_package = "github.com/argus-labs/world-engine/chain/x/shard/types";
+option go_package = "pkg.world.dev/world-engine/chain/x/shard/types";
 
 service Query {
   rpc Transactions(QueryTransactionsRequest) returns (QueryTransactionsResponse);

--- a/chain/proto/shard/v1/tx.proto
+++ b/chain/proto/shard/v1/tx.proto
@@ -6,7 +6,7 @@ import "cosmos_proto/cosmos.proto";
 import "cosmos/msg/v1/msg.proto";
 import "shard/v1/types.proto";
 
-option go_package = "github.com/argus-labs/world-engine/chain/x/shard/types";
+option go_package = "pkg.world.dev/world-engine/chain/x/shard/types";
 
 
 service Msg {

--- a/chain/proto/shard/v1/types.proto
+++ b/chain/proto/shard/v1/types.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package shard.v1;
 
-option go_package = "github.com/argus-labs/world-engine/chain/x/shard/types";
+option go_package = "pkg.world.dev/world-engine/chain/x/shard/types";
 
 
 message Transaction {

--- a/chain/router/mocks/router.go
+++ b/chain/router/mocks/router.go
@@ -8,7 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	router "github.com/argus-labs/world-engine/chain/router"
+	router "pkg.world.dev/world-engine/chain/router"
 	gomock "github.com/golang/mock/gomock"
 )
 

--- a/chain/shard/server.go
+++ b/chain/shard/server.go
@@ -15,7 +15,7 @@ import (
 	"os"
 	"sync"
 
-	"github.com/argus-labs/world-engine/chain/x/shard/types"
+	"pkg.world.dev/world-engine/chain/x/shard/types"
 )
 
 var (

--- a/chain/shard/tx_queue.go
+++ b/chain/shard/tx_queue.go
@@ -1,8 +1,8 @@
 package shard
 
 import (
-	"github.com/argus-labs/world-engine/chain/x/shard/types"
 	"github.com/zyedidia/generic/queue"
+	"pkg.world.dev/world-engine/chain/x/shard/types"
 	"sync"
 )
 

--- a/chain/shard/tx_queue_test.go
+++ b/chain/shard/tx_queue_test.go
@@ -1,8 +1,8 @@
 package shard
 
 import (
-	"github.com/argus-labs/world-engine/chain/x/shard/types"
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/chain/x/shard/types"
 	"sync"
 	"testing"
 )

--- a/chain/tests/e2e/node/node_test.go
+++ b/chain/tests/e2e/node/node_test.go
@@ -10,9 +10,9 @@ import (
 	"github.com/stretchr/testify/suite"
 	"gotest.tools/assert"
 
-	"github.com/argus-labs/world-engine/chain/runtime"
-	argus "github.com/argus-labs/world-engine/chain/runtime/config"
-	"github.com/argus-labs/world-engine/chain/utils"
+	"pkg.world.dev/world-engine/chain/runtime"
+	argus "pkg.world.dev/world-engine/chain/runtime/config"
+	"pkg.world.dev/world-engine/chain/utils"
 
 	"cosmossdk.io/simapp/params"
 

--- a/chain/types/config.go
+++ b/chain/types/config.go
@@ -27,7 +27,7 @@ import (
 
 	"pkg.berachain.dev/polaris/eth/accounts"
 
-	"github.com/argus-labs/world-engine/chain/config"
+	"pkg.world.dev/world-engine/chain/config"
 )
 
 var (

--- a/chain/x/router/depinject.go
+++ b/chain/x/router/depinject.go
@@ -7,8 +7,8 @@ import (
 	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
 	govtypes "github.com/cosmos/cosmos-sdk/x/gov/types"
 
-	v1 "github.com/argus-labs/world-engine/chain/api/router/module/v1"
-	"github.com/argus-labs/world-engine/chain/x/router/keeper"
+	v1 "pkg.world.dev/world-engine/chain/api/router/module/v1"
+	"pkg.world.dev/world-engine/chain/x/router/keeper"
 )
 
 //nolint:gochecknoinits // GRRRR fix later.

--- a/chain/x/router/keeper/keeper.go
+++ b/chain/x/router/keeper/keeper.go
@@ -4,7 +4,7 @@ import (
 	storetypes "cosmossdk.io/store/types"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	routertypes "github.com/argus-labs/world-engine/chain/x/router/types"
+	routertypes "pkg.world.dev/world-engine/chain/x/router/types"
 )
 
 type Keeper struct {

--- a/chain/x/router/keeper/msg_server.go
+++ b/chain/x/router/keeper/msg_server.go
@@ -5,7 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/argus-labs/world-engine/chain/x/router/types"
+	"pkg.world.dev/world-engine/chain/x/router/types"
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 )

--- a/chain/x/router/keeper/query_server.go
+++ b/chain/x/router/keeper/query_server.go
@@ -5,7 +5,7 @@ import (
 
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/argus-labs/world-engine/chain/x/router/types"
+	"pkg.world.dev/world-engine/chain/x/router/types"
 )
 
 var _ types.QueryServiceServer = &Keeper{}

--- a/chain/x/router/keeper/storage.go
+++ b/chain/x/router/keeper/storage.go
@@ -6,7 +6,7 @@ import (
 	"cosmossdk.io/store/prefix"
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/argus-labs/world-engine/chain/x/router/types"
+	"pkg.world.dev/world-engine/chain/x/router/types"
 )
 
 var (

--- a/chain/x/router/module.go
+++ b/chain/x/router/module.go
@@ -16,8 +16,8 @@ import (
 	"github.com/cosmos/cosmos-sdk/types/module"
 	"github.com/spf13/cobra"
 
-	"github.com/argus-labs/world-engine/chain/x/router/keeper"
-	routertypes "github.com/argus-labs/world-engine/chain/x/router/types"
+	"pkg.world.dev/world-engine/chain/x/router/keeper"
+	routertypes "pkg.world.dev/world-engine/chain/x/router/types"
 )
 
 const (

--- a/chain/x/router/types/msg.go
+++ b/chain/x/router/types/msg.go
@@ -6,7 +6,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/argus-labs/world-engine/chain/utils"
+	"pkg.world.dev/world-engine/chain/utils"
 )
 
 var (

--- a/chain/x/shard/depinject.go
+++ b/chain/x/shard/depinject.go
@@ -4,8 +4,8 @@ import (
 	"cosmossdk.io/core/appmodule"
 	"cosmossdk.io/core/store"
 	"cosmossdk.io/depinject"
-	modulev1 "github.com/argus-labs/world-engine/chain/api/shard/module/v1"
-	"github.com/argus-labs/world-engine/chain/x/shard/keeper"
+	modulev1 "pkg.world.dev/world-engine/chain/api/shard/module/v1"
+	"pkg.world.dev/world-engine/chain/x/shard/keeper"
 )
 
 //nolint:gochecknoinits // GRRRR fix later.

--- a/chain/x/shard/keeper/keeper.go
+++ b/chain/x/shard/keeper/keeper.go
@@ -3,7 +3,7 @@ package keeper
 import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 
-	"github.com/argus-labs/world-engine/chain/x/shard/types"
+	"pkg.world.dev/world-engine/chain/x/shard/types"
 
 	"cosmossdk.io/core/store"
 )

--- a/chain/x/shard/keeper/keeper_test.go
+++ b/chain/x/shard/keeper/keeper_test.go
@@ -2,9 +2,9 @@ package keeper_test
 
 import (
 	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"
-	"github.com/argus-labs/world-engine/chain/x/shard"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 	"google.golang.org/protobuf/proto"
+	"pkg.world.dev/world-engine/chain/x/shard"
 	"testing"
 
 	storetypes "cosmossdk.io/store/types"
@@ -17,8 +17,8 @@ import (
 	moduletestutil "github.com/cosmos/cosmos-sdk/types/module/testutil"
 	"github.com/stretchr/testify/suite"
 
-	"github.com/argus-labs/world-engine/chain/x/shard/keeper"
-	"github.com/argus-labs/world-engine/chain/x/shard/types"
+	"pkg.world.dev/world-engine/chain/x/shard/keeper"
+	"pkg.world.dev/world-engine/chain/x/shard/types"
 )
 
 type TestSuite struct {

--- a/chain/x/shard/keeper/msg_server.go
+++ b/chain/x/shard/keeper/msg_server.go
@@ -5,7 +5,7 @@ import (
 	sdk "github.com/cosmos/cosmos-sdk/types"
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/argus-labs/world-engine/chain/x/shard/types"
+	"pkg.world.dev/world-engine/chain/x/shard/types"
 )
 
 var _ types.MsgServer = &Keeper{}

--- a/chain/x/shard/keeper/query_server.go
+++ b/chain/x/shard/keeper/query_server.go
@@ -6,7 +6,7 @@ import (
 
 	sdkerrors "github.com/cosmos/cosmos-sdk/types/errors"
 
-	"github.com/argus-labs/world-engine/chain/x/shard/types"
+	"pkg.world.dev/world-engine/chain/x/shard/types"
 )
 
 var _ types.QueryServer = &Keeper{}

--- a/chain/x/shard/keeper/tx_storage.go
+++ b/chain/x/shard/keeper/tx_storage.go
@@ -4,9 +4,9 @@ import (
 	"cosmossdk.io/store/prefix"
 	"encoding/binary"
 	"fmt"
-	"github.com/argus-labs/world-engine/chain/x/shard/types"
 	"github.com/cosmos/cosmos-sdk/runtime"
 	sdk "github.com/cosmos/cosmos-sdk/types"
+	"pkg.world.dev/world-engine/chain/x/shard/types"
 )
 
 const (

--- a/chain/x/shard/module.go
+++ b/chain/x/shard/module.go
@@ -13,8 +13,8 @@ import (
 	"github.com/grpc-ecosystem/grpc-gateway/runtime"
 	"github.com/spf13/cobra"
 
-	"github.com/argus-labs/world-engine/chain/x/shard/keeper"
-	"github.com/argus-labs/world-engine/chain/x/shard/types"
+	"pkg.world.dev/world-engine/chain/x/shard/keeper"
+	"pkg.world.dev/world-engine/chain/x/shard/types"
 )
 
 const (

--- a/sign/go.mod
+++ b/sign/go.mod
@@ -1,4 +1,4 @@
-module github.com/argus-labs/world-engine/sign
+module pkg.world.dev/world-engine/sign
 
 go 1.20
 


### PR DESCRIPTION
## What is the purpose of the change

vanity package names for our go modules

## Brief Changelog

changes all our modules to use vanity package name

## Testing and Verifying

n/a
