### PR TITLE
fix(chain): enable API server in startup script

### DIFF
--- a/chain/scripts/start-rollup.sh
+++ b/chain/scripts/start-rollup.sh
@@ -42,6 +42,6 @@ world genesis collect-gentxs
 
 sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' /root/.world/config/config.toml
 
-sed -i 's/enable = false/enable = true/' /root/.world/config/app.toml
+sed -i '/api\]/,/\[/ s/enable = false/enable = true/' /root/.world/config/app.toml
 
 world start --rollkit.aggregator true --rollkit.da_layer celestia --rollkit.da_config=$DA_CONFIG --rollkit.namespace_id $DA_NAMESPACE_ID --rollkit.da_start_height $DA_BLOCK_HEIGHT --minimum-gas-prices 0stake

--- a/chain/scripts/start-rollup.sh
+++ b/chain/scripts/start-rollup.sh
@@ -42,4 +42,6 @@ world genesis collect-gentxs
 
 sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' /root/.world/config/config.toml
 
+sed -i 's/enable = false/enable = true/' /root/.world/config/app.toml
+
 world start --rollkit.aggregator true --rollkit.da_layer celestia --rollkit.da_config=$DA_CONFIG --rollkit.namespace_id $DA_NAMESPACE_ID --rollkit.da_start_height $DA_BLOCK_HEIGHT --minimum-gas-prices 0stake


### PR DESCRIPTION
Closes: n/a

## What is the purpose of the change

enables the API server via a sed command that edits the app.toml configuration

## Brief Changelog

add sed command to start-rollup.sh that edits the app.toml configuration and sets enabled = true in the api section.

## Testing and Verifying

run the stack, you should see a log from polaris say the rpc is running at 8545
