### PR TITLE
chore(cardinal): remove redundant method Set value from ComponentType (CAR-147)

### DIFF
--- a/cardinal/ecs/component.go
+++ b/cardinal/ecs/component.go
@@ -134,15 +134,6 @@ func (c *ComponentType[T]) AddTo(w *World, id storage.EntityID) error {
 	return e.AddComponent(w, c)
 }
 
-// SetValue sets the value of the component.
-func (c *ComponentType[T]) SetValue(w *World, id storage.EntityID, value T) error {
-	_, err := c.Get(w, id)
-	if err != nil {
-		return err
-	}
-	return c.Set(w, id, value)
-}
-
 // String returns the component type name.
 func (c *ComponentType[T]) String() string {
 	return c.name


### PR DESCRIPTION
Closes: #CAR-147

## What is the purpose of the change

Remove SetValue from Cardinal in components.go. It is a redundant method to Set and it's not used anywhere. 

## Brief Changelog

I just deleted the method. A very simple change. 


## Testing and Verifying

go test ./... in the ecs folder under cardinal yielded no issues. 