### PR TITLE
fix(cardinal): update history to have the correct tick

### DIFF
--- a/cardinal/ecs/receipt/receipt.go
+++ b/cardinal/ecs/receipt/receipt.go
@@ -60,6 +60,10 @@ func (h *History) NextTick() {
 	h.history[mod] = map[transaction.TxHash]Receipt{}
 }
 
+func (h *History) SetTick(tick uint64) {
+	h.currTick.Store(tick)
+}
+
 // AddError associates the given error with the given transaction hash. Calling this multiple times will append
 // the error any previously added errors.
 func (h *History) AddError(hash transaction.TxHash, err error) {

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -451,7 +451,6 @@ func (w *World) Tick(ctx context.Context) error {
 			return err
 		}
 	}
-	w.receiptHistory.NextTick()
 
 	if err := w.saveArchetypeData(); err != nil {
 		return err
@@ -461,6 +460,7 @@ func (w *World) Tick(ctx context.Context) error {
 		return err
 	}
 	w.tick++
+	w.receiptHistory.NextTick()
 
 	return nil
 }
@@ -554,6 +554,7 @@ func (w *World) LoadGameState() error {
 			return err
 		}
 	}
+	w.receiptHistory.SetTick(w.tick)
 
 	return nil
 }


### PR DESCRIPTION

## What is the purpose of the change

The receiptHistory keeps track of receipts from previous ticks, and allowed for the querying of receipts from past ticks. It's important that the receiptHistory's tick is the same as the world's tick, so that when the user asks for receipts from a certain tick, the receiptHistory struct can find them.

If the World object loads some game state that is on a non-zero tick, the receiptHistory struct was never notified about this advanced tick, and would not be able to return accurate tx receipt data.

This PR ensures the receitHistory tick and the world tick are always in sync.

## Testing and Verifying

I intend to write a unit test to demonstrate this bug, but I want to merge this and make a tagged version of cardinal to unblock some people first.
