### PR TITLE
chore(cardinal): removed extra boolean from return value of first. Change in function …

### DIFF
--- a/cardinal/ecs/component.go
+++ b/cardinal/ecs/component.go
@@ -99,21 +99,17 @@ func (c *ComponentType[T]) Each(w *World, callback QueryCallBackFn) {
 }
 
 // First returns the first entity that has the component.
-func (c *ComponentType[T]) First(w *World) (storage.EntityID, bool, error) {
+func (c *ComponentType[T]) First(w *World) (storage.EntityID, error) {
 	return c.query.First(w)
 }
 
 // MustFirst returns the first entity that has the component or panics.
-func (c *ComponentType[T]) MustFirst(w *World) (storage.EntityID, error) {
-	id, ok, err := c.query.First(w)
+func (c *ComponentType[T]) MustFirst(w *World) storage.EntityID {
+	id, err := c.query.First(w)
 	if err != nil {
-		return storage.BadID, err
-	}
-	if !ok {
 		panic(fmt.Sprintf("no entity has the component %s", c.name))
 	}
-
-	return id, nil
+	return id
 }
 
 // RemoveFrom removes this component form the given entity.

--- a/cardinal/ecs/query.go
+++ b/cardinal/ecs/query.go
@@ -63,20 +63,20 @@ func (q *Query) Count(w *World) int {
 }
 
 // First returns the first entity that matches the query.
-func (q *Query) First(w *World) (id storage.EntityID, ok bool, err error) {
+func (q *Query) First(w *World) (id storage.EntityID, err error) {
 	accessor := w.StorageAccessor()
 	result := q.evaluateQuery(w, &accessor)
 	iter := storage.NewEntityIterator(0, accessor.Archetypes, result)
 	if !iter.HasNext() {
-		return storage.BadID, false, err
+		return storage.BadID, err
 	}
 	for iter.HasNext() {
 		entities := iter.Next()
 		if len(entities) > 0 {
-			return entities[0], true, nil
+			return entities[0], nil
 		}
 	}
-	return storage.BadID, false, err
+	return storage.BadID, err
 }
 
 func (q *Query) evaluateQuery(world *World, accessor *StorageAccessor) []storage.ArchetypeID {

--- a/cardinal/ecs/tests/tick_test.go
+++ b/cardinal/ecs/tests/tick_test.go
@@ -116,9 +116,8 @@ func TestCanModifyArchetypeAndGetEntity(t *testing.T) {
 
 	verifyCanFindEntity := func() {
 		// Make sure we can find the entity
-		gotID, ok, err := alpha.First(world)
+		gotID, err := alpha.First(world)
 		assert.NilError(t, err)
-		assert.Check(t, ok)
 		assert.Equal(t, wantID, gotID)
 
 		// Make sure the associated component is correct
@@ -158,9 +157,8 @@ func TestCanRecoverStateAfterFailedArchetypeChange(t *testing.T) {
 		errorToggleComponent := errors.New("problem with toggle component")
 		world.AddSystem(func(w *ecs.World, _ *ecs.TransactionQueue) error {
 			// Get the one and only entity ID
-			id, ok, err := static.First(w)
+			id, err := static.First(w)
 			assert.NilError(t, err)
-			assert.Check(t, ok)
 
 			s, err := static.Get(w, id)
 			assert.NilError(t, err)
@@ -180,9 +178,8 @@ func TestCanRecoverStateAfterFailedArchetypeChange(t *testing.T) {
 		})
 		assert.NilError(t, world.LoadGameState())
 
-		id, ok, err := static.First(world)
+		id, err := static.First(world)
 		assert.NilError(t, err)
-		assert.Check(t, ok)
 
 		if firstWorldIteration {
 			for i := 0; i < 4; i++ {
@@ -223,9 +220,9 @@ func TestCanRecoverTransactionsFromFailedSystemRun(t *testing.T) {
 		assert.NilError(t, world.RegisterTransactions(powerTx))
 
 		world.AddSystem(func(w *ecs.World, queue *ecs.TransactionQueue) error {
-			id, err := powerComp.MustFirst(w)
-			assert.NilError(t, err)
+			id := powerComp.MustFirst(w)
 			entityPower, err := powerComp.Get(w, id)
+			assert.NilError(t, err)
 
 			changes := powerTx.In(queue)
 			assert.Equal(t, 1, len(changes))
@@ -247,8 +244,7 @@ func TestCanRecoverTransactionsFromFailedSystemRun(t *testing.T) {
 
 		// fetchPower is a small helper to get the power of the only entity in the world
 		fetchPower := func() float64 {
-			id, ok, err := powerComp.First(world)
-			assert.Check(t, ok)
+			id, err := powerComp.First(world)
 			assert.NilError(t, err)
 			power, err := powerComp.Get(world, id)
 			assert.NilError(t, err)


### PR DESCRIPTION
…signature propagated to other places also resulting in changes.

Closes: #CAR-148
## What is the purpose of the change
Removes redundant return value from query.First (result, book, err)
logic shows when err is nil, bool is true, when err is not nil bool is false, making the boolean show redundant information as err should report the same information. 

Perhaps this was done earlier because the ok boolean would sometimes return true with an error? Worth considering in review. 

## Brief Changelog

- changed Query.First
- change in Query.First resulted in change in ComponentType.First
- change in Query.First resulted in change in ComponentType.MustFirst 
  - It no longer makes sense for MustFirst to return an error. It simply panics if Query.First returns an error. 
- changed associated unit tests. 

## Testing and Verifying

Ran go test ./... in the ecs directory. 