### PR TITLE
chore(ci): prebuilt chain/base_shard docker image release

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -1,0 +1,59 @@
+name: image-release-pipeline
+
+## workflow will trigger on below condition,
+## except image release that have jobs condition to trigger only on tagging
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*.*.*'
+
+env:
+  REGISTRY_URL: us-docker.pkg.dev
+
+jobs:
+  chain-release:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: chain
+    # Add "id-token" with the intended permissions.
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: GCP auth
+        id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
+      - name: GCP - Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID_PACKAGES }}
+      - name: Docker - Auth to artifact registry
+        run: |
+          gcloud auth configure-docker ${{ env.REGISTRY_URL }}
+      - name: Docker - Build
+        run: |
+          docker build -t chain-local-build:latest .
+      - name: Docker - Publish Image
+        run: |
+          ## Construct image_id
+          IMAGE_ID_CHAIN=${{ env.REGISTRY_URL }}/${{ github.repository_owner }}/${{ github.event.repository.name }}/chain
+          IMAGE_ID_CHAIN=$(echo $IMAGE_ID_CHAIN | tr '[A-Z]' '[a-z]')
+
+          ## Get version from tag name, or use latest when on main branch
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+          [ "$VERSION" == "main" ] && VERSION=latest
+
+          docker tag chain-local-build:latest $IMAGE_ID_CHAIN:$VERSION .
+          docker push $IMAGE_ID_CHAIN:$VERSION

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -28,6 +28,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
+      - name: Cache Docker images.
+        uses: ScribeMD/docker-cache@0.3.4
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles(./chain/Dockerfile) }}
       - name: GCP auth
         id: auth
         uses: google-github-actions/auth@v1

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -28,10 +28,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      # - name: Cache Docker images
-      #   uses: ScribeMD/docker-cache@0.3.4
-      #   with:
-      #     key: docker-${{ runner.os }}-${{ hashFiles(./Dockerfile) }}
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.3.4
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles('chain/Dockerfile') }}
       - name: GCP auth
         id: auth
         uses: google-github-actions/auth@v1

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -28,10 +28,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Cache Docker images.
+      - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.3.4
         with:
-          key: docker-${{ runner.os }}-${{ hashFiles(./chain/Dockerfile) }}
+          key: docker-${{ runner.os }}-${{ hashFiles(./Dockerfile) }}
       - name: GCP auth
         id: auth
         uses: google-github-actions/auth@v1

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -28,10 +28,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.4
-        with:
-          key: docker-${{ runner.os }}-${{ hashFiles(./Dockerfile) }}
+      # - name: Cache Docker images
+      #   uses: ScribeMD/docker-cache@0.3.4
+      #   with:
+      #     key: docker-${{ runner.os }}-${{ hashFiles(./Dockerfile) }}
       - name: GCP auth
         id: auth
         uses: google-github-actions/auth@v1

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -54,6 +54,7 @@ jobs:
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
           [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
           [ "$VERSION" == "main" ] && VERSION=latest
+          echo "Image to push: $IMAGE_ID_CHAIN:$VERSION"
 
-          docker tag chain-local-build:latest $IMAGE_ID_CHAIN:$VERSION .
+          docker tag chain-local-build:latest $IMAGE_ID_CHAIN:$VERSION
           docker push $IMAGE_ID_CHAIN:$VERSION

--- a/chain/README.md
+++ b/chain/README.md
@@ -6,6 +6,20 @@
 
 The easiest way to install a Cosmos-SDK Blockchain running Polaris is to download a pre-built binary. You can find the latest binaries on the [releases](https://github.com/polaris/releases) page.
 
+### From Prebuilt Docker Image
+
+Pull `chain` prebuild Docker Image:
+```bash
+docker pull us-docker.pkg.dev/argus-labs/world-engine/chain:<latest/tag_version>
+```
+
+Run `chain` container, supply the DA_BASE_URL and DA_AUTH_TOKEN environment variables accordingly:
+```bash
+docker run -it --rm -e DA_BASE_URL=http://celestia-da-layer-url:26658 -e DA_AUTH_TOKEN=celestia-da-later-token  us-docker.pkg.dev/argus-labs/world-engine/chain:latest
+```
+
+See the Docker Compose section below for instructions on running both the `chain` and `Celestia Devnet` stack.
+
 ### From Source
 
 **Step 1: Install Golang & Foundry**
@@ -110,8 +124,9 @@ Start the `chain` and `celestia-devnet` using `chain/docker-compose.yml`, make s
 
 - Start the `chain` / `evm_base_shard`
   ```
-  docker compose up chain -d
+  docker compose up chain --buiild --detach
   ```
+
 
 
 

--- a/chain/README.md
+++ b/chain/README.md
@@ -124,7 +124,7 @@ Start the `chain` and `celestia-devnet` using `chain/docker-compose.yml`, make s
 
 - Start the `chain` / `evm_base_shard`
   ```
-  docker compose up chain --buiild --detach
+  docker compose up chain --build --detach
   ```
 
 

--- a/chain/docker-compose.yml
+++ b/chain/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       ## Env vars reference: https://github.com/Argus-Labs/world-engine/blob/main/chain/README.md
       ## Get AUTH_TOKEN from celestia_devnet container: `docker logs celestia_devnet 2>&1 | grep CELESTIA_NODE_AUTH_TOKEN -A 5 | tail -n 1`
       - DA_AUTH_TOKEN=${DA_AUTH_TOKEN:-}
+    image: us-docker.pkg.dev/argus-labs/world-engine/chain:latest
     build:
       context: .
       dockerfile: Dockerfile


### PR DESCRIPTION
Closes: #DEVOP-38

## What is the purpose of the change

Add CI pipeline to upload `chain` docker image to a public GCP Artifact Registry, and add README instruction on how to run the prebuilt docker image.


## Brief Changelog

- Add CI pipeline (`.github/workflows/image-release.yaml`) to build & release `chain` docker image to GCP Artifact Registry.
- Container registry format will look like this:
  - latest tag: `us-docker.pkg.dev/argus-labs/world-engine/chain:latest`
  - specific tag version: `us-docker.pkg.dev/argus-labs/world-engine/chain:0.1.0-alpha2`
- Docker images will be published on these two event:
  - push on main --> publish `latest` tag
  - tag event --> publish tag version (`0.1.0-alpha`, `0.1.1`, ...)

![image](https://github.com/Argus-Labs/world-engine/assets/29672212/d10c088b-17bc-4631-a31d-ca6f000200bc)
![image](https://github.com/Argus-Labs/world-engine/assets/29672212/e94dab57-be5a-4f1d-814e-61a2f0f15685)

## Testing and Verifying

- Create a tag release from Github repository pages
- Wait for CI to finish the build & push the image to Artifact Registry
- Try to pull the released docker image:
  -  `docker pull us-docker.pkg.dev/argus-labs/world-engine/chain:<latest/tag_version>`