### PR TITLE
chore(ci): fix test dependency - ginkgo

### DIFF
--- a/magefiles/setup/setup.go
+++ b/magefiles/setup/setup.go
@@ -48,7 +48,8 @@ var (
 
 	// allTools = []string{buf, gosec, golangcilint, addlicense,
 	// moq, ginkgo, golines, rlpgen, abigen, gci}
-	allTools []string
+	
+	allTools []string{ginkgo}
 )
 
 // Setup runs the setup script for the current OS.

--- a/magefiles/setup/setup.go
+++ b/magefiles/setup/setup.go
@@ -48,8 +48,8 @@ var (
 
 	// allTools = []string{buf, gosec, golangcilint, addlicense,
 	// moq, ginkgo, golines, rlpgen, abigen, gci}
-	
-	allTools []string{ginkgo}
+
+	allTools = []string{ginkgo}
 )
 
 // Setup runs the setup script for the current OS.


### PR DESCRIPTION
Closes: [#DEVOP-45](https://linear.app/arguslabs/issue/DEVOP-45/fix-ci-build-cache-on-world-engine-repo)

## What is the purpose of the change

- Fix CI test issue: `exec: "ginkgo": executable file not found in $PATH"`. (for example this [job run](https://github.com/Argus-Labs/world-engine/actions/runs/6166740214/job/16736732832?pr=264))
- Previously, this CI test issues were intermittent because the old cache still had `ginkgo` executables, now it will always installed during magefiles setup.

## Brief Changelog

- Bring back `ginkgo` package for foundry to install during magefiles setup

## Testing and Verifying

- Run CI `testunitcover` job
