### PR TITLE
pretty logging option for cardinal.

### DIFF
--- a/cardinal/option.go
+++ b/cardinal/option.go
@@ -1,8 +1,11 @@
 package cardinal
 
 import (
+	"os"
 	"time"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/server"
 	"pkg.world.dev/world-engine/cardinal/shard"
@@ -62,4 +65,9 @@ func WithLoopInterval(interval time.Duration) WorldOption {
 			world.loopInterval = interval
 		},
 	}
+}
+
+func WithPrettyLogOption(world *ecs.World) {
+	prettyLogger := log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	world.Logger.Logger = &prettyLogger
 }


### PR DESCRIPTION
Closes: #CAR-197
## What is the purpose of the change

Option to add pretty logging to cardinal

## Brief Changelog

Just a new function in options.go

## Testing and Verifying

Visually. Changes aren't human readable directly you can only see the results if it's written to os.Stderr. 