### PR TITLE
refactor(cardinal): Remove StorageAccessor

### DIFF
--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -11,14 +11,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rs/zerolog"
-
-	"google.golang.org/protobuf/proto"
-
-	"github.com/rs/zerolog/log"
-
 	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"
-
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/protobuf/proto"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
@@ -31,16 +27,6 @@ import (
 
 // Namespace is a unique identifier for a world.
 type Namespace string
-
-// StorageAccessor is an accessor for the world's storage.
-type StorageAccessor struct {
-	// Index is the search archCompIndexStore for the world.
-	Index storage.ArchetypeComponentIndex
-	// Components is the component storage for the world.
-	Components *storage.Components
-	// Archetypes is the archetype storage for the world.
-	Archetypes storage.ArchetypeAccessor
-}
 
 type World struct {
 	namespace                Namespace
@@ -439,14 +425,6 @@ func (w *World) TransferArchetype(from storage.ArchetypeID, to storage.Archetype
 	}
 
 	return storage.ComponentIndex(len(toArch.Entities()) - 1), nil
-}
-
-func (w *World) StorageAccessor() StorageAccessor {
-	return StorageAccessor{
-		w.store.ArchCompIdxStore,
-		&w.store.CompStore,
-		w.store.ArchAccessor,
-	}
 }
 
 // copyTransactions makes a copy of the world txQueue, then zeroes out the txQueue.


### PR DESCRIPTION
Closes: #WORLD-319 and #WORLD-129

## What is the purpose of the change

Remove StorageAccessor. It's just a wrapper around a subset of the world.store field. 

As we continue with refactoring the ECS/storage packages it will be important to know when we require the ecs.World object when when we require a storage object. This PR makes that requirement more clear.

## Testing and Verifying

Existing tests will verify no functionality has changed. 