### PR TITLE
fix(cardinal): return 404 for dynamic routes. Added tests to cover this.

### DIFF
--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -99,7 +99,7 @@ func createSwaggerQueryHandler[Request any, Response any](requestName string, re
 	return func(params interface{}) (interface{}, error) {
 		request, ok := getValueFromParams[Request](params, requestName)
 		if !ok {
-			return nil, errors.New(fmt.Sprintf("could not find %s in parameters", requestName))
+			return middleware.Error(404, fmt.Errorf("%s not found", requestName)), nil
 		}
 		resp, err := requestHandler(request)
 		if err != nil {
@@ -206,7 +206,7 @@ func registerTxHandlerSwagger(world *ecs.World, api *untyped.API, handler *Handl
 		}
 		tx, err := getTxFromParams("txType", params, txNameToTx)
 		if err != nil {
-			return nil, err
+			return middleware.Error(404, err), nil
 		}
 		if tx.Name() == ecs.AuthorizePersonaAddressTx.Name() {
 			return nil, fmt.Errorf("This route should not process %s, use tx/persona/%s", tx.Name(), ecs.AuthorizePersonaAddressTx.Name())
@@ -307,7 +307,7 @@ func registerReadHandlerSwagger(world *ecs.World, api *untyped.API, handler *Han
 		}
 		outputType, ok := readNameToReadType[readTypeString]
 		if !ok {
-			return nil, fmt.Errorf(fmt.Sprintf("readType of type %s does not exist", readTypeString))
+			return middleware.Error(404, fmt.Errorf("readType of type %s does not exist", readTypeString)), nil
 		}
 
 		bodyData, ok := mapStruct["readBody"]

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -374,6 +374,13 @@ func TestHandleSwaggerServer(t *testing.T) {
 	assert.NilError(t, err)
 	assert.DeepEqual(t, gotTxReply, expectedTxReply)
 
+	resp5, err := http.Post(txh.makeURL("tx/game/dsakjsdlfksdj"), "application/json", bytes.NewBuffer(signedTxJson))
+	assert.NilError(t, err)
+	assert.Equal(t, resp5.StatusCode, 404)
+	resp6, err := http.Post(txh.makeURL("query/game/sdsdfsdfsdf"), "application/json", bytes.NewBuffer(signedTxJson))
+	assert.NilError(t, err)
+	assert.Equal(t, resp6.StatusCode, 404)
+
 }
 
 func TestHandleWrappedTransactionWithNoSignatureVerification(t *testing.T) {


### PR DESCRIPTION
Closes: #world-298

## What is the purpose of the change

Small bug for swagger dynamic routes returning 500 errors instead of 404 when you put in the wrong dynamic route. 

## Brief Changelog

changed to return 404 instead of error for 2 specific cases. 

## Testing and Verifying

Added two unit tests to test for 404 status code for these specific routes:

`/query/game/<readType>`
`/tx/game/<txType>`