### PR TITLE
feat(cardinal): create parser for component query language.

### DIFF
--- a/cardinal/ecs/cql/cql.go
+++ b/cardinal/ecs/cql/cql.go
@@ -7,70 +7,70 @@ import (
 	"github.com/alecthomas/participle/v2"
 )
 
-type CQLOperator int
+type cqlOperator int
 
 const (
-	OpAnd CQLOperator = iota
-	OpOr
+	opAnd cqlOperator = iota
+	opOr
 )
 
-var operatorMap = map[string]CQLOperator{"&": OpAnd, "|": OpOr}
+var operatorMap = map[string]cqlOperator{"&": opAnd, "|": opOr}
 
-func (o *CQLOperator) Capture(s []string) error {
+func (o *cqlOperator) Capture(s []string) error {
 	*o = operatorMap[s[0]]
 	return nil
 }
 
-type CQLComponent struct {
+type cqlComponent struct {
 	Name string `@Ident`
 }
 
-type CQLNot struct {
-	SubExpression *CQLValue `"!" @@`
+type cqlNot struct {
+	SubExpression *cqlValue `"!" @@`
 }
 
-type CQLExact struct {
-	Components []*CQLComponent `"EXACT""(" (@@",")* @@ ")"`
+type cqlExact struct {
+	Components []*cqlComponent `"EXACT""(" (@@",")* @@ ")"`
 }
 
-type CQLContains struct {
-	Components []*CQLComponent `"CONTAINS" "(" (@@",")* @@ ")"`
+type cqlContains struct {
+	Components []*cqlComponent `"CONTAINS" "(" (@@",")* @@ ")"`
 }
 
-type CQLValue struct {
-	Exact         *CQLExact    `@@`
-	Contains      *CQLContains `| @@`
-	Not           *CQLNot      `| @@`
-	Subexpression *CQLTerm     `| "(" @@ ")"`
+type cqlValue struct {
+	Exact         *cqlExact    `@@`
+	Contains      *cqlContains `| @@`
+	Not           *cqlNot      `| @@`
+	Subexpression *cqlTerm     `| "(" @@ ")"`
 }
 
-type CQLFactor struct {
-	Base *CQLValue `@@`
+type cqlFactor struct {
+	Base *cqlValue `@@`
 }
 
-type CQLOpFactor struct {
-	Operator CQLOperator `@("&" | "|")`
-	Factor   *CQLFactor  `@@`
+type cqlOpFactor struct {
+	Operator cqlOperator `@("&" | "|")`
+	Factor   *cqlFactor  `@@`
 }
 
-type CQLTerm struct {
-	Left  *CQLFactor     `@@`
-	Right []*CQLOpFactor `@@*`
+type cqlTerm struct {
+	Left  *cqlFactor     `@@`
+	Right []*cqlOpFactor `@@*`
 }
 
 // Display
 
-func (o CQLOperator) String() string {
+func (o cqlOperator) String() string {
 	switch o {
-	case OpAnd:
+	case opAnd:
 		return "&"
-	case OpOr:
+	case opOr:
 		return "|"
 	}
 	panic("unsupported operator")
 }
 
-func (e *CQLExact) String() string {
+func (e *cqlExact) String() string {
 	parameters := ""
 	for i, comp := range e.Components {
 		parameters += comp.Name + ", "
@@ -82,7 +82,7 @@ func (e *CQLExact) String() string {
 
 }
 
-func (e *CQLContains) String() string {
+func (e *cqlContains) String() string {
 	parameters := ""
 	for i, comp := range e.Components {
 		parameters += comp.Name
@@ -93,7 +93,7 @@ func (e *CQLContains) String() string {
 	return "CONTAINS(" + parameters + ")"
 }
 
-func (v *CQLValue) String() string {
+func (v *cqlValue) String() string {
 	if v.Exact != nil {
 		parameters := ""
 		for _, comp := range v.Exact.Components {
@@ -115,16 +115,16 @@ func (v *CQLValue) String() string {
 	}
 }
 
-func (f *CQLFactor) String() string {
+func (f *cqlFactor) String() string {
 	out := f.Base.String()
 	return out
 }
 
-func (o *CQLOpFactor) String() string {
+func (o *cqlOpFactor) String() string {
 	return fmt.Sprintf("%s %s", o.Operator, o.Factor)
 }
 
-func (t *CQLTerm) String() string {
+func (t *cqlTerm) String() string {
 	out := []string{t.Left.String()}
 	for _, r := range t.Right {
 		out = append(out, r.String())
@@ -132,4 +132,4 @@ func (t *CQLTerm) String() string {
 	return strings.Join(out, " ")
 }
 
-var CQLParser = participle.MustBuild[CQLTerm]()
+var CQLParser = participle.MustBuild[cqlTerm]()

--- a/cardinal/ecs/cql/cql.go
+++ b/cardinal/ecs/cql/cql.go
@@ -82,7 +82,7 @@ func (o cqlOperator) String() string {
 func (e *cqlExact) String() string {
 	parameters := ""
 	for i, comp := range e.Components {
-		parameters += comp.Name + ", "
+		parameters += comp.Name
 		if i < len(e.Components)-1 {
 			parameters += ", "
 		}
@@ -104,23 +104,15 @@ func (e *cqlContains) String() string {
 
 func (v *cqlValue) String() string {
 	if v.Exact != nil {
-		parameters := ""
-		for _, comp := range v.Exact.Components {
-			parameters += comp.Name + ", "
-		}
-		return "EXACT(" + parameters + ")"
+		return v.Exact.String()
 	} else if v.Contains != nil {
-		parameters := ""
-		for _, comp := range v.Contains.Components {
-			parameters += comp.Name + ", "
-		}
-		return "CONTAINS(" + parameters + ")"
+		return v.Contains.String()
 	} else if v.Not != nil {
 		return "!(" + v.Not.SubExpression.String() + ")"
 	} else if v.Subexpression != nil {
 		return "(" + v.Subexpression.String() + ")"
 	} else {
-		panic("blah")
+		panic("logic error displaying CQL ast. Check the code in cql.go")
 	}
 }
 

--- a/cardinal/ecs/cql/cql.go
+++ b/cardinal/ecs/cql/cql.go
@@ -1,0 +1,135 @@
+package cql
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/alecthomas/participle/v2"
+)
+
+type CQLOperator int
+
+const (
+	OpAnd CQLOperator = iota
+	OpOr
+)
+
+var operatorMap = map[string]CQLOperator{"&": OpAnd, "|": OpOr}
+
+func (o *CQLOperator) Capture(s []string) error {
+	*o = operatorMap[s[0]]
+	return nil
+}
+
+type CQLComponent struct {
+	Name string `@Ident`
+}
+
+type CQLNot struct {
+	SubExpression *CQLValue `"!" @@`
+}
+
+type CQLExact struct {
+	Components []*CQLComponent `"EXACT""(" (@@",")* @@ ")"`
+}
+
+type CQLContains struct {
+	Components []*CQLComponent `"CONTAINS" "(" (@@",")* @@ ")"`
+}
+
+type CQLValue struct {
+	Exact         *CQLExact    `@@`
+	Contains      *CQLContains `| @@`
+	Not           *CQLNot      `| @@`
+	Subexpression *CQLTerm     `| "(" @@ ")"`
+}
+
+type CQLFactor struct {
+	Base *CQLValue `@@`
+}
+
+type CQLOpFactor struct {
+	Operator CQLOperator `@("&" | "|")`
+	Factor   *CQLFactor  `@@`
+}
+
+type CQLTerm struct {
+	Left  *CQLFactor     `@@`
+	Right []*CQLOpFactor `@@*`
+}
+
+// Display
+
+func (o CQLOperator) String() string {
+	switch o {
+	case OpAnd:
+		return "&"
+	case OpOr:
+		return "|"
+	}
+	panic("unsupported operator")
+}
+
+func (e *CQLExact) String() string {
+	parameters := ""
+	for i, comp := range e.Components {
+		parameters += comp.Name + ", "
+		if i < len(e.Components)-1 {
+			parameters += ", "
+		}
+	}
+	return "EXACT(" + parameters + ")"
+
+}
+
+func (e *CQLContains) String() string {
+	parameters := ""
+	for i, comp := range e.Components {
+		parameters += comp.Name
+		if i < len(e.Components)-1 {
+			parameters += ", "
+		}
+	}
+	return "CONTAINS(" + parameters + ")"
+}
+
+func (v *CQLValue) String() string {
+	if v.Exact != nil {
+		parameters := ""
+		for _, comp := range v.Exact.Components {
+			parameters += comp.Name + ", "
+		}
+		return "EXACT(" + parameters + ")"
+	} else if v.Contains != nil {
+		parameters := ""
+		for _, comp := range v.Contains.Components {
+			parameters += comp.Name + ", "
+		}
+		return "CONTAINS(" + parameters + ")"
+	} else if v.Not != nil {
+		return "!(" + v.Not.SubExpression.String() + ")"
+	} else if v.Subexpression != nil {
+		return "(" + v.Subexpression.String() + ")"
+	} else {
+		panic("blah")
+	}
+}
+
+func (f *CQLFactor) String() string {
+	out := f.Base.String()
+	return out
+}
+
+func (o *CQLOpFactor) String() string {
+	return fmt.Sprintf("%s %s", o.Operator, o.Factor)
+}
+
+func (t *CQLTerm) String() string {
+	out := []string{t.Left.String()}
+	for _, r := range t.Right {
+		out = append(out, r.String())
+	}
+	return strings.Join(out, " ")
+}
+
+var CQLParser = participle.MustBuild[CQLTerm]()

--- a/cardinal/ecs/cql/cql.go
+++ b/cardinal/ecs/cql/cql.go
@@ -1,6 +1,7 @@
 package cql
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
@@ -16,8 +17,16 @@ const (
 
 var operatorMap = map[string]cqlOperator{"&": opAnd, "|": opOr}
 
+// Capture basically tells the parser library how to transform a string token that's parsed into the operator type.
 func (o *cqlOperator) Capture(s []string) error {
-	*o = operatorMap[s[0]]
+	if len(s) <= 0 {
+		return errors.New("invalid operator")
+	}
+	operator, ok := operatorMap[s[0]]
+	if !ok {
+		return errors.New("invalid operator")
+	}
+	*o = operator
 	return nil
 }
 

--- a/cardinal/ecs/cql/cql_test.go
+++ b/cardinal/ecs/cql/cql_test.go
@@ -8,27 +8,27 @@ import (
 
 func TestParser(t *testing.T) {
 	term, err := CQLParser.ParseString("", "!(EXACT(a, b) & EXACT(a)) | CONTAINS(b)")
-	testTerm := CQLTerm{
-		Left: &CQLFactor{Base: &CQLValue{
+	testTerm := cqlTerm{
+		Left: &cqlFactor{Base: &cqlValue{
 			Exact:    nil,
 			Contains: nil,
-			Not: &CQLNot{SubExpression: &CQLValue{
+			Not: &cqlNot{SubExpression: &cqlValue{
 				Exact:    nil,
 				Contains: nil,
 				Not:      nil,
-				Subexpression: &CQLTerm{
-					Left: &CQLFactor{Base: &CQLValue{
-						Exact: &CQLExact{Components: []*CQLComponent{
-							&CQLComponent{Name: "a"},
-							&CQLComponent{Name: "b"}}},
+				Subexpression: &cqlTerm{
+					Left: &cqlFactor{Base: &cqlValue{
+						Exact: &cqlExact{Components: []*cqlComponent{
+							&cqlComponent{Name: "a"},
+							&cqlComponent{Name: "b"}}},
 						Contains:      nil,
 						Not:           nil,
 						Subexpression: nil,
 					}},
-					Right: []*CQLOpFactor{&CQLOpFactor{
-						Operator: OpAnd,
-						Factor: &CQLFactor{Base: &CQLValue{
-							Exact:         &CQLExact{Components: []*CQLComponent{&CQLComponent{Name: "a"}}},
+					Right: []*cqlOpFactor{&cqlOpFactor{
+						Operator: opAnd,
+						Factor: &cqlFactor{Base: &cqlValue{
+							Exact:         &cqlExact{Components: []*cqlComponent{&cqlComponent{Name: "a"}}},
 							Contains:      nil,
 							Not:           nil,
 							Subexpression: nil,
@@ -38,12 +38,12 @@ func TestParser(t *testing.T) {
 			}},
 			Subexpression: nil,
 		}},
-		Right: []*CQLOpFactor{
-			&CQLOpFactor{
-				Operator: OpOr,
-				Factor: &CQLFactor{Base: &CQLValue{
+		Right: []*cqlOpFactor{
+			&cqlOpFactor{
+				Operator: opOr,
+				Factor: &cqlFactor{Base: &cqlValue{
 					Exact:         nil,
-					Contains:      &CQLContains{Components: []*CQLComponent{&CQLComponent{Name: "b"}}},
+					Contains:      &cqlContains{Components: []*cqlComponent{&cqlComponent{Name: "b"}}},
 					Not:           nil,
 					Subexpression: nil,
 				}},

--- a/cardinal/ecs/cql/cql_test.go
+++ b/cardinal/ecs/cql/cql_test.go
@@ -1,0 +1,55 @@
+package cql
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestParser(t *testing.T) {
+	term, err := CQLParser.ParseString("", "!(EXACT(a, b) & EXACT(a)) | CONTAINS(b)")
+	testTerm := CQLTerm{
+		Left: &CQLFactor{Base: &CQLValue{
+			Exact:    nil,
+			Contains: nil,
+			Not: &CQLNot{SubExpression: &CQLValue{
+				Exact:    nil,
+				Contains: nil,
+				Not:      nil,
+				Subexpression: &CQLTerm{
+					Left: &CQLFactor{Base: &CQLValue{
+						Exact: &CQLExact{Components: []*CQLComponent{
+							&CQLComponent{Name: "a"},
+							&CQLComponent{Name: "b"}}},
+						Contains:      nil,
+						Not:           nil,
+						Subexpression: nil,
+					}},
+					Right: []*CQLOpFactor{&CQLOpFactor{
+						Operator: OpAnd,
+						Factor: &CQLFactor{Base: &CQLValue{
+							Exact:         &CQLExact{Components: []*CQLComponent{&CQLComponent{Name: "a"}}},
+							Contains:      nil,
+							Not:           nil,
+							Subexpression: nil,
+						}},
+					}},
+				},
+			}},
+			Subexpression: nil,
+		}},
+		Right: []*CQLOpFactor{
+			&CQLOpFactor{
+				Operator: OpOr,
+				Factor: &CQLFactor{Base: &CQLValue{
+					Exact:         nil,
+					Contains:      &CQLContains{Components: []*CQLComponent{&CQLComponent{Name: "b"}}},
+					Not:           nil,
+					Subexpression: nil,
+				}},
+			},
+		},
+	}
+	assert.NilError(t, err)
+	assert.DeepEqual(t, *term, testTerm)
+}

--- a/cardinal/ecs/cql/cql_test.go
+++ b/cardinal/ecs/cql/cql_test.go
@@ -1,6 +1,7 @@
 package cql
 
 import (
+	"fmt"
 	"testing"
 
 	"gotest.tools/v3/assert"
@@ -8,6 +9,7 @@ import (
 
 func TestParser(t *testing.T) {
 	term, err := CQLParser.ParseString("", "!(EXACT(a, b) & EXACT(a)) | CONTAINS(b)")
+	fmt.Println(term.String())
 	testTerm := cqlTerm{
 		Left: &cqlFactor{Base: &cqlValue{
 			Exact:    nil,

--- a/cardinal/ecs/storage/legacy_storage.go
+++ b/cardinal/ecs/storage/legacy_storage.go
@@ -10,7 +10,7 @@ import (
 var _ ComponentStorageManager = &ComponentsSliceStorage{}
 
 // ComponentsSliceStorage is a structure that contains component data in slices.
-// Component data is indexed by component type ID, archetype Index, and finally component Index.
+// CQLComponent data is indexed by component type ID, archetype Index, and finally component Index.
 type ComponentsSliceStorage struct {
 	componentStorages []*ComponentSliceStorage
 }

--- a/cardinal/ecs/storage/legacy_storage.go
+++ b/cardinal/ecs/storage/legacy_storage.go
@@ -10,7 +10,7 @@ import (
 var _ ComponentStorageManager = &ComponentsSliceStorage{}
 
 // ComponentsSliceStorage is a structure that contains component data in slices.
-// CQLComponent data is indexed by component type ID, archetype Index, and finally component Index.
+// Component data is indexed by component type ID, archetype Index, and finally component Index.
 type ComponentsSliceStorage struct {
 	componentStorages []*ComponentSliceStorage
 }

--- a/cardinal/go.mod
+++ b/cardinal/go.mod
@@ -16,6 +16,7 @@ replace (
 require (
 	buf.build/gen/go/argus-labs/world-engine/grpc/go v1.3.0-20230808004839-11a21a99bf62.1
 	buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go v1.31.0-20230808004839-11a21a99bf62.1
+	github.com/alecthomas/participle/v2 v2.1.0
 	github.com/alicebob/miniredis/v2 v2.30.5
 	github.com/cometbft/cometbft v0.38.0-rc3
 	github.com/ethereum/go-ethereum v1.12.0

--- a/cardinal/go.sum
+++ b/cardinal/go.sum
@@ -425,6 +425,12 @@ github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbt
 github.com/PuerkitoBio/urlesc v0.0.0-20170810143723-de5bf2ad4578/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
 github.com/VividCortex/gohistogram v1.0.0 h1:6+hBz+qvs0JOrrNhhmR7lFxo5sINxBCGXrdtl/UvroE=
 github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/4+TcAqDqk/vUH7g=
+github.com/alecthomas/assert/v2 v2.3.0 h1:mAsH2wmvjsuvyBvAmCtm7zFsBlb8mIHx5ySLVdDZXL0=
+github.com/alecthomas/assert/v2 v2.3.0/go.mod h1:pXcQ2Asjp247dahGEmsZ6ru0UVwnkhktn7S0bBDLxvQ=
+github.com/alecthomas/participle/v2 v2.1.0 h1:z7dElHRrOEEq45F2TG5cbQihMtNTv8vwldytDj7Wrz4=
+github.com/alecthomas/participle/v2 v2.1.0/go.mod h1:Y1+hAs8DHPmc3YUFzqllV+eSQ9ljPTk0ZkPMtEdAx2c=
+github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk=
+github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
@@ -867,6 +873,8 @@ github.com/hashicorp/yamux v0.1.1 h1:yrQxtgseBDrq9Y652vSRDvsKCJKOUD+GzTS4Y0Y8pvE
 github.com/hashicorp/yamux v0.1.1/go.mod h1:CtWFDAQgb7dxtzFs4tWbplKIe2jSi3+5vKbgIO0SLnQ=
 github.com/hdevalence/ed25519consensus v0.1.0 h1:jtBwzzcHuTmFrQN6xQZn6CQEO/V9f7HsjsjeEZ6auqU=
 github.com/hdevalence/ed25519consensus v0.1.0/go.mod h1:w3BHWjwJbFU29IRHL1Iqkw3sus+7FctEyM4RqDxYNzo=
+github.com/hexops/gotextdiff v1.0.3 h1:gitA9+qJrrTCsiCl7+kh75nPqQt1cx4ZkudSTLoUqJM=
+github.com/hexops/gotextdiff v1.0.3/go.mod h1:pSWU5MAI3yDq+fZBTazCSJysOMbxWL1BSow5/V2vxeg=
 github.com/holiman/uint256 v1.2.3 h1:K8UWO1HUJpRMXBxbmaY1Y8IAMZC/RsKB+ArEnnK4l5o=
 github.com/holiman/uint256 v1.2.3/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=


### PR DESCRIPTION
Closes: #WORLD-109

## What is the purpose of the change

Adds a parser for a dynamic component query language. The intention of this language is to be parsed into a LayoutFilter type. 

Also branch name is wrong. Please ignore this is referencing WORLD 300, 109 is the EPIC. 

`
!(EXACT(a, b) & EXACT(a)) | CONTAINS(b)
`

CQL stands for component query language. 


## Brief Changelog
Added two files. cql.go and cql_test.go

cql.go generates a parser:  string -> AST


## Testing and Verifying

This expression was tested: 

`!(EXACT(a, b) & EXACT(a)) | CONTAINS(b)` it covers multiple functions contains and exact. It covers & and |. It also covers higher precedence with parenthesis and the NOT (!) operator. 