### PR TITLE
feat(cardinal): fetch component by name.

### DIFF
--- a/cardinal/component.go
+++ b/cardinal/component.go
@@ -27,17 +27,17 @@ func toIComponentType(ins []AnyComponentType) []component.IComponentType {
 
 // NewComponentType creates a new instance of a ComponentType. When this ComponentType is added to an EntityID,
 // the zero value of the T struct will be saved with the entity.
-func NewComponentType[T any]() *ComponentType[T] {
+func NewComponentType[T any](name string) *ComponentType[T] {
 	return &ComponentType[T]{
-		impl: ecs.NewComponentType[T](),
+		impl: ecs.NewComponentType[T](name),
 	}
 }
 
 // NewComponentTypeWithDefault creates a new instance of a ComponentType. When this ComponentType is added to
 // an EntityID, the defaultVal will be saved with the entity.
-func NewComponentTypeWithDefault[T any](defaultVal T) *ComponentType[T] {
+func NewComponentTypeWithDefault[T any](name string, defaultVal T) *ComponentType[T] {
 	return &ComponentType[T]{
-		impl: ecs.NewComponentType[T](ecs.WithDefault(defaultVal)),
+		impl: ecs.NewComponentType[T](name, ecs.WithDefault(defaultVal)),
 	}
 }
 

--- a/cardinal/ecs/component.go
+++ b/cardinal/ecs/component.go
@@ -16,9 +16,9 @@ type IComponentType = component.IComponentType
 
 // NewComponentType creates a new component type.
 // The function is used to create a new component of the type.
-func NewComponentType[T any](opts ...ComponentOption[T]) *ComponentType[T] {
+func NewComponentType[T any](name string, opts ...ComponentOption[T]) *ComponentType[T] {
 	var t T
-	comp := newComponentType(t, nil)
+	comp := newComponentType(t, name, nil)
 	for _, opt := range opts {
 		opt(comp)
 	}
@@ -179,10 +179,10 @@ func (c *ComponentType[T]) validateDefaultVal() {
 
 // newComponentType creates a new component type.
 // The argument is a struct that represents a data of the component.
-func newComponentType[T any](s T, defaultVal interface{}) *ComponentType[T] {
+func newComponentType[T any](s T, name string, defaultVal interface{}) *ComponentType[T] {
 	componentType := &ComponentType[T]{
 		typ:        reflect.TypeOf(s),
-		name:       reflect.TypeOf(s).Name(),
+		name:       name,
 		defaultVal: defaultVal,
 	}
 	componentType.query = NewQuery(filter.Contains(componentType))

--- a/cardinal/ecs/component/components_test.go
+++ b/cardinal/ecs/component/components_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
@@ -104,6 +105,10 @@ func TestErrorWhenAccessingComponentNotOnEntity(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 	foundComp := ecs.NewComponentType[string]()
 	notFoundComp := ecs.NewComponentType[string]()
+
+	foundComp.SetName("foundComp")
+	notFoundComp.SetName("notFoundComp")
+
 	assert.NilError(t, world.RegisterComponents(foundComp, notFoundComp))
 
 	id, err := world.Create(foundComp)

--- a/cardinal/ecs/component/components_test.go
+++ b/cardinal/ecs/component/components_test.go
@@ -103,11 +103,8 @@ func TestComponents(t *testing.T) {
 
 func TestErrorWhenAccessingComponentNotOnEntity(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
-	foundComp := ecs.NewComponentType[string]()
-	notFoundComp := ecs.NewComponentType[string]()
-
-	foundComp.SetName("foundComp")
-	notFoundComp.SetName("notFoundComp")
+	foundComp := ecs.NewComponentType[string]("foundComp")
+	notFoundComp := ecs.NewComponentType[string]("notFoundComp")
 
 	assert.NilError(t, world.RegisterComponents(foundComp, notFoundComp))
 
@@ -122,7 +119,7 @@ func TestMultipleCallsToCreateSupported(t *testing.T) {
 		Val int
 	}
 	world := inmem.NewECSWorldForTest(t)
-	valComp := ecs.NewComponentType[ValueComponent]()
+	valComp := ecs.NewComponentType[ValueComponent]("ValueComponent")
 	assert.NilError(t, world.RegisterComponents(valComp))
 
 	id, err := world.Create(valComp)

--- a/cardinal/ecs/cql/cql_test.go
+++ b/cardinal/ecs/cql/cql_test.go
@@ -60,7 +60,7 @@ func TestParser(t *testing.T) {
 	assert.NilError(t, err)
 	assert.DeepEqual(t, *term, testTerm)
 
-	emptyComponent := ecs.NewComponentType[struct{}]()
+	emptyComponent := ecs.NewComponentType[struct{}]("emptyComponent")
 	stringToComponent := func(_ string) component.IComponentType {
 		return emptyComponent
 	}

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -44,8 +44,8 @@ func UpdateEnergySystem(w *ecs.World, tq *ecs.TransactionQueue, _ *ecs.Logger) e
 }
 
 var (
-	Energy  = ecs.NewComponentType[EnergyComponent]()
-	Ownable = ecs.NewComponentType[OwnableComponent]()
+	Energy  = ecs.NewComponentType[EnergyComponent]("EnergyComponent")
+	Ownable = ecs.NewComponentType[OwnableComponent]("OwnableComponent")
 )
 
 func TestECS(t *testing.T) {
@@ -90,8 +90,8 @@ func TestVelocitySimulation(t *testing.T) {
 		DX, DY float64
 	}
 	// These components are a mix of concrete types and pointer types to make sure they both work
-	Position := ecs.NewComponentType[Pos]()
-	Velocity := ecs.NewComponentType[*Vel]()
+	Position := ecs.NewComponentType[Pos]("Position")
+	Velocity := ecs.NewComponentType[*Vel]("Velocity")
 	assert.NilError(t, world.RegisterComponents(Position, Velocity))
 	assert.NilError(t, world.LoadGameState())
 
@@ -122,7 +122,7 @@ func TestCanSetDefaultValue(t *testing.T) {
 		Name string
 	}
 	wantOwner := Owner{"Jeff"}
-	owner := ecs.NewComponentType[Owner](ecs.WithDefault(wantOwner))
+	owner := ecs.NewComponentType[Owner]("owner", ecs.WithDefault(wantOwner))
 	assert.NilError(t, world.RegisterComponents(owner))
 	assert.NilError(t, world.LoadGameState())
 
@@ -146,7 +146,7 @@ func TestCanRemoveEntity(t *testing.T) {
 		A, B int
 	}
 
-	tuple := ecs.NewComponentType[Tuple]()
+	tuple := ecs.NewComponentType[Tuple]("tuple")
 	assert.NilError(t, world.RegisterComponents(tuple))
 	assert.NilError(t, world.LoadGameState())
 
@@ -202,7 +202,7 @@ func TestCanRemoveEntriesDuringCallToEach(t *testing.T) {
 	type CountComponent struct {
 		Val int
 	}
-	Count := ecs.NewComponentType[CountComponent]()
+	Count := ecs.NewComponentType[CountComponent]("Count")
 	assert.NilError(t, world.RegisterComponents(Count))
 	assert.NilError(t, world.LoadGameState())
 
@@ -246,7 +246,7 @@ func TestCanRemoveEntriesDuringCallToEach(t *testing.T) {
 
 func TestAddingAComponentThatAlreadyExistsIsError(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
-	energy := ecs.NewComponentType[EnergyComponent]()
+	energy := ecs.NewComponentType[EnergyComponent]("energy")
 	assert.NilError(t, world.RegisterComponents(energy))
 	assert.NilError(t, world.LoadGameState())
 
@@ -257,10 +257,8 @@ func TestAddingAComponentThatAlreadyExistsIsError(t *testing.T) {
 
 func TestRemovingAMissingComponentIsError(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
-	reactorEnergy := ecs.NewComponentType[EnergyComponent]()
-	weaponsEnergy := ecs.NewComponentType[EnergyComponent]()
-	reactorEnergy.SetName("reactorEnergy")
-	weaponsEnergy.SetName("weaponsEnergy")
+	reactorEnergy := ecs.NewComponentType[EnergyComponent]("reactorEnergy")
+	weaponsEnergy := ecs.NewComponentType[EnergyComponent]("weaponsEnergy")
 	assert.NilError(t, world.RegisterComponents(reactorEnergy, weaponsEnergy))
 	assert.NilError(t, world.LoadGameState())
 	ent, err := world.Create(reactorEnergy)
@@ -273,7 +271,7 @@ func TestVerifyAutomaticCreationOfArchetypesWorks(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 	type Foo struct{}
 	type Bar struct{}
-	a, b := ecs.NewComponentType[Foo](), ecs.NewComponentType[Bar]()
+	a, b := ecs.NewComponentType[Foo]("a"), ecs.NewComponentType[Bar]("b")
 	assert.NilError(t, world.RegisterComponents(a, b))
 	assert.NilError(t, world.LoadGameState())
 
@@ -300,12 +298,9 @@ func TestEntriesCanChangeTheirArchetype(t *testing.T) {
 	type Label struct {
 		Name string
 	}
-	alpha := ecs.NewComponentType[Label](ecs.WithDefault(Label{"alpha"}))
-	beta := ecs.NewComponentType[Label](ecs.WithDefault(Label{"beta"}))
-	gamma := ecs.NewComponentType[Label](ecs.WithDefault(Label{"gamma"}))
-	alpha.SetName("alpha")
-	beta.SetName("beta")
-	gamma.SetName("gamma")
+	alpha := ecs.NewComponentType[Label]("alpha", ecs.WithDefault(Label{"alpha"}))
+	beta := ecs.NewComponentType[Label]("beta", ecs.WithDefault(Label{"beta"}))
+	gamma := ecs.NewComponentType[Label]("game", ecs.WithDefault(Label{"gamma"}))
 	assert.NilError(t, world.RegisterComponents(alpha, beta, gamma))
 	assert.NilError(t, world.LoadGameState())
 
@@ -351,10 +346,8 @@ func TestEntriesCanChangeTheirArchetype(t *testing.T) {
 func TestCannotSetComponentThatDoesNotBelongToEntity(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 
-	alpha := ecs.NewComponentType[EnergyComponent]()
-	beta := ecs.NewComponentType[EnergyComponent]()
-	alpha.SetName("alpha")
-	beta.SetName("beta")
+	alpha := ecs.NewComponentType[EnergyComponent]("alpha")
+	beta := ecs.NewComponentType[EnergyComponent]("beta")
 	assert.NilError(t, world.RegisterComponents(alpha, beta))
 	assert.NilError(t, world.LoadGameState())
 
@@ -367,11 +360,7 @@ func TestCannotSetComponentThatDoesNotBelongToEntity(t *testing.T) {
 
 func TestQueriesAndFiltersWorks(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
-	a, b, c, d := ecs.NewComponentType[int](), ecs.NewComponentType[int](), ecs.NewComponentType[int](), ecs.NewComponentType[int]()
-	a.SetName("a")
-	b.SetName("b")
-	c.SetName("c")
-	d.SetName("d")
+	a, b, c, d := ecs.NewComponentType[int]("a"), ecs.NewComponentType[int]("b"), ecs.NewComponentType[int]("c"), ecs.NewComponentType[int]("d")
 	assert.NilError(t, world.RegisterComponents(a, b, c, d))
 	assert.NilError(t, world.LoadGameState())
 
@@ -406,7 +395,7 @@ func TestUpdateWithPointerType(t *testing.T) {
 		HP int
 	}
 	world := inmem.NewECSWorldForTest(t)
-	hpComp := ecs.NewComponentType[*HealthComponent]()
+	hpComp := ecs.NewComponentType[*HealthComponent]("hpComp")
 	assert.NilError(t, world.RegisterComponents(hpComp))
 	assert.NilError(t, world.LoadGameState())
 
@@ -431,7 +420,7 @@ func TestCanRemoveFirstEntity(t *testing.T) {
 		Val int
 	}
 	world := inmem.NewECSWorldForTest(t)
-	valComp := ecs.NewComponentType[ValueComponent]()
+	valComp := ecs.NewComponentType[ValueComponent]("valComp")
 	assert.NilError(t, world.RegisterComponents(valComp))
 
 	ids, err := world.CreateMany(3, valComp)
@@ -459,8 +448,8 @@ func TestCanChangeArchetypeOfFirstEntity(t *testing.T) {
 		Val int
 	}
 	world := inmem.NewECSWorldForTest(t)
-	valComp := ecs.NewComponentType[ValueComponent]()
-	otherComp := ecs.NewComponentType[OtherComponent]()
+	valComp := ecs.NewComponentType[ValueComponent]("valComp")
+	otherComp := ecs.NewComponentType[OtherComponent]("otherComp")
 	assert.NilError(t, world.RegisterComponents(valComp, otherComp))
 
 	ids, err := world.CreateMany(3, valComp)

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -76,6 +76,9 @@ func TestECS(t *testing.T) {
 	q := ecs.NewQuery(filter.Or(filter.Contains(Energy), filter.Contains(Ownable)))
 	amt := q.Count(world)
 	assert.Equal(t, numPlanets+numEnergyOnly, amt)
+	comp, exists := world.GetComponentByName("EnergyComponent")
+	assert.Assert(t, exists)
+	assert.Equal(t, comp.Name(), Energy.Name())
 }
 
 func TestVelocitySimulation(t *testing.T) {

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -259,6 +259,8 @@ func TestRemovingAMissingComponentIsError(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 	reactorEnergy := ecs.NewComponentType[EnergyComponent]()
 	weaponsEnergy := ecs.NewComponentType[EnergyComponent]()
+	reactorEnergy.SetName("reactorEnergy")
+	weaponsEnergy.SetName("weaponsEnergy")
 	assert.NilError(t, world.RegisterComponents(reactorEnergy, weaponsEnergy))
 	assert.NilError(t, world.LoadGameState())
 	ent, err := world.Create(reactorEnergy)
@@ -301,6 +303,9 @@ func TestEntriesCanChangeTheirArchetype(t *testing.T) {
 	alpha := ecs.NewComponentType[Label](ecs.WithDefault(Label{"alpha"}))
 	beta := ecs.NewComponentType[Label](ecs.WithDefault(Label{"beta"}))
 	gamma := ecs.NewComponentType[Label](ecs.WithDefault(Label{"gamma"}))
+	alpha.SetName("alpha")
+	beta.SetName("beta")
+	gamma.SetName("gamma")
 	assert.NilError(t, world.RegisterComponents(alpha, beta, gamma))
 	assert.NilError(t, world.LoadGameState())
 
@@ -348,6 +353,8 @@ func TestCannotSetComponentThatDoesNotBelongToEntity(t *testing.T) {
 
 	alpha := ecs.NewComponentType[EnergyComponent]()
 	beta := ecs.NewComponentType[EnergyComponent]()
+	alpha.SetName("alpha")
+	beta.SetName("beta")
 	assert.NilError(t, world.RegisterComponents(alpha, beta))
 	assert.NilError(t, world.LoadGameState())
 
@@ -361,6 +368,10 @@ func TestCannotSetComponentThatDoesNotBelongToEntity(t *testing.T) {
 func TestQueriesAndFiltersWorks(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 	a, b, c, d := ecs.NewComponentType[int](), ecs.NewComponentType[int](), ecs.NewComponentType[int](), ecs.NewComponentType[int]()
+	a.SetName("a")
+	b.SetName("b")
+	c.SetName("c")
+	d.SetName("d")
 	assert.NilError(t, world.RegisterComponents(a, b, c, d))
 	assert.NilError(t, world.LoadGameState())
 

--- a/cardinal/ecs/filter/filter_test.go
+++ b/cardinal/ecs/filter/filter_test.go
@@ -15,13 +15,9 @@ import (
 func TestCanFilterByArchetype(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 
-	alpha := ecs.NewComponentType[string]()
-	beta := ecs.NewComponentType[string]()
-	gamma := ecs.NewComponentType[string]()
-
-	alpha.SetName("alpha")
-	beta.SetName("beta")
-	gamma.SetName("gamma")
+	alpha := ecs.NewComponentType[string]("alpha")
+	beta := ecs.NewComponentType[string]("beta")
+	gamma := ecs.NewComponentType[string]("gamma")
 
 	assert.NilError(t, world.RegisterComponents(alpha, beta, gamma))
 	assert.NilError(t, world.LoadGameState())
@@ -52,8 +48,8 @@ func TestCanFilterByArchetype(t *testing.T) {
 // with the same parameters.
 func TestExactVsContains(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
-	alpha := ecs.NewComponentType[string]()
-	beta := ecs.NewComponentType[string]()
+	alpha := ecs.NewComponentType[string]("alpha")
+	beta := ecs.NewComponentType[string]("beta")
 	alphaCount := 75
 	_, err := world.CreateMany(alphaCount, alpha)
 	assert.NilError(t, err)
@@ -103,10 +99,8 @@ func TestExactVsContains(t *testing.T) {
 
 func TestCanGetArchetypeFromEntity(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
-	alpha := ecs.NewComponentType[string]()
-	beta := ecs.NewComponentType[string]()
-	alpha.SetName("alpha")
-	beta.SetName("beta")
+	alpha := ecs.NewComponentType[string]("alpha")
+	beta := ecs.NewComponentType[string]("beta")
 	assert.NilError(t, world.RegisterComponents(alpha, beta))
 	assert.NilError(t, world.LoadGameState())
 
@@ -133,7 +127,7 @@ func TestCanGetArchetypeFromEntity(t *testing.T) {
 func BenchmarkEntityCreation(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		world := inmem.NewECSWorldForTest(b)
-		alpha := ecs.NewComponentType[string]()
+		alpha := ecs.NewComponentType[string]("alpha")
 		assert.NilError(b, world.RegisterComponents(alpha))
 		assert.NilError(b, world.LoadGameState())
 		_, err := world.CreateMany(100000, alpha)
@@ -157,8 +151,8 @@ func BenchmarkFilterByArchetypeIsNotImpactedByTotalEntityCount(b *testing.B) {
 func helperArchetypeFilter(b *testing.B, relevantCount, ignoreCount int) {
 	b.StopTimer()
 	world := inmem.NewECSWorldForTest(b)
-	alpha := ecs.NewComponentType[string]()
-	beta := ecs.NewComponentType[string]()
+	alpha := ecs.NewComponentType[string]("alpha")
+	beta := ecs.NewComponentType[string]("beta")
 	assert.NilError(b, world.RegisterComponents(alpha, beta))
 	assert.NilError(b, world.LoadGameState())
 	_, err := world.CreateMany(relevantCount, alpha, beta)

--- a/cardinal/ecs/filter/filter_test.go
+++ b/cardinal/ecs/filter/filter_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
@@ -17,6 +18,10 @@ func TestCanFilterByArchetype(t *testing.T) {
 	alpha := ecs.NewComponentType[string]()
 	beta := ecs.NewComponentType[string]()
 	gamma := ecs.NewComponentType[string]()
+
+	alpha.SetName("alpha")
+	beta.SetName("beta")
+	gamma.SetName("gamma")
 
 	assert.NilError(t, world.RegisterComponents(alpha, beta, gamma))
 	assert.NilError(t, world.LoadGameState())
@@ -100,6 +105,8 @@ func TestCanGetArchetypeFromEntity(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 	alpha := ecs.NewComponentType[string]()
 	beta := ecs.NewComponentType[string]()
+	alpha.SetName("alpha")
+	beta.SetName("beta")
 	assert.NilError(t, world.RegisterComponents(alpha, beta))
 	assert.NilError(t, world.LoadGameState())
 

--- a/cardinal/ecs/log_test.go
+++ b/cardinal/ecs/log_test.go
@@ -4,16 +4,18 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
-	"gotest.tools/v3/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
-	"strings"
-	"testing"
-	"time"
 )
 
 type SendEnergyTx struct {
@@ -27,7 +29,7 @@ type EnergyComp struct {
 	value int
 }
 
-var energy = ecs.NewComponentType[EnergyComp]()
+var energy = ecs.NewComponentType[EnergyComp]("EnergyComp")
 
 func testSystem(w *ecs.World, _ *ecs.TransactionQueue, logger *ecs.Logger) error {
 	logger.Log().Msg("test")

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -90,7 +90,7 @@ type SignerComponent struct {
 }
 
 // SignerComp is the concrete ECS component that pairs a persona tag to a signer address.
-var SignerComp = NewComponentType[SignerComponent]()
+var SignerComp = NewComponentType[SignerComponent]("SignerComponent")
 
 type personaTagComponentData struct {
 	SignerAddress string

--- a/cardinal/ecs/query_test.go
+++ b/cardinal/ecs/query_test.go
@@ -1,19 +1,21 @@
 package ecs_test
 
 import (
+	"testing"
+
 	"gotest.tools/v3/assert"
+
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
-	"testing"
 )
 
 func TestQueryEarlyTermination(t *testing.T) {
 	type FooComponent struct {
 		Data string
 	}
-	foo := ecs.NewComponentType[FooComponent]()
+	foo := ecs.NewComponentType[FooComponent]("foo")
 	world := inmem.NewECSWorldForTest(t)
 	assert.NilError(t, world.RegisterComponents(foo))
 

--- a/cardinal/ecs/state_test.go
+++ b/cardinal/ecs/state_test.go
@@ -4,8 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/alicebob/miniredis/v2"
 	"gotest.tools/v3/assert"
+
+	"github.com/alicebob/miniredis/v2"
 	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
@@ -55,6 +56,8 @@ func TestErrorWhenSavedArchetypesDoNotMatchComponentTypes(t *testing.T) {
 	threeWorld := testutil.InitWorldWithRedis(t, redisStore)
 	threeAlphaNum := ecs.NewComponentType[NumberComponent]()
 	threeBetaNum := ecs.NewComponentType[NumberComponent]()
+	threeBetaNum.SetName("threeBetaNum")
+	threeAlphaNum.SetName("threeAlphaNum")
 	assert.NilError(t, threeWorld.RegisterComponents(threeAlphaNum, threeBetaNum))
 	assert.NilError(t, threeWorld.LoadGameState())
 
@@ -103,6 +106,8 @@ func TestCanRecoverArchetypeInformationAfterLoad(t *testing.T) {
 	oneWorld := testutil.InitWorldWithRedis(t, redisStore)
 	oneAlphaNum := ecs.NewComponentType[NumberComponent]()
 	oneBetaNum := ecs.NewComponentType[NumberComponent]()
+	oneAlphaNum.SetName("oneAlphaNum")
+	oneBetaNum.SetName("OneBetaNum")
 	assert.NilError(t, oneWorld.RegisterComponents(oneAlphaNum, oneBetaNum))
 	assert.NilError(t, oneWorld.LoadGameState())
 
@@ -129,6 +134,8 @@ func TestCanRecoverArchetypeInformationAfterLoad(t *testing.T) {
 	twoAlphaNum := ecs.NewComponentType[NumberComponent]()
 	twoBetaNum := ecs.NewComponentType[NumberComponent]()
 	// The ordering of registering these components is important. It must match the ordering above.
+	twoAlphaNum.SetName("towAlphaNum")
+	twoBetaNum.SetName("towBetaNum")
 	assert.NilError(t, twoWorld.RegisterComponents(twoAlphaNum, twoBetaNum))
 	assert.NilError(t, twoWorld.LoadGameState())
 
@@ -151,6 +158,8 @@ func TestCanRecoverArchetypeInformationAfterLoad(t *testing.T) {
 	threeAlphaNum := ecs.NewComponentType[NumberComponent]()
 	threeBetaNum := ecs.NewComponentType[NumberComponent]()
 	// Again, the ordering of registering these components is important. It must match the ordering above
+	threeAlphaNum.SetName("threeAlphaNum")
+	threeBetaNum.SetName("threeBetaNum")
 	assert.NilError(t, threeWorld.RegisterComponents(threeAlphaNum, threeBetaNum))
 	assert.NilError(t, threeWorld.LoadGameState())
 

--- a/cardinal/ecs/state_test.go
+++ b/cardinal/ecs/state_test.go
@@ -37,7 +37,7 @@ func TestErrorWhenSavedArchetypesDoNotMatchComponentTypes(t *testing.T) {
 	redisStore := miniredis.RunT(t)
 
 	oneWorld := testutil.InitWorldWithRedis(t, redisStore)
-	oneAlphaNum := ecs.NewComponentType[NumberComponent]()
+	oneAlphaNum := ecs.NewComponentType[NumberComponent]("oneAlphaNum")
 	assert.NilError(t, oneWorld.RegisterComponents(oneAlphaNum))
 	assert.NilError(t, oneWorld.LoadGameState())
 
@@ -54,16 +54,14 @@ func TestErrorWhenSavedArchetypesDoNotMatchComponentTypes(t *testing.T) {
 
 	// It's ok to register extra components.
 	threeWorld := testutil.InitWorldWithRedis(t, redisStore)
-	threeAlphaNum := ecs.NewComponentType[NumberComponent]()
-	threeBetaNum := ecs.NewComponentType[NumberComponent]()
-	threeBetaNum.SetName("threeBetaNum")
-	threeAlphaNum.SetName("threeAlphaNum")
+	threeAlphaNum := ecs.NewComponentType[NumberComponent]("threeAlphaNum")
+	threeBetaNum := ecs.NewComponentType[NumberComponent]("threeBetaNum")
 	assert.NilError(t, threeWorld.RegisterComponents(threeAlphaNum, threeBetaNum))
 	assert.NilError(t, threeWorld.LoadGameState())
 
 	// Just the right number of components registered
 	fourWorld := testutil.InitWorldWithRedis(t, redisStore)
-	fourAlphaNum := ecs.NewComponentType[NumberComponent]()
+	fourAlphaNum := ecs.NewComponentType[NumberComponent]("foundAlphaNum")
 	assert.NilError(t, fourWorld.RegisterComponents(fourAlphaNum))
 	assert.NilError(t, fourWorld.LoadGameState())
 }
@@ -71,7 +69,7 @@ func TestErrorWhenSavedArchetypesDoNotMatchComponentTypes(t *testing.T) {
 func TestArchetypeIDIsConsistentAfterSaveAndLoad(t *testing.T) {
 	redisStore := miniredis.RunT(t)
 	oneWorld := testutil.InitWorldWithRedis(t, redisStore)
-	oneNum := ecs.NewComponentType[NumberComponent]()
+	oneNum := ecs.NewComponentType[NumberComponent]("oneNum")
 	assert.NilError(t, oneWorld.RegisterComponents(oneNum))
 	assert.NilError(t, oneWorld.LoadGameState())
 
@@ -87,7 +85,7 @@ func TestArchetypeIDIsConsistentAfterSaveAndLoad(t *testing.T) {
 
 	// Make a second instance of the world using the same storage.
 	twoWorld := testutil.InitWorldWithRedis(t, redisStore)
-	twoNum := ecs.NewComponentType[NumberComponent]()
+	twoNum := ecs.NewComponentType[NumberComponent]("twoNum")
 	assert.NilError(t, twoWorld.RegisterComponents(twoNum))
 	assert.NilError(t, twoWorld.LoadGameState())
 
@@ -104,10 +102,8 @@ func TestCanRecoverArchetypeInformationAfterLoad(t *testing.T) {
 	redisStore := miniredis.RunT(t)
 
 	oneWorld := testutil.InitWorldWithRedis(t, redisStore)
-	oneAlphaNum := ecs.NewComponentType[NumberComponent]()
-	oneBetaNum := ecs.NewComponentType[NumberComponent]()
-	oneAlphaNum.SetName("oneAlphaNum")
-	oneBetaNum.SetName("OneBetaNum")
+	oneAlphaNum := ecs.NewComponentType[NumberComponent]("oneAlphaNum")
+	oneBetaNum := ecs.NewComponentType[NumberComponent]("oneBetaNum")
 	assert.NilError(t, oneWorld.RegisterComponents(oneAlphaNum, oneBetaNum))
 	assert.NilError(t, oneWorld.LoadGameState())
 
@@ -131,11 +127,9 @@ func TestCanRecoverArchetypeInformationAfterLoad(t *testing.T) {
 	// Create a brand new world, but use the original redis store. We should be able to load
 	// the game state from the redis store (including archetype indices).
 	twoWorld := testutil.InitWorldWithRedis(t, redisStore)
-	twoAlphaNum := ecs.NewComponentType[NumberComponent]()
-	twoBetaNum := ecs.NewComponentType[NumberComponent]()
+	twoAlphaNum := ecs.NewComponentType[NumberComponent]("towAlphaNum")
+	twoBetaNum := ecs.NewComponentType[NumberComponent]("twoBetaNum")
 	// The ordering of registering these components is important. It must match the ordering above.
-	twoAlphaNum.SetName("towAlphaNum")
-	twoBetaNum.SetName("towBetaNum")
 	assert.NilError(t, twoWorld.RegisterComponents(twoAlphaNum, twoBetaNum))
 	assert.NilError(t, twoWorld.LoadGameState())
 
@@ -155,11 +149,9 @@ func TestCanRecoverArchetypeInformationAfterLoad(t *testing.T) {
 	assert.NilError(t, twoWorld.Tick(context.Background()))
 
 	threeWorld := testutil.InitWorldWithRedis(t, redisStore)
-	threeAlphaNum := ecs.NewComponentType[NumberComponent]()
-	threeBetaNum := ecs.NewComponentType[NumberComponent]()
+	threeAlphaNum := ecs.NewComponentType[NumberComponent]("threeAlphaNum")
+	threeBetaNum := ecs.NewComponentType[NumberComponent]("threeBetaNum")
 	// Again, the ordering of registering these components is important. It must match the ordering above
-	threeAlphaNum.SetName("threeAlphaNum")
-	threeBetaNum.SetName("threeBetaNum")
 	assert.NilError(t, threeWorld.RegisterComponents(threeAlphaNum, threeBetaNum))
 	assert.NilError(t, threeWorld.LoadGameState())
 
@@ -175,7 +167,7 @@ func TestCanRecoverArchetypeInformationAfterLoad(t *testing.T) {
 func TestCanReloadState(t *testing.T) {
 	redisStore := miniredis.RunT(t)
 	alphaWorld := testutil.InitWorldWithRedis(t, redisStore)
-	oneAlphaNum := ecs.NewComponentType[NumberComponent]()
+	oneAlphaNum := ecs.NewComponentType[NumberComponent]("oneAlphaNum")
 	assert.NilError(t, alphaWorld.RegisterComponents(oneAlphaNum))
 
 	_, err := alphaWorld.CreateMany(10, oneAlphaNum)
@@ -195,7 +187,7 @@ func TestCanReloadState(t *testing.T) {
 
 	// Make a new world, using the original redis DB that (hopefully) has our data
 	betaWorld := testutil.InitWorldWithRedis(t, redisStore)
-	oneBetaNum := ecs.NewComponentType[NumberComponent]()
+	oneBetaNum := ecs.NewComponentType[NumberComponent]("oneBetaNum")
 	assert.NilError(t, betaWorld.RegisterComponents(oneBetaNum))
 	assert.NilError(t, betaWorld.LoadGameState())
 

--- a/cardinal/ecs/tick_test.go
+++ b/cardinal/ecs/tick_test.go
@@ -3,11 +3,13 @@ package ecs_test
 import (
 	"context"
 	"errors"
-	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
 	"testing"
 
-	"github.com/alicebob/miniredis/v2"
+	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
+
 	"gotest.tools/v3/assert"
+
+	"github.com/alicebob/miniredis/v2"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
@@ -148,6 +150,8 @@ func TestCanRecoverStateAfterFailedArchetypeChange(t *testing.T) {
 		world := testutil.InitWorldWithRedis(t, rs)
 		static := ecs.NewComponentType[ScalarComponent]()
 		toggle := ecs.NewComponentType[ScalarComponent]()
+		static.SetName("static")
+		toggle.SetName("toggle")
 		assert.NilError(t, world.RegisterComponents(static, toggle))
 
 		if firstWorldIteration {

--- a/cardinal/ecs/tick_test.go
+++ b/cardinal/ecs/tick_test.go
@@ -19,7 +19,7 @@ import (
 func TestTickHappyPath(t *testing.T) {
 	rs := miniredis.RunT(t)
 	oneWorld := testutil.InitWorldWithRedis(t, rs)
-	oneEnergy := ecs.NewComponentType[EnergyComponent]()
+	oneEnergy := ecs.NewComponentType[EnergyComponent]("oneEnergy")
 	assert.NilError(t, oneWorld.RegisterComponents(oneEnergy))
 	assert.NilError(t, oneWorld.LoadGameState())
 
@@ -30,7 +30,7 @@ func TestTickHappyPath(t *testing.T) {
 	assert.Equal(t, uint64(10), oneWorld.CurrentTick())
 
 	twoWorld := testutil.InitWorldWithRedis(t, rs)
-	twoEnergy := ecs.NewComponentType[EnergyComponent]()
+	twoEnergy := ecs.NewComponentType[EnergyComponent]("twoEnergy")
 	assert.NilError(t, twoWorld.RegisterComponents(twoEnergy))
 	assert.NilError(t, twoWorld.LoadGameState())
 	assert.Equal(t, uint64(10), twoWorld.CurrentTick())
@@ -43,7 +43,7 @@ func TestCanIdentifyAndFixSystemError(t *testing.T) {
 
 	rs := miniredis.RunT(t)
 	oneWorld := testutil.InitWorldWithRedis(t, rs)
-	onePower := ecs.NewComponentType[PowerComponent]()
+	onePower := ecs.NewComponentType[PowerComponent]("onePower")
 	assert.NilError(t, oneWorld.RegisterComponents(onePower))
 
 	id, err := oneWorld.Create(onePower)
@@ -74,7 +74,7 @@ func TestCanIdentifyAndFixSystemError(t *testing.T) {
 
 	// Set up a new world using the same storage layer
 	twoWorld := testutil.InitWorldWithRedis(t, rs)
-	twoPower := ecs.NewComponentType[*PowerComponent]()
+	twoPower := ecs.NewComponentType[*PowerComponent]("twoPower")
 	assert.NilError(t, twoWorld.RegisterComponents(twoPower))
 
 	// this is our fixed system that can handle Power levels of 3 and higher
@@ -105,8 +105,8 @@ func TestCanModifyArchetypeAndGetEntity(t *testing.T) {
 		Val int
 	}
 	world := inmem.NewECSWorldForTest(t)
-	alpha := ecs.NewComponentType[ScalarComponent]()
-	beta := ecs.NewComponentType[ScalarComponent]()
+	alpha := ecs.NewComponentType[ScalarComponent]("alpha")
+	beta := ecs.NewComponentType[ScalarComponent]("beta")
 	assert.NilError(t, world.RegisterComponents(alpha))
 	assert.NilError(t, world.LoadGameState())
 
@@ -148,10 +148,8 @@ func TestCanRecoverStateAfterFailedArchetypeChange(t *testing.T) {
 	rs := miniredis.RunT(t)
 	for _, firstWorldIteration := range []bool{true, false} {
 		world := testutil.InitWorldWithRedis(t, rs)
-		static := ecs.NewComponentType[ScalarComponent]()
-		toggle := ecs.NewComponentType[ScalarComponent]()
-		static.SetName("static")
-		toggle.SetName("toggle")
+		static := ecs.NewComponentType[ScalarComponent]("static")
+		toggle := ecs.NewComponentType[ScalarComponent]("toggle")
 		assert.NilError(t, world.RegisterComponents(static, toggle))
 
 		if firstWorldIteration {
@@ -218,7 +216,7 @@ func TestCanRecoverTransactionsFromFailedSystemRun(t *testing.T) {
 	for _, isBuggyIteration := range []bool{true, false} {
 		world := testutil.InitWorldWithRedis(t, rs)
 
-		powerComp := ecs.NewComponentType[FloatValue]()
+		powerComp := ecs.NewComponentType[FloatValue]("powerComp")
 		assert.NilError(t, world.RegisterComponents(powerComp))
 
 		powerTx := ecs.NewTransactionType[FloatValue, FloatValue]("change_power")

--- a/cardinal/ecs/transaction/transaction_test.go
+++ b/cardinal/ecs/transaction/transaction_test.go
@@ -29,7 +29,7 @@ func TestCanQueueTransactions(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 
 	// Create an entity with a score component
-	score := ecs.NewComponentType[*ScoreComponent]()
+	score := ecs.NewComponentType[*ScoreComponent]("score")
 	assert.NilError(t, world.RegisterComponents(score))
 	modifyScoreTx := ecs.NewTransactionType[*ModifyScoreTx, *EmptyTxResult]("modify_score")
 	assert.NilError(t, world.RegisterTransactions(modifyScoreTx))
@@ -85,7 +85,7 @@ func TestSystemsAreExecutedDuringGameTick(t *testing.T) {
 	type CounterComponent struct {
 		Count int
 	}
-	count := ecs.NewComponentType[CounterComponent]()
+	count := ecs.NewComponentType[CounterComponent]("count")
 	assert.NilError(t, world.RegisterComponents(count))
 
 	id, err := world.Create(count)
@@ -109,7 +109,7 @@ func TestSystemsAreExecutedDuringGameTick(t *testing.T) {
 
 func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
-	alphaScore := ecs.NewComponentType[ScoreComponent]()
+	alphaScore := ecs.NewComponentType[ScoreComponent]("alphaScore")
 	assert.NilError(t, world.RegisterComponents(alphaScore))
 
 	modifyScoreTx := ecs.NewTransactionType[*ModifyScoreTx, *EmptyTxResult]("modify_score")


### PR DESCRIPTION
Closes: #WORLD-299

## What is the purpose of the change

Allow fetching component by name. 

Currently many tests don't utilize the component name, additionally names now have to be unique. 

This issue is worth a conversation about usage of component names. Right now component names live in code as types and don't really exist in run time. There is a property called "Names" but I don't know how often that's used as uniqueness and explicit naming isn't enforced. There is a bit of reflection to sometimes match the type name but this isn't enforced strictly either and the results aren't always unique. 

I'm putting this up as a PR for now. It could change depending on the conversation.

I think this is worth a bit of a conversation then writing a secondary issue on top of this. Will bring it up on next stand up then update this. 

## Brief Changelog

Adds a new map to World that associates name with IComponent. 

Added some tests to verify fetching of the component, and changed a lot of tests to make sure all components had unique names. 

Relevant files:

cardinal/ecs/world.go
cardinal/component.go

All the other changes are just fixing the tests because of the signature change. 