### PR TITLE
perf(sign): Use json.Compact instead of marshal/unmarshal

### DIFF
--- a/sign/sign.go
+++ b/sign/sign.go
@@ -75,19 +75,20 @@ func normalizeJSON(data any) ([]byte, error) {
 		return json.Marshal(data)
 	}
 
-	// Make sure the given string/[]byte is valid json
 	if !json.Valid(asBuf) {
 		return nil, fmt.Errorf("data %q is not valid json", string(asBuf))
 	}
-	// Unmarshal, then marshal the data to normalize it. For example, extra spaces will be removed.
+
+	dst := &bytes.Buffer{}
+
+	// JSON strings need to be compacted (insignificant whitespace removed).
 	// This is required because when the signed payload is serialized/deserialized those spaces will also
 	// be lost. If they are not removed beforehand, the hashes of the message before serialization and after
 	// will be different.
-	m := map[string]any{}
-	if err := json.Unmarshal(asBuf, &m); err != nil {
+	if err := json.Compact(dst, asBuf); err != nil {
 		return nil, err
 	}
-	return json.Marshal(m)
+	return dst.Bytes(), nil
 }
 
 // newSignedAny uses the given private key to sign the personaTag, namespace, nonce, and data.

--- a/sign/sign_test.go
+++ b/sign/sign_test.go
@@ -104,6 +104,11 @@ func TestStringsBytesAndStructsCanBeSigned(t *testing.T) {
 		SomeStruct{Str: "a-string", Num: 99},
 		`{"Str": "a-string", "Num": 99}`,
 		[]byte(`{"Str": "a-string", "Num": 99}`),
+		// This test case has different kinds of whitespace.
+		`{
+		"Str":      "a-string", 
+
+"Num":    99   }`,
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION


## What is the purpose of the change

I recently fixed a bug where spaces in a signed message would be removed during the json marshal/unmarshal process, resulting in a different hash after sending the message over the wire. To fix this issue, I ran the json through a marshal/unmarshal process before computing the hash.

It turns out there's a method in encoding/json called "Compact" which already "normalizes" the json, and it's 4x faster.

## Testing and Verifying

No functionality changes, just an overall speedup. Existing unit tests verify the code.
