### PR TITLE
refactor(cardinal): move tx queue out of ecs

### DIFF
--- a/cardinal/ecs/chain_recover_test.go
+++ b/cardinal/ecs/chain_recover_test.go
@@ -9,6 +9,7 @@ import (
 	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"
 	"github.com/cometbft/cometbft/libs/rand"
 	"google.golang.org/protobuf/proto"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 	"pkg.world.dev/world-engine/sign"
 
 	"gotest.tools/v3/assert"
@@ -99,7 +100,7 @@ func TestWorld_RecoverFromChain(t *testing.T) {
 	sysRuns := uint64(0)
 	timesSendEnergyRan := 0
 	// send energy system
-	w.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		sysRuns++
 		txs := SendEnergyTx.In(queue)
 		if len(txs) > 0 {

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
@@ -22,7 +23,7 @@ type OwnableComponent struct {
 	Owner string
 }
 
-func UpdateEnergySystem(w *ecs.World, tq *ecs.TransactionQueue, _ *ecs.Logger) error {
+func UpdateEnergySystem(w *ecs.World, tq *transaction.TxQueue, _ *ecs.Logger) error {
 	errs := []error{}
 
 	Energy.Each(w, func(ent storage.EntityID) bool {

--- a/cardinal/ecs/log_test.go
+++ b/cardinal/ecs/log_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
@@ -31,7 +32,7 @@ type EnergyComp struct {
 
 var energy = ecs.NewComponentType[EnergyComp]("EnergyComp")
 
-func testSystem(w *ecs.World, _ *ecs.TransactionQueue, logger *ecs.Logger) error {
+func testSystem(w *ecs.World, _ *transaction.TxQueue, logger *ecs.Logger) error {
 	logger.Log().Msg("test")
 	energy.Each(w, func(entityId storage.EntityID) bool {
 		energyPlanet, err := energy.Get(w, entityId)
@@ -49,7 +50,7 @@ func testSystem(w *ecs.World, _ *ecs.TransactionQueue, logger *ecs.Logger) error
 	return nil
 }
 
-func testSystemWarningTrigger(w *ecs.World, tx *ecs.TransactionQueue, logger *ecs.Logger) error {
+func testSystemWarningTrigger(w *ecs.World, tx *transaction.TxQueue, logger *ecs.Logger) error {
 	time.Sleep(time.Millisecond * 400)
 	return testSystem(w, tx, logger)
 }

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -6,6 +6,7 @@ import (
 
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
 // CreatePersonaTransaction allows for the associating of a persona tag with a signer address.
@@ -40,7 +41,7 @@ var AuthorizePersonaAddressTx = NewTransactionType[AuthorizePersonaAddress, Auth
 // AuthorizePersonaAddressSystem enables users to authorize an address to a persona tag. This is mostly used so that
 // users who want to interact with the game via smart contract can link their EVM address to their persona tag, enabling
 // them to mutate their owned state from the context of the EVM.
-func AuthorizePersonaAddressSystem(world *World, queue *TransactionQueue, _ *Logger) error {
+func AuthorizePersonaAddressSystem(world *World, queue *transaction.TxQueue, _ *Logger) error {
 	txs := AuthorizePersonaAddressTx.In(queue)
 	if len(txs) == 0 {
 		return nil
@@ -120,7 +121,7 @@ func buildPersonaTagMapping(world *World) (map[string]personaTagComponentData, e
 
 // RegisterPersonaSystem is an ecs.System that will associate persona tags with signature addresses. Each persona tag
 // may have at most 1 signer, so additional attempts to register a signer with a persona tag will be ignored.
-func RegisterPersonaSystem(world *World, queue *TransactionQueue, _ *Logger) error {
+func RegisterPersonaSystem(world *World, queue *transaction.TxQueue, _ *Logger) error {
 	createTxs := CreatePersonaTx.In(queue)
 	if len(createTxs) == 0 {
 		return nil

--- a/cardinal/ecs/state_test.go
+++ b/cardinal/ecs/state_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 
 	"github.com/alicebob/miniredis/v2"
 	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
@@ -172,7 +173,7 @@ func TestCanReloadState(t *testing.T) {
 
 	_, err := alphaWorld.CreateMany(10, oneAlphaNum)
 	assert.NilError(t, err)
-	alphaWorld.AddSystem(func(w *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	alphaWorld.AddSystem(func(w *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		oneAlphaNum.Each(w, func(id storage.EntityID) bool {
 			err := oneAlphaNum.Set(w, id, NumberComponent{int(id)})
 			assert.Check(t, err == nil)
@@ -235,7 +236,7 @@ func TestCanFindTransactionsAfterReloadingWorld(t *testing.T) {
 	for reload := 0; reload < 5; reload++ {
 		world := testutil.InitWorldWithRedis(t, redisStore)
 		assert.NilError(t, world.RegisterTransactions(someTx))
-		world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, logger *ecs.Logger) error {
+		world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, logger *ecs.Logger) error {
 			for _, tx := range someTx.In(queue) {
 				someTx.SetResult(world, tx.TxHash, Result{})
 			}

--- a/cardinal/ecs/storage/engine.go
+++ b/cardinal/ecs/storage/engine.go
@@ -89,9 +89,9 @@ type StateStorage interface {
 
 type TickStorage interface {
 	GetTickNumbers() (start, end uint64, err error)
-	StartNextTick(txs []transaction.ITransaction, queues transaction.TxMap) error
+	StartNextTick(txs []transaction.ITransaction, queues *transaction.TxQueue) error
 	FinalizeTick() error
-	Recover(txs []transaction.ITransaction) (transaction.TxMap, error)
+	Recover(txs []transaction.ITransaction) (*transaction.TxQueue, error)
 }
 
 type NonceStorage interface {

--- a/cardinal/ecs/storage/redis_storage.go
+++ b/cardinal/ecs/storage/redis_storage.go
@@ -463,10 +463,10 @@ type pendingTransaction struct {
 	Sig    *sign.SignedPayload
 }
 
-func (r *RedisStorage) storeTransactions(ctx context.Context, txs []transaction.ITransaction, queues transaction.TxMap) error {
+func (r *RedisStorage) storeTransactions(ctx context.Context, txs []transaction.ITransaction, queue *transaction.TxQueue) error {
 	var pending []pendingTransaction
 	for _, tx := range txs {
-		currList := queues[tx.ID()]
+		currList := queue.ForID(tx.ID())
 		for _, txData := range currList {
 			buf, err := tx.Encode(txData.Value)
 			if err != nil {
@@ -502,9 +502,9 @@ func (r *RedisStorage) getPendingTransactionsFromRedis(ctx context.Context) ([]p
 	return Decode[[]pendingTransaction](buf)
 }
 
-func (r *RedisStorage) StartNextTick(txs []transaction.ITransaction, queues transaction.TxMap) error {
+func (r *RedisStorage) StartNextTick(txs []transaction.ITransaction, queue *transaction.TxQueue) error {
 	ctx := context.Background()
-	if err := r.storeTransactions(ctx, txs, queues); err != nil {
+	if err := r.storeTransactions(ctx, txs, queue); err != nil {
 		return err
 	}
 	if err := r.makeSnapshot(ctx); err != nil {
@@ -599,7 +599,7 @@ func (r *RedisStorage) recoverSnapshot(ctx context.Context) error {
 
 // Recover recovers the game state from the last game tick and any pending transactions that have been saved to the DB,
 // but not yet applied to a game tick.
-func (r *RedisStorage) Recover(txs []transaction.ITransaction) (transaction.TxMap, error) {
+func (r *RedisStorage) Recover(txs []transaction.ITransaction) (*transaction.TxQueue, error) {
 	ctx := context.Background()
 	if err := r.recoverSnapshot(ctx); err != nil {
 		return nil, err
@@ -613,20 +613,16 @@ func (r *RedisStorage) Recover(txs []transaction.ITransaction) (transaction.TxMa
 		idToTx[tx.ID()] = tx
 	}
 
-	allQueues := transaction.TxMap{}
+	txQueue := transaction.NewTxQueue()
 	for _, p := range pending {
 		tx := idToTx[p.TypeID]
 		txData, err := tx.Decode(p.Data)
 		if err != nil {
 			return nil, err
 		}
-		allQueues[tx.ID()] = append(allQueues[tx.ID()], transaction.TxAny{
-			TxHash: p.TxHash,
-			Sig:    p.Sig,
-			Value:  txData,
-		})
+		txQueue.AddTransaction(tx.ID(), txData, p.Sig)
 	}
-	return allQueues, nil
+	return txQueue, nil
 }
 
 // ---------------------------------------------------------------------------

--- a/cardinal/ecs/system.go
+++ b/cardinal/ecs/system.go
@@ -1,3 +1,5 @@
 package ecs
 
-type System func(*World, *TransactionQueue, *Logger) error
+import "pkg.world.dev/world-engine/cardinal/ecs/transaction"
+
+type System func(*World, *transaction.TxQueue, *Logger) error

--- a/cardinal/ecs/tick_test.go
+++ b/cardinal/ecs/tick_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 
 	"gotest.tools/v3/assert"
 
@@ -52,7 +53,7 @@ func TestIfPanicMessageLogged(t *testing.T) {
 	w.InjectLogger(&cardinalLogger)
 	// In this test, our "buggy" system fails once Power reaches 3
 	errorTxt := "BIG ERROR OH NO"
-	w.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		panic(errorTxt)
 	})
 	assert.NilError(t, w.LoadGameState())
@@ -113,7 +114,7 @@ func TestCanIdentifyAndFixSystemError(t *testing.T) {
 	errorSystem := errors.New("3 power? That's too much, man!")
 
 	// In this test, our "buggy" system fails once Power reaches 3
-	oneWorld.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	oneWorld.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		p, err := onePower.Get(world, id)
 		if err != nil {
 			return err
@@ -139,7 +140,7 @@ func TestCanIdentifyAndFixSystemError(t *testing.T) {
 	assert.NilError(t, twoWorld.RegisterComponents(twoPower))
 
 	// this is our fixed system that can handle Power levels of 3 and higher
-	twoWorld.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	twoWorld.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		p, err := onePower.Get(world, id)
 		if err != nil {
 			return err
@@ -219,7 +220,7 @@ func TestCanRecoverStateAfterFailedArchetypeChange(t *testing.T) {
 		}
 
 		errorToggleComponent := errors.New("problem with toggle component")
-		world.AddSystem(func(w *ecs.World, _ *ecs.TransactionQueue, _ *ecs.Logger) error {
+		world.AddSystem(func(w *ecs.World, _ *transaction.TxQueue, _ *ecs.Logger) error {
 			// Get the one and only entity ID
 			id, err := static.First(w)
 			assert.NilError(t, err)
@@ -283,7 +284,7 @@ func TestCanRecoverTransactionsFromFailedSystemRun(t *testing.T) {
 		powerTx := ecs.NewTransactionType[FloatValue, FloatValue]("change_power")
 		assert.NilError(t, world.RegisterTransactions(powerTx))
 
-		world.AddSystem(func(w *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+		world.AddSystem(func(w *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 			id := powerComp.MustFirst(w)
 			entityPower, err := powerComp.Get(w, id)
 			assert.NilError(t, err)

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -3,6 +3,7 @@ package ecs
 import (
 	"errors"
 	"fmt"
+
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/invopop/jsonschema"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
@@ -24,12 +25,6 @@ type TransactionType[In, Out any] struct {
 	name       string
 	inEVMType  *abi.Type
 	outEVMType *abi.Type
-}
-
-// TransactionQueue is a list of transactions that were queued since the start of the
-// last game tick.
-type TransactionQueue struct {
-	queue transaction.TxMap
 }
 
 func WithTxEVMSupport[In, Out any]() func(transactionType *TransactionType[In, Out]) {
@@ -137,9 +132,9 @@ func (t *TransactionType[In, Out]) GetReceipt(world *World, hash transaction.TxH
 }
 
 // In extracts all the transactions in the transaction queue that match this TransactionType's ID.
-func (t *TransactionType[In, Out]) In(tq *TransactionQueue) []TxData[In] {
+func (t *TransactionType[In, Out]) In(tq *transaction.TxQueue) []TxData[In] {
 	var txs []TxData[In]
-	for _, tx := range tq.queue[t.ID()] {
+	for _, tx := range tq.ForID(t.ID()) {
 		if val, ok := tx.Value.(In); ok {
 			txs = append(txs, TxData[In]{
 				TxHash: tx.TxHash,

--- a/cardinal/ecs/transaction/transaction.go
+++ b/cardinal/ecs/transaction/transaction.go
@@ -1,11 +1,51 @@
 package transaction
 
 import (
+	"sync"
+
 	"github.com/invopop/jsonschema"
 	"pkg.world.dev/world-engine/sign"
 )
 
-type TxMap map[TypeID][]TxAny
+type TxQueue struct {
+	m   txMap
+	mux *sync.Mutex
+}
+
+func NewTxQueue() *TxQueue {
+	return &TxQueue{
+		m:   txMap{},
+		mux: &sync.Mutex{},
+	}
+}
+
+func (t *TxQueue) AddTransaction(id TypeID, v any, sig *sign.SignedPayload) TxHash {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	txHash := TxHash(sig.HashHex())
+	t.m[id] = append(t.m[id], TxAny{
+		TxHash: txHash,
+		Value:  v,
+		Sig:    sig,
+	})
+	return txHash
+}
+
+func (t *TxQueue) CopyTransaction() *TxQueue {
+	t.mux.Lock()
+	defer t.mux.Unlock()
+	cpy := &TxQueue{
+		m: t.m,
+	}
+	t.m = txMap{}
+	return cpy
+}
+
+func (t *TxQueue) ForID(id TypeID) []TxAny {
+	return t.m[id]
+}
+
+type txMap map[TypeID][]TxAny
 
 type TxAny struct {
 	Value  any

--- a/cardinal/ecs/transaction/transaction_test.go
+++ b/cardinal/ecs/transaction/transaction_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 
 	"gotest.tools/v3/assert"
 
@@ -38,7 +39,7 @@ func TestCanQueueTransactions(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Set up a system that allows for the modification of a player's score
-	world.AddSystem(func(w *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	world.AddSystem(func(w *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		modifyScore := modifyScoreTx.In(queue)
 		for _, txData := range modifyScore {
 			ms := txData.Value
@@ -90,7 +91,7 @@ func TestSystemsAreExecutedDuringGameTick(t *testing.T) {
 
 	id, err := world.Create(count)
 	assert.NilError(t, err)
-	world.AddSystem(func(w *ecs.World, _ *ecs.TransactionQueue, _ *ecs.Logger) error {
+	world.AddSystem(func(w *ecs.World, _ *transaction.TxQueue, _ *ecs.Logger) error {
 		return count.Update(w, id, func(c CounterComponent) CounterComponent {
 			c.Count++
 			return c
@@ -115,7 +116,7 @@ func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 	modifyScoreTx := ecs.NewTransactionType[*ModifyScoreTx, *EmptyTxResult]("modify_score")
 	assert.NilError(t, world.RegisterTransactions(modifyScoreTx))
 
-	world.AddSystem(func(w *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	world.AddSystem(func(w *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		modifyScores := modifyScoreTx.In(queue)
 		for _, msData := range modifyScores {
 			ms := msData.Value
@@ -173,7 +174,7 @@ func TestAddToQueueDuringTickDoesNotTimeout(t *testing.T) {
 	inSystemCh := make(chan struct{})
 	// This system will block forever. This will give us a never-ending game tick that we can use
 	// to verify that the addition of more transactions doesn't block.
-	world.AddSystem(func(*ecs.World, *ecs.TransactionQueue, *ecs.Logger) error {
+	world.AddSystem(func(*ecs.World, *transaction.TxQueue, *ecs.Logger) error {
 		<-inSystemCh
 		select {}
 		return nil
@@ -216,13 +217,13 @@ func TestTransactionsAreExecutedAtNextTick(t *testing.T) {
 
 	// Create two system that report how many instances of the ModifyScoreTx exist in the
 	// transaction queue. These counts should be the same for each tick.
-	world.AddSystem(func(_ *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	world.AddSystem(func(_ *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		modScores := modScoreTx.In(queue)
 		modScoreCountCh <- len(modScores)
 		return nil
 	})
 
-	world.AddSystem(func(_ *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	world.AddSystem(func(_ *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		modScores := modScoreTx.In(queue)
 		modScoreCountCh <- len(modScores)
 		return nil
@@ -282,7 +283,7 @@ func TestIdenticallyTypedTransactionCanBeDistinguished(t *testing.T) {
 	alpha.AddToQueue(world, NewOwner{"alpha"})
 	beta.AddToQueue(world, NewOwner{"beta"})
 
-	world.AddSystem(func(_ *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	world.AddSystem(func(_ *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		newNames := alpha.In(queue)
 		assert.Check(t, 1 == len(newNames), "expected 1 transaction, not %d", len(newNames))
 		assert.Check(t, "alpha" == newNames[0].Value.Name)
@@ -370,7 +371,7 @@ func TestCanGetTransactionErrorsAndResults(t *testing.T) {
 	wantSecondError := errors.New("another transaction error")
 	wantDeltaX, wantDeltaY := 99, 100
 
-	world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		// This new TxsIn function returns a triplet of information:
 		// 1) The transaction input
 		// 2) An ID that uniquely identifies this specific transaction
@@ -424,7 +425,7 @@ func TestSystemCanFindErrorsFromEarlierSystem(t *testing.T) {
 	assert.NilError(t, world.RegisterTransactions(numTx))
 	wantErr := errors.New("some transaction error")
 	systemCalls := 0
-	world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		systemCalls++
 		txs := numTx.In(queue)
 		assert.Equal(t, 1, len(txs))
@@ -435,7 +436,7 @@ func TestSystemCanFindErrorsFromEarlierSystem(t *testing.T) {
 		return nil
 	})
 
-	world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		systemCalls++
 		txs := numTx.In(queue)
 		assert.Equal(t, 1, len(txs))
@@ -468,7 +469,7 @@ func TestSystemCanClobberTransactionResult(t *testing.T) {
 
 	firstResult := TxOut{1234}
 	secondResult := TxOut{5678}
-	world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		systemCalls++
 		txs := numTx.In(queue)
 		assert.Equal(t, 1, len(txs))
@@ -479,7 +480,7 @@ func TestSystemCanClobberTransactionResult(t *testing.T) {
 		return nil
 	})
 
-	world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		systemCalls++
 		txs := numTx.In(queue)
 		assert.Equal(t, 1, len(txs))

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -11,14 +11,10 @@ import (
 	"sync"
 	"time"
 
-	"github.com/rs/zerolog"
-
-	"google.golang.org/protobuf/proto"
-
-	"github.com/rs/zerolog/log"
-
 	shardv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/shard/v1"
-
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/protobuf/proto"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
@@ -31,16 +27,6 @@ import (
 
 // Namespace is a unique identifier for a world.
 type Namespace string
-
-// StorageAccessor is an accessor for the world's storage.
-type StorageAccessor struct {
-	// Index is the search archCompIndexStore for the world.
-	Index storage.ArchetypeComponentIndex
-	// Components is the component storage for the world.
-	Components *storage.Components
-	// Archetypes is the archetype storage for the world.
-	Archetypes storage.ArchetypeAccessor
-}
 
 type World struct {
 	namespace                Namespace
@@ -439,14 +425,6 @@ func (w *World) TransferArchetype(from storage.ArchetypeID, to storage.Archetype
 	}
 
 	return storage.ComponentIndex(len(toArch.Entities()) - 1), nil
-}
-
-func (w *World) StorageAccessor() StorageAccessor {
-	return StorageAccessor{
-		w.store.ArchCompIdxStore,
-		&w.store.CompStore,
-		w.store.ArchAccessor,
-	}
 }
 
 // copyTransactions makes a copy of the world txQueue, then zeroes out the txQueue.

--- a/cardinal/ecs/world_test.go
+++ b/cardinal/ecs/world_test.go
@@ -2,15 +2,17 @@ package ecs_test
 
 import (
 	"context"
+	"testing"
+
 	"gotest.tools/v3/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/inmem"
-	"testing"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
 func TestAddSystems(t *testing.T) {
 	count := 0
-	sys := func(w *ecs.World, txq *ecs.TransactionQueue, _ *ecs.Logger) error {
+	sys := func(w *ecs.World, txq *transaction.TxQueue, _ *ecs.Logger) error {
 		count++
 		return nil
 	}
@@ -29,13 +31,13 @@ func TestAddSystems(t *testing.T) {
 func TestSystemExecutionOrder(t *testing.T) {
 	w := inmem.NewECSWorldForTest(t)
 	order := make([]int, 0, 3)
-	w.AddSystems(func(world *ecs.World, queue *ecs.TransactionQueue, logger *ecs.Logger) error {
+	w.AddSystems(func(world *ecs.World, queue *transaction.TxQueue, logger *ecs.Logger) error {
 		order = append(order, 1)
 		return nil
-	}, func(world *ecs.World, queue *ecs.TransactionQueue, logger *ecs.Logger) error {
+	}, func(world *ecs.World, queue *transaction.TxQueue, logger *ecs.Logger) error {
 		order = append(order, 2)
 		return nil
-	}, func(world *ecs.World, queue *ecs.TransactionQueue, logger *ecs.Logger) error {
+	}, func(world *ecs.World, queue *transaction.TxQueue, logger *ecs.Logger) error {
 		order = append(order, 3)
 		return nil
 	})

--- a/cardinal/evm/server_test.go
+++ b/cardinal/evm/server_test.go
@@ -3,6 +3,7 @@ package evm
 import (
 	"context"
 	"fmt"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 	"pkg.world.dev/world-engine/sign"
 	"testing"
 
@@ -53,7 +54,7 @@ func TestServer_SendMessage(t *testing.T) {
 	enabled := false
 
 	// add a system that checks that they are submitted properly to the world.
-	w.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		if !enabled {
 			return nil
 		}

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -186,7 +187,7 @@ func TestHandleTransactionWithNoSignatureVerification(t *testing.T) {
 		sendTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult](endpoint)
 		assert.NilError(t, w.RegisterTransactions(sendTx))
 		count := 0
-		w.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+		w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 			txs := sendTx.In(queue)
 			assert.Equal(t, 1, len(txs))
 			tx := txs[0]
@@ -235,7 +236,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 	w := inmem.NewECSWorldForTest(t)
 	sendTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult]("send-energy")
 	assert.NilError(t, w.RegisterTransactions(sendTx))
-	w.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 		return nil
 	})
 	type garbageStruct struct {
@@ -435,7 +436,7 @@ func TestHandleWrappedTransactionWithNoSignatureVerification(t *testing.T) {
 		w := inmem.NewECSWorldForTest(t)
 		sendTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult](endpoint)
 		assert.NilError(t, w.RegisterTransactions(sendTx))
-		w.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+		w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 			txs := sendTx.In(queue)
 			assert.Equal(t, 1, len(txs))
 			tx := txs[0]
@@ -885,7 +886,7 @@ func TestCanGetTransactionReceiptsSwagger(t *testing.T) {
 		world := inmem.NewECSWorldForTest(t)
 		assert.NilError(t, world.RegisterTransactions(incTx, dupeTx, errTx))
 		// System to handle incrementing numbers
-		world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+		world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 			for _, tx := range incTx.In(queue) {
 				incTx.SetResult(world, tx.TxHash, IncReply{
 					Number: tx.Value.Number + 1,
@@ -894,7 +895,7 @@ func TestCanGetTransactionReceiptsSwagger(t *testing.T) {
 			return nil
 		})
 		// System to handle duplicating strings
-		world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+		world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 			for _, tx := range dupeTx.In(queue) {
 				dupeTx.SetResult(world, tx.TxHash, DupeReply{
 					Str: tx.Value.Str + tx.Value.Str,
@@ -904,7 +905,7 @@ func TestCanGetTransactionReceiptsSwagger(t *testing.T) {
 		})
 		wantError := errors.New("some error")
 		// System to handle error production
-		world.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, _ *ecs.Logger) error {
+		world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *ecs.Logger) error {
 			for _, tx := range errTx.In(queue) {
 				errTx.AddError(world, tx.TxHash, wantError)
 				errTx.AddError(world, tx.TxHash, wantError)

--- a/cardinal/transaction.go
+++ b/cardinal/transaction.go
@@ -15,7 +15,7 @@ type AnyTransaction interface {
 // TransactionQueue contains the entire set of transactions that should be processed in a game tick. It is a parameter
 // to a System function. Access the transactions of a particular type by using TransactionType.In
 type TransactionQueue struct {
-	impl *ecs.TransactionQueue
+	impl *transaction.TxQueue
 }
 
 // TxData represents a single transaction.

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -125,7 +125,7 @@ func (w *World) StartGame() error {
 // game tick. This Register method can be called multiple times.
 func (w *World) RegisterSystems(systems ...System) {
 	for _, system := range systems {
-		w.impl.AddSystem(func(world *ecs.World, queue *ecs.TransactionQueue, logger *ecs.Logger) error {
+		w.impl.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, logger *ecs.Logger) error {
 			return system(&World{impl: world}, &TransactionQueue{queue}, &Logger{logger})
 		})
 	}


### PR DESCRIPTION
Closes: #WORLD-318

## What is the purpose of the change

Move the TransactionQueue struct out of the ecs package. We want to reduce the number of places that need to depend on the ecs package.

This touches a lot of files, but most of them are just `s/ecs.TransactionQueue/transaction.TxQueue`. 

## Testing and Verifying

Existing tests verify there are no functional changes.
