### PR TITLE
feat(cardinal): create additional context for panics in logging. 

### DIFF
--- a/cardinal/ecs/tick_test.go
+++ b/cardinal/ecs/tick_test.go
@@ -1,10 +1,15 @@
 package ecs_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"testing"
 
+	"github.com/rs/zerolog"
 	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
 
 	"gotest.tools/v3/assert"
@@ -34,6 +39,59 @@ func TestTickHappyPath(t *testing.T) {
 	assert.NilError(t, twoWorld.RegisterComponents(twoEnergy))
 	assert.NilError(t, twoWorld.LoadGameState())
 	assert.Equal(t, uint64(10), twoWorld.CurrentTick())
+}
+func TestIfPanicMessageLogged(t *testing.T) {
+
+	w := inmem.NewECSWorldForTest(t)
+	//replaces internal Logger with one that logs to the buf variable above.
+	var buf bytes.Buffer
+	bufLogger := zerolog.New(&buf)
+	cardinalLogger := ecs.Logger{
+		&bufLogger,
+	}
+	w.InjectLogger(&cardinalLogger)
+	// In this test, our "buggy" system fails once Power reaches 3
+	errorTxt := "BIG ERROR OH NO"
+	w.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+		panic(errorTxt)
+	})
+	assert.NilError(t, w.LoadGameState())
+	ctx := context.Background()
+
+	defer func() {
+		if panicValue := recover(); panicValue != nil {
+			//This test should swallow a panic
+			lastjson, err := findLastJSON(buf.Bytes())
+			assert.NilError(t, err)
+			values := map[string]string{}
+			err = json.Unmarshal(lastjson, &values)
+			assert.NilError(t, err)
+			msg, ok := values["message"]
+			assert.Assert(t, ok)
+			assert.Equal(t, msg, "Tick: 0, Current running system: ecs_test.TestIfPanicMessageLogged.func1")
+		} else {
+			assert.Assert(t, false) //This test should create a panic.
+		}
+	}()
+
+	err := w.Tick(ctx)
+	assert.NilError(t, err)
+}
+
+func findLastJSON(buf []byte) (json.RawMessage, error) {
+	dec := json.NewDecoder(bytes.NewReader(buf))
+	var lastVal json.RawMessage
+	for {
+		if err := dec.Decode(&lastVal); err == io.EOF {
+			break
+		} else if err != nil {
+			return nil, err
+		}
+	}
+	if lastVal == nil {
+		return nil, fmt.Errorf("no JSON value found")
+	}
+	return lastVal, nil
 }
 
 func TestCanIdentifyAndFixSystemError(t *testing.T) {

--- a/cardinal/ecs/tick_test.go
+++ b/cardinal/ecs/tick_test.go
@@ -69,6 +69,9 @@ func TestIfPanicMessageLogged(t *testing.T) {
 			msg, ok := values["message"]
 			assert.Assert(t, ok)
 			assert.Equal(t, msg, "Tick: 0, Current running system: ecs_test.TestIfPanicMessageLogged.func1")
+			panicString, ok := panicValue.(string)
+			assert.Assert(t, ok)
+			assert.Equal(t, panicString, errorTxt)
 		} else {
 			assert.Assert(t, false) //This test should create a panic.
 		}

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -480,6 +480,14 @@ func (w *World) AddTransaction(id transaction.TypeID, v any, sig *sign.SignedPay
 // Tick performs one game tick. This consists of taking a snapshot of all pending transactions, then calling
 // each System in turn with the snapshot of transactions.
 func (w *World) Tick(ctx context.Context) error {
+	nullSystemName := "No system  is running."
+	nameOfCurrentRunningSystem := nullSystemName
+	defer func() {
+		if panicValue := recover(); panicValue != nil {
+			w.Logger.Error().Msgf("Tick: %d, Current running system: %s", w.tick, nameOfCurrentRunningSystem)
+			panic(panicValue)
+		}
+	}()
 	startTime := time.Now()
 	warningThreshold := 100 * time.Millisecond
 	tickAsString := strconv.FormatUint(w.tick, 10)
@@ -497,7 +505,10 @@ func (w *World) Tick(ctx context.Context) error {
 		queue: txs,
 	}
 	for i, sys := range w.systems {
-		if err := sys(w, txQueue, w.systemLoggers[i]); err != nil {
+		nameOfCurrentRunningSystem = w.systemNames[i]
+		err := sys(w, txQueue, w.systemLoggers[i])
+		nameOfCurrentRunningSystem = nullSystemName
+		if err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Closes: #WORLD-308
## What is the purpose of the change

Additional logging during a system panic

## Brief Changelog

Added a recovery function that will log current system name and tick number, before forwarding the panic. 

## Testing and Verifying

Added a test to tick_test.go