### PR TITLE
feat(cardinal): add constructors for Transaction/Read types with EVM support enabled

### DIFF
--- a/cardinal/read.go
+++ b/cardinal/read.go
@@ -28,6 +28,17 @@ func NewReadType[Request any, Reply any](
 	}
 }
 
+// NewReadTypeWithEVMSupport creates a new instance of a ReadType with EVM support, allowing this read to be called from
+// the EVM base shard. The World state must not be changed in the given handler function.
+func NewReadTypeWithEVMSupport[Request, Reply any](name string, handler func(*World, Request) (Reply, error)) *ReadType[Request, Reply] {
+	return &ReadType[Request, Reply]{
+		impl: ecs.NewReadType[Request, Reply](name, func(world *ecs.World, req Request) (Reply, error) {
+			outerWorld := &World{impl: world}
+			return handler(outerWorld, req)
+		}, ecs.WithReadEVMSupport[Request, Reply]),
+	}
+}
+
 // Convert implements the AnyReadType interface which allows a ReadType to be registered
 // with a World via RegisterReads.
 func (r *ReadType[Request, Reply]) Convert() ecs.IRead {

--- a/cardinal/transaction.go
+++ b/cardinal/transaction.go
@@ -36,6 +36,14 @@ func NewTransactionType[Msg, Result any](name string) *TransactionType[Msg, Resu
 	}
 }
 
+// NewTransactionTypeWithEVMSupport creates a new instance of a TransactionType, with EVM transactions enabled.
+// This allows this transaction to be sent from EVM smart contracts on the EVM base shard.
+func NewTransactionTypeWithEVMSupport[Msg, Result any](name string) *TransactionType[Msg, Result] {
+	return &TransactionType[Msg, Result]{
+		impl: ecs.NewTransactionType[Msg, Result](name, ecs.WithTxEVMSupport[Msg, Result]),
+	}
+}
+
 // AddError adds the given error to the transaction identified by the given hash. Multiple errors can be
 // added to the same transaction hash.
 func (t *TransactionType[Msg, Result]) AddError(world *World, hash TxHash, err error) {


### PR DESCRIPTION
## What is the purpose of the change

adds new constructors for both transaction and read types that enable EVM support.

## Brief Changelog

- new function in transaction.go and read.go

## Testing and Verifying

n/a