### PR TITLE
feat(cardinal): force creation of new read types and transaction types to be structs …

### DIFF
--- a/cardinal/ecs/read.go
+++ b/cardinal/ecs/read.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"reflect"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/invopop/jsonschema"
@@ -60,6 +61,24 @@ func NewReadType[Request any, Reply any](
 	handler func(world *World, req Request) (Reply, error),
 	opts ...func() func(readType *ReadType[Request, Reply]),
 ) *ReadType[Request, Reply] {
+	var req Request
+	var rep Reply
+	reqType := reflect.TypeOf(req)
+	reqKind := reqType.Kind()
+	reqValid := false
+	if (reqKind == reflect.Pointer && reqType.Elem().Kind() == reflect.Struct) || reqKind == reflect.Struct {
+		reqValid = true
+	}
+	repType := reflect.TypeOf(rep)
+	repKind := reqType.Kind()
+	repValid := false
+	if (repKind == reflect.Pointer && repType.Elem().Kind() == reflect.Struct) || repKind == reflect.Struct {
+		repValid = true
+	}
+
+	if !repValid || !reqValid {
+		panic("The Request and Reply must be both structs")
+	}
 	r := &ReadType[Request, Reply]{
 		name:    name,
 		handler: handler,

--- a/cardinal/ecs/read.go
+++ b/cardinal/ecs/read.go
@@ -77,7 +77,7 @@ func NewReadType[Request any, Reply any](
 	}
 
 	if !repValid || !reqValid {
-		panic("The Request and Reply must be both structs")
+		panic(fmt.Sprintf("Invalid ReadType: %s: The Request and Reply must be both structs", name))
 	}
 	r := &ReadType[Request, Reply]{
 		name:    name,

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -73,7 +73,7 @@ func NewTransactionType[In, Out any](
 	}
 
 	if !outValid || !inValid {
-		panic("The Request and Reply must be both structs")
+		panic(fmt.Sprintf("Invalid ReadType: %s: The Request and Reply must be both structs", name))
 	}
 
 	txt := &TransactionType[In, Out]{

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -3,6 +3,8 @@ package ecs
 import (
 	"errors"
 	"fmt"
+	"reflect"
+
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/invopop/jsonschema"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
@@ -54,6 +56,26 @@ func NewTransactionType[In, Out any](
 	name string,
 	opts ...func() func(*TransactionType[In, Out]),
 ) *TransactionType[In, Out] {
+
+	var in In
+	var out Out
+	inType := reflect.TypeOf(in)
+	inKind := inType.Kind()
+	inValid := false
+	if (inKind == reflect.Pointer && inType.Elem().Kind() == reflect.Struct) || inKind == reflect.Struct {
+		inValid = true
+	}
+	outType := reflect.TypeOf(out)
+	outKind := inType.Kind()
+	outValid := false
+	if (outKind == reflect.Pointer && outType.Elem().Kind() == reflect.Struct) || outKind == reflect.Struct {
+		outValid = true
+	}
+
+	if !outValid || !inValid {
+		panic("The Request and Reply must be both structs")
+	}
+
 	txt := &TransactionType[In, Out]{
 		name: name,
 	}

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -73,7 +73,7 @@ func NewTransactionType[In, Out any](
 	}
 
 	if !outValid || !inValid {
-		panic(fmt.Sprintf("Invalid ReadType: %s: The Request and Reply must be both structs", name))
+		panic(fmt.Sprintf("Invalid TransactionType: %s: The In and Out must be both structs", name))
 	}
 
 	txt := &TransactionType[In, Out]{

--- a/cardinal/ecs/transaction/transaction_test.go
+++ b/cardinal/ecs/transaction/transaction_test.go
@@ -25,6 +25,27 @@ type ModifyScoreTx struct {
 
 type EmptyTxResult struct{}
 
+func TestReadTypeNotStructs(t *testing.T) {
+
+	defer func() {
+		// test should trigger a panic. it is swallowed here.
+		panicValue := recover()
+		assert.Assert(t, panicValue != nil)
+
+		defer func() {
+			//defered function should not fail
+			panicValue := recover()
+			assert.Assert(t, panicValue == nil)
+		}()
+
+		ecs.NewTransactionType[*ModifyScoreTx, *EmptyTxResult]("modify_score2")
+
+	}()
+
+	ecs.NewTransactionType[string, string]("modify_score1")
+
+}
+
 func TestCanQueueTransactions(t *testing.T) {
 	world := inmem.NewECSWorldForTest(t)
 


### PR DESCRIPTION
Closes: #world-131

## What is the purpose of the change

make sure ReadTypes and transaction types only have structs as generic parameters. 

## Brief Changelog

just added reflection. 

## Testing and Verifying

Wrote two tests. 