### PR TITLE
feat(cardinal): support slices of structs in ABI generated types

### DIFF
--- a/cardinal/ecs/abi.go
+++ b/cardinal/ecs/abi.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -128,4 +129,15 @@ func goTypeToSolidityType(t string, tag string) (string, error) {
 	}
 	return t, nil
 
+}
+
+func SerdeInto[T any](iface interface{}) (T, error) {
+	v := new(T)
+	bz, err := json.Marshal(iface)
+	if err != nil {
+		return *v, err
+	}
+
+	err = json.Unmarshal(bz, v)
+	return *v, err
 }

--- a/cardinal/ecs/abi_test.go
+++ b/cardinal/ecs/abi_test.go
@@ -1,7 +1,6 @@
 package ecs
 
 import (
-	"encoding/json"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
@@ -104,20 +103,9 @@ func TestGenerateABIType_AllValidTypes(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, unpacked, 1)
 
-	got, err := serDeInto[BigType](unpacked[0])
+	got, err := SerdeInto[BigType](unpacked[0])
 	assert.Nil(t, err)
-	assert.Equal(t, *got, b)
-}
-
-func serDeInto[T any](iface interface{}) (*T, error) {
-	bz, err := json.Marshal(iface)
-	if err != nil {
-		return nil, err
-	}
-
-	v := new(T)
-	err = json.Unmarshal(bz, v)
-	return v, err
+	assert.Equal(t, got, b)
 }
 
 func TestGenerateABIType_PanicOnImportedTypes(t *testing.T) {
@@ -164,10 +152,10 @@ func TestGenerateABIType_StructInStruct(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, unpacked, 1)
 
-	got, err := serDeInto[Foo](unpacked[0])
+	got, err := SerdeInto[Foo](unpacked[0])
 	assert.Nil(t, err)
 
-	assert.Equal(t, *got, foo)
+	assert.Equal(t, got, foo)
 }
 
 func TestGenerateABIType_SliceOfStructInStruct(t *testing.T) {
@@ -190,8 +178,8 @@ func TestGenerateABIType_SliceOfStructInStruct(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, unpacked, 1)
 
-	underlyingFoo, err := serDeInto[Foo](unpacked[0])
+	underlyingFoo, err := SerdeInto[Foo](unpacked[0])
 	assert.Nil(t, err)
 
-	assert.Equal(t, *underlyingFoo, foo)
+	assert.Equal(t, underlyingFoo, foo)
 }

--- a/cardinal/ecs/read.go
+++ b/cardinal/ecs/read.go
@@ -131,16 +131,11 @@ func (r *ReadType[req, rep]) DecodeEVMRequest(bz []byte) (any, error) {
 	if len(unpacked) < 1 {
 		return nil, errors.New("error decoding EVM bytes: no values could be unpacked")
 	}
-	encoded, err := json.Marshal(unpacked[0])
+	request, err := SerdeInto[req](unpacked[0])
 	if err != nil {
 		return nil, err
 	}
-	request := new(req)
-	err = json.Unmarshal(encoded, request)
-	if err != nil {
-		return nil, err
-	}
-	return *request, nil
+	return request, nil
 }
 
 func (r *ReadType[req, rep]) DecodeEVMReply(bz []byte) (any, error) {
@@ -155,16 +150,11 @@ func (r *ReadType[req, rep]) DecodeEVMReply(bz []byte) (any, error) {
 	if len(unpacked) < 1 {
 		return nil, errors.New("error decoding EVM bytes: no values could be unpacked")
 	}
-	encoded, err := json.Marshal(unpacked[0])
+	reply, err := SerdeInto[rep](unpacked[0])
 	if err != nil {
 		return nil, err
 	}
-	reply := new(rep)
-	err = json.Unmarshal(encoded, reply)
-	if err != nil {
-		return nil, err
-	}
-	return *reply, nil
+	return reply, nil
 }
 
 func (r *ReadType[req, rep]) EncodeEVMReply(a any) ([]byte, error) {

--- a/cardinal/ecs/read.go
+++ b/cardinal/ecs/read.go
@@ -137,7 +137,10 @@ func (r *ReadType[req, rep]) DecodeEVMRequest(bz []byte) (any, error) {
 	}
 	request := new(req)
 	err = json.Unmarshal(encoded, request)
-	return request, err
+	if err != nil {
+		return nil, err
+	}
+	return *request, nil
 }
 
 func (r *ReadType[req, rep]) DecodeEVMReply(bz []byte) (any, error) {
@@ -158,7 +161,10 @@ func (r *ReadType[req, rep]) DecodeEVMReply(bz []byte) (any, error) {
 	}
 	reply := new(rep)
 	err = json.Unmarshal(encoded, reply)
-	return reply, err
+	if err != nil {
+		return nil, err
+	}
+	return *reply, nil
 }
 
 func (r *ReadType[req, rep]) EncodeEVMReply(a any) ([]byte, error) {

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -199,5 +199,8 @@ func (t *TransactionType[In, Out]) DecodeEVMBytes(bz []byte) (any, error) {
 	}
 	input := new(In)
 	err = json.Unmarshal(encoded, input)
-	return input, err
+	if err != nil {
+		return nil, err
+	}
+	return *input, nil
 }

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -1,7 +1,6 @@
 package ecs
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"github.com/ethereum/go-ethereum/accounts/abi"
@@ -193,14 +192,9 @@ func (t *TransactionType[In, Out]) DecodeEVMBytes(bz []byte) (any, error) {
 	if len(unpacked) < 1 {
 		return nil, fmt.Errorf("error decoding EVM bytes: no values could be unpacked into the abi type")
 	}
-	encoded, err := json.Marshal(unpacked[0])
+	input, err := SerdeInto[In](unpacked[0])
 	if err != nil {
 		return nil, err
 	}
-	input := new(In)
-	err = json.Unmarshal(encoded, input)
-	if err != nil {
-		return nil, err
-	}
-	return *input, nil
+	return input, nil
 }


### PR DESCRIPTION
## What is the purpose of the change

adds support for slices of structs in EVM supported txs/reads

## Brief Changelog

- adds support for slices of structs in EVM supported txs/reads
- changes the way unpacked values are handled in ABI decodings. previously, we could set the TupleType and the ABI package would use this type with reflection to set values into. There was no obvious way to do this with embedded types, so i am instead abusing the fact that the ABI package implicitly adds json struct tags to their reflected built structs. this allows us to JSON marshal the unpacked interface and JSON unmarshal into the typed structs.

## Testing and Verifying

cd cardinal
go test ./...
