### PR TITLE
fix: return interface from evm server package, port option

### DIFF
--- a/cardinal/evm/option.go
+++ b/cardinal/evm/option.go
@@ -16,3 +16,9 @@ func WithCredentials(certPath, keyPath string) Option {
 		s.serverOpts = append(s.serverOpts, grpc.Creds(creds))
 	}
 }
+
+func WithPort(port string) Option {
+	return func(impl *msgServerImpl) {
+		impl.port = port
+	}
+}

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -76,16 +76,16 @@ func TestIfServeSetEnvVarForPort(t *testing.T) {
 	txh.port = ""
 	err = os.Setenv("CARDINAL_PORT", "1337")
 	assert.NilError(t, err)
-	txh.InitializeServer()
+	txh.initialize()
 	assert.Equal(t, txh.port, "1337")
 	txh.port = ""
 	err = os.Setenv("CARDINAL_PORT", "133asdfsdgdfdfgdf7")
 	assert.NilError(t, err)
-	txh.InitializeServer()
+	txh.initialize()
 	assert.Equal(t, txh.port, "4040")
 	err = os.Setenv("CARDINAL_PORT", "4555")
 	txh.port = "bad"
-	txh.InitializeServer()
+	txh.initialize()
 	assert.Equal(t, txh.port, "4555")
 }
 

--- a/chain/shard/server.go
+++ b/chain/shard/server.go
@@ -81,7 +81,7 @@ func (s *Server) Serve(listenAddr string) {
 	go func() {
 		err = grpcServer.Serve(listener)
 		if err != nil {
-			panic(err)
+			log.Fatal(err)
 		}
 	}()
 }


### PR DESCRIPTION
## What is the purpose of the change

previously, evm server returned a proto generated interface, hiding the `Serve` method. this PR fixes that by making a new interface with the Serve method in it. 

it also adds a port option, port env var, and a default port if neither is set.

also changes usage of `panic` to `log.Fatal` in go routines, so the entire program crashes, instead of just the go-routine.

## Brief Changelog

- add port options for evm_sever
- return an interface from evm_server
- change usage of panic to log.Fatal for go routines

## Testing and Verifying

