### PR TITLE
style(cardinal): make error followed by colon instead of comma

### DIFF
--- a/cardinal/server/handler.go
+++ b/cardinal/server/handler.go
@@ -104,7 +104,7 @@ func (t *Handler) makeSchemaHandler(inSchema, outSchema *jsonschema.Schema) http
 func (t *Handler) processTransaction(tx transaction.ITransaction, payload []byte, sp *sign.SignedPayload) ([]byte, error) {
 	txVal, err := tx.Decode(payload)
 	if err != nil {
-		return nil, fmt.Errorf("unable to decode transaction, %w", err)
+		return nil, fmt.Errorf("unable to decode transaction: %w", err)
 	}
 
 	submitTx := func() (uint64, []byte, error) {
@@ -115,7 +115,7 @@ func (t *Handler) processTransaction(tx transaction.ITransaction, payload []byte
 			Tick:   tick,
 		})
 		if err != nil {
-			return 0, nil, fmt.Errorf("unable to marshal response, %w", err)
+			return 0, nil, fmt.Errorf("unable to marshal response: %w", err)
 		}
 		return tick, res, nil
 	}
@@ -132,7 +132,7 @@ func (t *Handler) processTransaction(tx transaction.ITransaction, payload []byte
 			}
 			err = t.adapter.Submit(context.Background(), sp, uint64(tx.ID()), tick)
 			if err != nil {
-				return nil, fmt.Errorf("error submitting transaction to blockchain, %w", err)
+				return nil, fmt.Errorf("error submitting transaction to blockchain: %w", err)
 			}
 			return res, nil
 		}


### PR DESCRIPTION
## What is the purpose of the change

fixes the styling of how we return errors, usually have them followed by colons, not commas

## Brief Changelog


## Testing and Verifying

