### PR TITLE
fix(docs): fix MDX syntax error (new line)

### DIFF
--- a/docs/pages/Cardinal/API-Reference/cql.mdx
+++ b/docs/pages/Cardinal/API-Reference/cql.mdx
@@ -7,6 +7,7 @@ CQL (Component Query Language) is a simple query language that queries entities 
 ### Components
 
 import Link from 'next/link'
+
 The language uses the names of <Link href="/Cardinal/API-Reference/Components">Components</Link> to specify the entities you are interested in querying.
 
 Examples:


### PR DESCRIPTION
Closes: #XXX

## What is the purpose of the change

- Fix docs MDX syntax error
```
./pages/Cardinal/API-Reference/cql.mdx
Could not parse import/exports with acorn: SyntaxError: Unexpected token

Import trace for requested module:
./pages/Cardinal/API-Reference/cql.mdx
```

## Brief Changelog

-  add new line after `import Link from 'next/link'`
## Testing and Verifying
