### PR TITLE
fix(cardinal): fix flaky http tests

### DIFF
--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -3,12 +3,12 @@ package server
 import (
 	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
+	"strconv"
+
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/shard"
-	"strconv"
 )
 
 // Handler is a type that contains endpoints for transactions and queries in a given ecs world.
@@ -99,16 +99,10 @@ func (t *Handler) initialize() {
 // Please us `go txh.Serve()` if you do not want to block execution after calling this function.
 // Will default to env var "CARDINAL_PORT". If that's not set correctly then will default to port 4040
 // if no correct port was previously set.
-func (t *Handler) Serve() {
-	err := t.server.ListenAndServe()
-	if err != nil {
-		log.Fatal(err)
-	}
+func (t *Handler) Serve() error {
+	return t.server.ListenAndServe()
 }
 
 func (t *Handler) Close() error {
-	if err := t.server.Close(); err != nil {
-		return err
-	}
-	return nil
+	return t.server.Close()
 }


### PR DESCRIPTION
Closes: #CAR-115 (hopefully)

## What is the purpose of the change

Fix the flaky tests in cardinal/server. Two issues were identified:

1) http's ListenAndServe returns an error when the server is shut down, and Handler.Serve would log a fatal error when ListenAndServe returns an error. During tests, it is desirable to close the http sever to free up the port for other tests. This was causing log.Fatal to be called during tests, which would not run all future tests. *The fix:* Return an error from Handler.Serve and let the caller decide how to handle the error.

2) While startup up an http server is fast, it's not instantaneous. In tests, we start the server on a non-main goroutine, but there's no guarantee that the server would be ready to handle traffic once the test code on the main threat was reached. *The fix:* Create a health check endpoint for tests that we query before any test code is run. Errors from this health check endpoint are ignored (as the server is still starting up). Once the health check returns 200, allow the test logic to run.  


## Testing and Verifying

This PR verifies very little non-test code. Existing unit tests should verify the change.
