### PR TITLE
refactor(cardinal): Create store manager that will handle the modification of components …

### DIFF
--- a/cardinal/ecs/component/component.go
+++ b/cardinal/ecs/component/component.go
@@ -13,5 +13,8 @@ type (
 		New() ([]byte, error)
 		// Name returns the name of the component.
 		Name() string
+
+		Decode([]byte) (any, error)
+		Encode(any) ([]byte, error)
 	}
 )

--- a/cardinal/ecs/storage/entity.go
+++ b/cardinal/ecs/storage/entity.go
@@ -1,25 +1,18 @@
 package storage
 
 import (
-	"bytes"
 	"errors"
-	"fmt"
 	"math"
 
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 type WorldAccessor interface {
-	Component(componentType component.IComponentType, archID ArchetypeID, componentIndex ComponentIndex) ([]byte, error)
-	SetComponent(component.IComponentType, []byte, ArchetypeID, ComponentIndex) error
-	GetLayout(archID ArchetypeID) []component.IComponentType
 	GetArchetypeForComponents([]component.IComponentType) ArchetypeID
-	TransferArchetype(ArchetypeID, ArchetypeID, ComponentIndex) (ComponentIndex, error)
 	Entity(id EntityID) (Entity, error)
 	Remove(id EntityID) error
 	Valid(id EntityID) (bool, error)
 	Archetype(ArchetypeID) ArchetypeStorage
-	SetEntityLocation(id EntityID, location Location) error
 }
 
 var _ EntityManager = &entityMgrImpl{}
@@ -76,167 +69,15 @@ var (
 	BadEntity Entity   = Entity{BadID, Location{}}
 )
 
-// Get returns the component from the entity
-func Get[T any](w WorldAccessor, id EntityID, cType component.IComponentType) (*T, error) {
-	e, err := w.Entity(id)
-	if err != nil {
-		return nil, err
-	}
-	compBz, err := e.Component(w, cType)
-	if err != nil {
-		return nil, err
-	}
-	return Decode[*T](compBz)
-}
-
-// Add adds the component to the entity.
-func Add[T any](w WorldAccessor, id EntityID, cType component.IComponentType, component *T) error {
-	e, err := w.Entity(id)
-	if err != nil {
-		return err
-	}
-	bz, err := Encode(component)
-	if err != nil {
-		return err
-	}
-	e.AddComponent(w, cType, bz)
-	return nil
-}
-
-// Set sets the component of the entity.
-func Set[T any](w WorldAccessor, id EntityID, ctype component.IComponentType, component *T) error {
-	e, err := w.Entity(id)
-	if err != nil {
-		return err
-	}
-	bz, err := Encode(component)
-	if err != nil {
-		return err
-	}
-	e.SetComponent(w, ctype, bz)
-	return nil
-}
-
-// SetValue sets the value of the component.
-func SetValue[T any](w WorldAccessor, id EntityID, ctype component.IComponentType, value T) error {
-	c, err := Get[T](w, id, ctype)
-	if err != nil {
-		return err
-	}
-	*c = value
-	return nil
-}
-
-// Remove removes the component from the entity.
-func Remove[T any](w WorldAccessor, id EntityID, ctype component.IComponentType) error {
-	e, err := w.Entity(id)
-	if err != nil {
-		return err
-	}
-	return e.RemoveComponent(w, ctype)
-}
-
-// Valid returns true if the entity is valid.
-func Valid(w WorldAccessor, id EntityID) (bool, error) {
-	if id == BadID {
-		return false, nil
-	}
-	e, err := w.Entity(id)
-	if err != nil {
-		return false, err
-	}
-	ok, err := e.Valid(w)
-	return ok, err
-}
-
 // EntityID returns the Entity.
 func (e Entity) EntityID() EntityID {
 	return e.ID
-}
-
-// Component returns the component.
-func (e Entity) Component(w WorldAccessor, cType component.IComponentType) ([]byte, error) {
-	c := e.Loc.CompIndex
-	a := e.Loc.ArchID
-	return w.Component(cType, a, c)
-}
-
-// SetComponent sets the component.
-func (e Entity) SetComponent(w WorldAccessor, cType component.IComponentType, component []byte) error {
-	c := e.Loc.CompIndex
-	a := e.Loc.ArchID
-	return w.SetComponent(cType, component, a, c)
 }
 
 var (
 	ErrorComponentAlreadyOnEntity = errors.New("component already on entity")
 	ErrorComponentNotOnEntity     = errors.New("component not on entity")
 )
-
-// AddComponent adds the component to the Ent.
-func (e Entity) AddComponent(w WorldAccessor, cType component.IComponentType, components ...[]byte) error {
-	if len(components) > 1 {
-		panic("AddComponent: component argument must be a single value")
-	}
-	if e.HasComponent(w, cType) {
-		return ErrorComponentAlreadyOnEntity
-	}
-
-	c := e.Loc.CompIndex
-	a := e.Loc.ArchID
-
-	baseLayout := w.GetLayout(a)
-	targetArc := w.GetArchetypeForComponents(append(baseLayout, cType))
-	if _, err := w.TransferArchetype(a, targetArc, c); err != nil {
-		return err
-	}
-
-	ent, err := w.Entity(e.ID)
-	if err != nil {
-		return err
-	}
-	w.SetEntityLocation(e.ID, ent.Loc)
-
-	if len(components) == 1 {
-		e.SetComponent(w, cType, components[0])
-	}
-	return nil
-}
-
-// RemoveComponent removes the component from the Ent.
-func (e Entity) RemoveComponent(w WorldAccessor, cType component.IComponentType) error {
-	// if the entity doesn't even have this component, we can just return.
-	if !e.Archetype(w).Layout().HasComponent(cType) {
-		return ErrorComponentNotOnEntity
-	}
-
-	c := e.Loc.CompIndex
-	a := e.Loc.ArchID
-
-	baseLayout := w.GetLayout(a)
-	targetLayout := make([]component.IComponentType, 0, len(baseLayout)-1)
-	for _, c2 := range baseLayout {
-		if c2 == cType {
-			continue
-		}
-		targetLayout = append(targetLayout, c2)
-	}
-
-	targetArc := w.GetArchetypeForComponents(targetLayout)
-	compIndex, err := w.TransferArchetype(e.Loc.ArchID, targetArc, c)
-	if err != nil {
-		return err
-	}
-
-	ent, err := w.Entity(e.ID)
-	if err != nil {
-		return err
-	}
-	ent.Loc.ArchID = targetArc
-	ent.Loc.CompIndex = compIndex
-	w.SetEntityLocation(e.ID, ent.Loc)
-	return nil
-}
 
 // Remove removes the entity from the world.
 func (e Entity) Remove(w WorldAccessor) error {
@@ -255,30 +96,8 @@ func (e Entity) Archetype(w WorldAccessor) ArchetypeStorage {
 	return w.Archetype(a)
 }
 
-// HasComponent returns true if the Ent has the given component type.
-func (e Entity) HasComponent(w WorldAccessor, componentType component.IComponentType) bool {
-	return e.Archetype(w).Layout().HasComponent(componentType)
-}
-
 func (e Entity) GetComponents(w WorldAccessor) []component.IComponentType {
 	return e.Archetype(w).Layout().Components()
-}
-
-func (e Entity) StringXY(w WorldAccessor) string {
-	var out bytes.Buffer
-	out.WriteString("Entity: {")
-	out.WriteString(e.StringXX())
-	out.WriteString(", ")
-	out.WriteString(e.Archetype(w).Layout().String())
-	out.WriteString(", Valid: ")
-	ok, _ := e.Valid(w)
-	out.WriteString(fmt.Sprintf("%v", ok))
-	out.WriteString("}")
-	return out.String()
-}
-
-func (e Entity) StringXX() string {
-	return fmt.Sprintf("ID: %d, Loc: %+v", e.ID, e.Loc)
 }
 
 var _ StateStorage = &stateStorageImpl{}

--- a/cardinal/ecs/storage/mock.go
+++ b/cardinal/ecs/storage/mock.go
@@ -53,3 +53,13 @@ func (m *MockComponentType[T]) setDefaultVal(ptr unsafe.Pointer) {
 func (m *MockComponentType[T]) Name() string {
 	return fmt.Sprintf("%s[%s]", reflect.TypeOf(m).Name(), m.typ.Name())
 }
+
+var _ component.IComponentType = &MockComponentType[int]{}
+
+func (m *MockComponentType[T]) Decode(bytes []byte) (any, error) {
+	return Decode[T](bytes)
+}
+
+func (m *MockComponentType[T]) Encode(a any) ([]byte, error) {
+	return Encode(a)
+}

--- a/cardinal/ecs/store_manager.go
+++ b/cardinal/ecs/store_manager.go
@@ -1,0 +1,207 @@
+package ecs
+
+import (
+	"errors"
+	"fmt"
+
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
+)
+
+type StoreManager struct {
+	store storage.WorldStorage
+}
+
+func NewStoreManager(store storage.WorldStorage) *StoreManager {
+	return &StoreManager{store: store}
+}
+
+func (s *StoreManager) getEntity(id storage.EntityID) (storage.Entity, error) {
+	loc, err := s.getEntityLocation(id)
+	if err != nil {
+		return storage.BadEntity, err
+	}
+	return storage.NewEntity(id, loc), nil
+}
+
+func (s *StoreManager) getEntityLocation(id storage.EntityID) (storage.Location, error) {
+	return s.store.EntityLocStore.GetLocation(id)
+}
+
+func (s *StoreManager) SetComponentForEntity(cType IComponentType, id storage.EntityID, value any) error {
+	loc, err := s.getEntityLocation(id)
+	if err != nil {
+		return err
+	}
+	bz, err := cType.Encode(value)
+	if err != nil {
+		return err
+	}
+	return s.store.CompStore.Storage(cType).SetComponent(loc.ArchID, loc.CompIndex, bz)
+}
+
+func (s *StoreManager) GetComponentForEntity(cType IComponentType, id storage.EntityID) (any, error) {
+	loc, err := s.getEntityLocation(id)
+	if err != nil {
+		return nil, err
+	}
+	bz, err := s.store.CompStore.Storage(cType).Component(loc.ArchID, loc.CompIndex)
+	if err != nil {
+		return nil, err
+	}
+	return cType.Decode(bz)
+}
+
+func (s *StoreManager) getComponentsForArchetype(archID storage.ArchetypeID) *storage.Layout {
+	return s.store.ArchAccessor.Archetype(archID).Layout()
+}
+
+func (s *StoreManager) hasDuplicates(components []IComponentType) bool {
+	// check if there are duplicate values inside component slice
+	for i := 0; i < len(components); i++ {
+		for j := i + 1; j < len(components); j++ {
+			if components[i] == components[j] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (s *StoreManager) insertArchetype(layout *storage.Layout) storage.ArchetypeID {
+	s.store.ArchCompIdxStore.Push(layout)
+	archID := storage.ArchetypeID(s.store.ArchAccessor.Count())
+
+	s.store.ArchAccessor.PushArchetype(archID, layout)
+	// TODO: Decide on a good way to get this logger object into this StoreManager
+	// s.logger.Debug().Int("archetype_id", int(archID)).Msg("created")
+	return archID
+}
+
+func (s *StoreManager) getArchetypeIDForComponents(components []IComponentType) (storage.ArchetypeID, error) {
+	if len(components) == 0 {
+		return 0, errors.New("entities require at least 1 component")
+	}
+
+	if ii := s.store.ArchCompIdxStore.Search(filter.Exact(components...)); ii.HasNext() {
+		return ii.Next(), nil
+	}
+
+	if s.hasDuplicates(components) {
+		return 0, fmt.Errorf("duplicate component types: %v", components)
+	}
+
+	return s.insertArchetype(storage.NewLayout(components)), nil
+}
+
+func (s *StoreManager) transferArchetype(from, to storage.ArchetypeID, idx storage.ComponentIndex) (storage.ComponentIndex, error) {
+	if from == to {
+		return idx, nil
+	}
+	fromArch := s.store.ArchAccessor.Archetype(from)
+	toArch := s.store.ArchAccessor.Archetype(to)
+
+	// move entity id
+	id := fromArch.SwapRemove(idx)
+	toArch.PushEntity(id)
+	err := s.store.EntityLocStore.Insert(id, to, storage.ComponentIndex(len(toArch.Entities())-1))
+	if err != nil {
+		return 0, err
+	}
+
+	if len(fromArch.Entities()) > int(idx) {
+		movedID := fromArch.Entities()[idx]
+		err := s.store.EntityLocStore.Insert(movedID, from, idx)
+		if err != nil {
+			return 0, err
+		}
+	}
+
+	// creates component if not exists in new layout
+	fromLayout := fromArch.Layout()
+	toLayout := toArch.Layout()
+	for _, componentType := range toLayout.Components() {
+		if !fromLayout.HasComponent(componentType) {
+			store := s.store.CompStore.Storage(componentType)
+			if err := store.PushComponent(componentType, to); err != nil {
+				return 0, err
+			}
+		}
+	}
+
+	// move component
+	for _, componentType := range fromLayout.Components() {
+		store := s.store.CompStore.Storage(componentType)
+		if toLayout.HasComponent(componentType) {
+			if err := store.MoveComponent(from, idx, to); err != nil {
+				return 0, err
+			}
+		} else {
+			_, err := store.SwapRemove(from, idx)
+			if err != nil {
+				return 0, err
+			}
+		}
+	}
+	err = s.store.CompStore.Move(from, to)
+	if err != nil {
+		return 0, err
+	}
+	return storage.ComponentIndex(len(toArch.Entities()) - 1), nil
+}
+
+func (s *StoreManager) AddComponentToEntity(cType IComponentType, id storage.EntityID) error {
+	loc, err := s.getEntityLocation(id)
+	if err != nil {
+		return err
+	}
+
+	currComponents := s.getComponentsForArchetype(loc.ArchID)
+	if currComponents.HasComponent(cType) {
+		return storage.ErrorComponentAlreadyOnEntity
+	}
+	targetComponents := append(currComponents.Components(), cType)
+	targetArchID, err := s.getArchetypeIDForComponents(targetComponents)
+	if err != nil {
+		return fmt.Errorf("unable to create new archetype: %w", err)
+	}
+	newCompIndex, err := s.transferArchetype(loc.ArchID, targetArchID, loc.CompIndex)
+	if err != nil {
+		return err
+	}
+
+	loc.ArchID = targetArchID
+	loc.CompIndex = newCompIndex
+	return s.store.EntityLocStore.SetLocation(id, loc)
+}
+
+func (s *StoreManager) RemoveComponentFromEntity(cType IComponentType, id storage.EntityID) error {
+	loc, err := s.getEntityLocation(id)
+	if err != nil {
+		return err
+	}
+
+	currComponents := s.getComponentsForArchetype(loc.ArchID)
+	if !currComponents.HasComponent(cType) {
+		return storage.ErrorComponentNotOnEntity
+	}
+	targetComponents := make([]component.IComponentType, 0, len(currComponents.Components())-1)
+	for _, c2 := range currComponents.Components() {
+		if c2 == cType {
+			continue
+		}
+		targetComponents = append(targetComponents, c2)
+	}
+	targetArchID, err := s.getArchetypeIDForComponents(targetComponents)
+	if err != nil {
+		return err
+	}
+	newCompIndex, err := s.transferArchetype(loc.ArchID, targetArchID, loc.CompIndex)
+	if err != nil {
+		return err
+	}
+	loc.ArchID = targetArchID
+	loc.CompIndex = newCompIndex
+	return s.store.EntityLocStore.SetLocation(id, loc)
+}


### PR DESCRIPTION
…in a world

## What is the purpose of the change

Currently, code for component management (Get/Set/AddToEntity/RemoveFromEntity) was split between the *World object and storage.Entity. 

storage.Entity is a very simple struct that doesn't need business logic attached to it. In addition, the Entity was dispatching some of the logic *World object (hidden behind a WorldAccessor interface).

This PR takes the component management code out of Entity and World and puts it into a "StoreManager". Eventually this StoreManager code will live in a standalone package. The dependency graph will be:

ecs -> store_manager -> component, filter, storage.

instead of the current: ecs <--> storage.

The eventual goal is to completely remove the WorldAccessor interface.

Note: The code in store_manager.go is pretty much exactly the removed code from world.go and storage/entity.go.

## Testing and Verifying

No functional changes are intended, so existing unit tests should validate that everything is working correctly.
