### PR TITLE
fix: add fallbacks to insecure transport for adapter/router

### DIFF
--- a/chain/router/router.go
+++ b/chain/router/router.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
+	"google.golang.org/grpc/credentials/insecure"
 	"os"
 )
 
@@ -60,6 +61,9 @@ func NewRouter(cardinalAddr string, opts ...Option) Router {
 	r := &router{cardinalAddr: cardinalAddr}
 	for _, opt := range opts {
 		opt(r)
+	}
+	if len(r.clientOpts) == 0 {
+		r.clientOpts = append(r.clientOpts, grpc.WithTransportCredentials(insecure.NewCredentials()))
 	}
 	return r
 }


### PR DESCRIPTION
## What is the purpose of the change

adds fallbacks to insecure transport for adapter and router services. this helps with testing, so you don't need to have SSL certs on hand when you're testing locally.

## Brief Changelog

- adds insecure transport fallback to adapter and router servers

## Testing and Verifying

spin up a router/adapter without credential options