### PR TITLE
feat(cardinal): add support for ABI generating structs with struct fields

### DIFF
--- a/cardinal/ecs/abi_test.go
+++ b/cardinal/ecs/abi_test.go
@@ -110,7 +110,7 @@ func TestGenerateABIType_NoSizeOnInt(t *testing.T) {
 
 func TestGenerateABIType_StructInStruct(t *testing.T) {
 	type Bar struct {
-		X uint64 `json:"X"`
+		HelloWorld uint64 `json:"HelloWorld"`
 	}
 
 	type Foo struct {

--- a/cardinal/ecs/abi_test.go
+++ b/cardinal/ecs/abi_test.go
@@ -107,3 +107,29 @@ func TestGenerateABIType_NoSizeOnInt(t *testing.T) {
 	_, err = GenerateABIType(InvalidInt{})
 	assert.Error(t, err)
 }
+
+func TestGenerateABIType_StructInStruct(t *testing.T) {
+	type Bar struct {
+		X uint64 `json:"X"`
+	}
+
+	type Foo struct {
+		Y uint64
+		B Bar
+	}
+	foo := Foo{32, Bar{42}}
+	a, err := GenerateABIType(foo)
+	assert.Nil(t, err)
+	args := abi.Arguments{{Type: *a}}
+	bz, err := args.Pack(foo)
+	assert.Nil(t, err)
+
+	unpacked, err := args.Unpack(bz)
+	assert.Nil(t, err)
+	assert.Len(t, unpacked, 1)
+
+	underlyingFoo, ok := unpacked[0].(Foo)
+	assert.True(t, ok)
+
+	assert.Equal(t, underlyingFoo, foo)
+}

--- a/cardinal/ecs/read.go
+++ b/cardinal/ecs/read.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/invopop/jsonschema"
 )
@@ -18,7 +17,7 @@ type IRead interface {
 	// and is expected to return a json encoded response struct.
 	HandleReadRaw(*World, []byte) ([]byte, error)
 	// Schema returns the json schema of the read request.
-  Schema() (request, reply *jsonschema.Schema)
+	Schema() (request, reply *jsonschema.Schema)
 	// DecodeEVMRequest decodes bytes originating from the evm into the request type, which will be ABI encoded.
 	DecodeEVMRequest([]byte) (any, error)
 	// EncodeEVMReply encodes the reply as an abi encoded struct.


### PR DESCRIPTION
## What is the purpose of the change

Previously, EVMSupport would not work for structs that had another struct as fields. this PR adds support for that. there is one caveat however, due to quirks in the ABI implementation. The inner struct MUST have JSON struct tags with PascalCase of the field name. For example:


```go
type Foo struct {
    HelloWorld uint64 `json:"HelloWorld"`
}
```

## Brief Changelog

- add ABI support for struct fields in structs

## Testing and Verifying

`cardinal/ecs/abi_test.go`
