### PR TITLE
refactor(cardinal): Finish removing the WorldAccessor interface

### DIFF
--- a/cardinal/ecs/component/component.go
+++ b/cardinal/ecs/component/component.go
@@ -18,3 +18,14 @@ type (
 		Encode(any) ([]byte, error)
 	}
 )
+
+// Contains returns true if the given slice of components contains the given cType. Components are the same if they
+// have the same ID.
+func Contains(components []IComponentType, cType IComponentType) bool {
+	for _, c := range components {
+		if cType.ID() == c.ID() {
+			return true
+		}
+	}
+	return false
+}

--- a/cardinal/ecs/component/component.go
+++ b/cardinal/ecs/component/component.go
@@ -19,7 +19,7 @@ type (
 	}
 )
 
-// Contains returns true if the given slice of components contains the given cType. Components are the same if they
+// Contains returns true if the given slice of components contains the given component. Components are the same if they
 // have the same ID.
 func Contains(components []IComponentType, cType IComponentType) bool {
 	for _, c := range components {

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -178,7 +178,7 @@ func TestCanRemoveEntity(t *testing.T) {
 	assert.Equal(t, count, 1)
 
 	// This entity was Removed, so we shouldn't be able to find it
-	_, err = world.Entity(entities[0])
+	_, err = world.StoreManager().GetEntity(entities[0])
 	assert.Check(t, err != nil)
 
 	// Remove the other entity
@@ -194,7 +194,7 @@ func TestCanRemoveEntity(t *testing.T) {
 	assert.Equal(t, count, 0)
 
 	// This entity was Removed, so we shouldn't be able to find it
-	_, err = world.Entity(entities[0])
+	_, err = world.StoreManager().GetEntity(entities[0])
 	assert.Check(t, err != nil)
 }
 
@@ -279,7 +279,7 @@ func TestVerifyAutomaticCreationOfArchetypesWorks(t *testing.T) {
 	entity, err := world.Create(a, b)
 	assert.NilError(t, err)
 
-	ent, err := world.Entity(entity)
+	ent, err := world.StoreManager().GetEntity(entity)
 	assert.NilError(t, err)
 
 	archIDBefore := ent.Loc.ArchID
@@ -287,7 +287,7 @@ func TestVerifyAutomaticCreationOfArchetypesWorks(t *testing.T) {
 	// The entity should now be in a different archetype
 	assert.NilError(t, a.RemoveFrom(world, entity))
 
-	ent, err = world.Entity(entity)
+	ent, err = world.StoreManager().GetEntity(entity)
 	assert.NilError(t, err)
 
 	archIDAfter := ent.Loc.ArchID

--- a/cardinal/ecs/filter/filter_test.go
+++ b/cardinal/ecs/filter/filter_test.go
@@ -158,7 +158,7 @@ func TestCanGetArchetypeFromEntity(t *testing.T) {
 	_, err = world.CreateMany(20, alpha)
 	assert.NilError(t, err)
 	id := ids[0]
-	comps, err := world.GetComponentsOnEntity(id)
+	comps, err := world.StoreManager().GetComponentTypesForEntity(id)
 	assert.NilError(t, err)
 
 	count := 0

--- a/cardinal/ecs/log.go
+++ b/cardinal/ecs/log.go
@@ -2,6 +2,7 @@ package ecs
 
 import (
 	"fmt"
+
 	"github.com/rs/zerolog"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
@@ -19,9 +20,9 @@ func (_ *Logger) loadComponentIntoArrayLogger(component component.IComponentType
 }
 
 func (l *Logger) loadComponentsToEvent(zeroLoggerEvent *zerolog.Event, world *World) *zerolog.Event {
-	zeroLoggerEvent.Int("total_components", len(*world.GetComponents()))
+	zeroLoggerEvent.Int("total_components", len(world.GetComponents()))
 	arrayLogger := zerolog.Arr()
-	for _, _component := range *world.GetComponents() {
+	for _, _component := range world.GetComponents() {
 		arrayLogger = l.loadComponentIntoArrayLogger(_component, arrayLogger)
 	}
 	return zeroLoggerEvent.Array("components", arrayLogger)
@@ -34,25 +35,19 @@ func (_ *Logger) loadSystemIntoArrayLogger(world *World, registeredSystemIndex i
 func (l *Logger) loadSystemIntoEvent(zeroLoggerEvent *zerolog.Event, world *World) *zerolog.Event {
 	zeroLoggerEvent.Int("total_systems", len(world.systems))
 	arrayLogger := zerolog.Arr()
-	for index, _ := range world.systems {
+	for index := range world.systems {
 		arrayLogger = l.loadSystemIntoArrayLogger(world, index, arrayLogger)
 	}
 	return zeroLoggerEvent.Array("systems", arrayLogger)
 }
 
-func (l *Logger) loadEntityIntoEvent(zeroLoggerEvent *zerolog.Event, world *World, entityID storage.EntityID) (*zerolog.Event, error) {
-	entity, err := world.Entity(entityID)
-	if err != nil {
-		return nil, err
-	}
-
-	archetype := entity.Archetype(world)
+func (l *Logger) loadEntityIntoEvent(zeroLoggerEvent *zerolog.Event, entity storage.Entity, components []IComponentType) (*zerolog.Event, error) {
 	arrayLogger := zerolog.Arr()
-	for _, _component := range archetype.Layout().Components() {
+	for _, _component := range components {
 		arrayLogger = l.loadComponentIntoArrayLogger(_component, arrayLogger)
 	}
 	zeroLoggerEvent.Array("components", arrayLogger)
-	zeroLoggerEvent.Int("entity_id", int(entityID))
+	zeroLoggerEvent.Int("entity_id", int(entity.EntityID()))
 	return zeroLoggerEvent.Int("archetype_id", int(entity.Loc.ArchID)), nil
 }
 
@@ -71,12 +66,12 @@ func (l *Logger) LogSystem(world *World, level zerolog.Level) {
 }
 
 // LogEntity logs entity info given an entityID
-func (l *Logger) LogEntity(world *World, level zerolog.Level, entityID storage.EntityID) {
+func (l *Logger) LogEntity(level zerolog.Level, entity storage.Entity, components []IComponentType) {
 	zeroLoggerEvent := l.WithLevel(level)
 	var err error = nil
-	zeroLoggerEvent, err = l.loadEntityIntoEvent(zeroLoggerEvent, world, entityID)
+	zeroLoggerEvent, err = l.loadEntityIntoEvent(zeroLoggerEvent, entity, components)
 	if err != nil {
-		l.Err(err).Msg(fmt.Sprintf("Error in Logger when retrieving entity with id %d", entityID))
+		l.Err(err).Msg(fmt.Sprintf("Error in Logger when retrieving entity with id %d", entity.EntityID()))
 	} else {
 		zeroLoggerEvent.Send()
 	}

--- a/cardinal/ecs/log_test.go
+++ b/cardinal/ecs/log_test.go
@@ -103,12 +103,16 @@ func TestWorldLogger(t *testing.T) {
 				"archetype_id":0,
 				"message":"created"
 			}`, archetype_creations_json_string)
-	entityId, err := w.Create(w.Archetype(archetypeId).Layout().Components()...)
+	components := w.Archetype(archetypeId).Layout().Components()
+	entityId, err := w.Create(components...)
 	assert.NilError(t, err)
 	buf.Reset()
 
+	entity, err := w.StoreManager().GetEntity(entityId)
+	assert.NilError(t, err)
+
 	// test log entity
-	cardinalLogger.LogEntity(w, zerolog.DebugLevel, entityId)
+	cardinalLogger.LogEntity(zerolog.DebugLevel, entity, components)
 	jsonEntityInfoString := `
 		{
 			"level":"debug",

--- a/cardinal/ecs/storage/entity.go
+++ b/cardinal/ecs/storage/entity.go
@@ -3,17 +3,7 @@ package storage
 import (
 	"errors"
 	"math"
-
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
-
-type WorldAccessor interface {
-	GetArchetypeForComponents([]component.IComponentType) ArchetypeID
-	Entity(id EntityID) (Entity, error)
-	Remove(id EntityID) error
-	Valid(id EntityID) (bool, error)
-	Archetype(ArchetypeID) ArchetypeStorage
-}
 
 var _ EntityManager = &entityMgrImpl{}
 
@@ -78,27 +68,6 @@ var (
 	ErrorComponentAlreadyOnEntity = errors.New("component already on entity")
 	ErrorComponentNotOnEntity     = errors.New("component not on entity")
 )
-
-// Remove removes the entity from the world.
-func (e Entity) Remove(w WorldAccessor) error {
-	return w.Remove(e.ID)
-}
-
-// Valid returns true if the entity is valid.
-func (e Entity) Valid(w WorldAccessor) (bool, error) {
-	ok, err := w.Valid(e.ID)
-	return ok, err
-}
-
-// Archetype returns the archetype.
-func (e Entity) Archetype(w WorldAccessor) ArchetypeStorage {
-	a := e.Loc.ArchID
-	return w.Archetype(a)
-}
-
-func (e Entity) GetComponents(w WorldAccessor) []component.IComponentType {
-	return e.Archetype(w).Layout().Components()
-}
 
 var _ StateStorage = &stateStorageImpl{}
 

--- a/cardinal/ecs/storage/layout.go
+++ b/cardinal/ecs/storage/layout.go
@@ -31,6 +31,8 @@ func (l *Layout) Components() []component.IComponentType {
 }
 
 // HasComponent returns true if the ArchLayout has the given component type.
+//
+// Deprecated: Use component.Contains instead
 func (l *Layout) HasComponent(componentType component.IComponentType) bool {
 	for _, ct := range l.ComponentTypes {
 		if ct == componentType {

--- a/cardinal/ecs/store_manager.go
+++ b/cardinal/ecs/store_manager.go
@@ -4,25 +4,137 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/rs/zerolog"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 type StoreManager struct {
-	store storage.WorldStorage
+	store  storage.WorldStorage
+	logger *Logger
 }
 
-func NewStoreManager(store storage.WorldStorage) *StoreManager {
-	return &StoreManager{store: store}
+func NewStoreManager(store storage.WorldStorage, logger *Logger) *StoreManager {
+	return &StoreManager{
+		store:  store,
+		logger: logger,
+	}
 }
 
-func (s *StoreManager) getEntity(id storage.EntityID) (storage.Entity, error) {
+func (s *StoreManager) InjectLogger(logger *Logger) {
+	s.logger = logger
+}
+
+func (s *StoreManager) GetEntity(id storage.EntityID) (storage.Entity, error) {
 	loc, err := s.getEntityLocation(id)
 	if err != nil {
 		return storage.BadEntity, err
 	}
 	return storage.NewEntity(id, loc), nil
+}
+
+func (s *StoreManager) isValid(id storage.EntityID) (bool, error) {
+	if id == storage.BadID {
+		return false, errors.New("invalid id: id is the bad ID sentinel")
+	}
+	ok, err := s.store.EntityLocStore.ContainsEntity(id)
+	if err != nil {
+		return false, fmt.Errorf("invalid id: failed to find the entity in the entity location store: %w", err)
+	}
+	if !ok {
+		return false, fmt.Errorf("invalid id: id is not in the entity location store")
+	}
+	loc, err := s.store.EntityLocStore.GetLocation(id)
+	if err != nil {
+		return false, fmt.Errorf("invalid id: failed to get the entity's location")
+	}
+	// If the version of the entity is not the same as the version of the archetype,
+	// the entity is invalid (it means the entity is already destroyed).
+	return id == s.store.ArchAccessor.Archetype(loc.ArchID).Entities()[loc.CompIndex], nil
+}
+
+func (s *StoreManager) removeAtLocation(id storage.EntityID, loc storage.Location) error {
+	archetype := s.store.ArchAccessor.Archetype(loc.ArchID)
+	archetype.SwapRemove(loc.CompIndex)
+	err := s.store.CompStore.Remove(loc.ArchID, archetype.Layout().Components(), loc.CompIndex)
+	if err != nil {
+		return err
+	}
+	if int(loc.CompIndex) < len(archetype.Entities()) {
+		swappedID := archetype.Entities()[loc.CompIndex]
+		if err := s.store.EntityLocStore.SetLocation(swappedID, loc); err != nil {
+			return err
+		}
+	}
+	s.store.EntityMgr.Destroy(id)
+	return nil
+}
+
+func (s *StoreManager) RemoveEntity(id storage.EntityID) error {
+	ok, err := s.isValid(id)
+	if err != nil {
+		s.logger.Debug().Int("entity_id", int(id)).Msg("failed to remove")
+		return err
+	}
+	if ok {
+		loc, err := s.store.EntityLocStore.GetLocation(id)
+		if err != nil {
+			return err
+		}
+		if err := s.store.EntityLocStore.Remove(id); err != nil {
+			return err
+		}
+		if err := s.removeAtLocation(id, loc); err != nil {
+			return err
+		}
+	}
+	s.logger.Debug().Int("entity_id", int(id)).Msg("removed")
+	return nil
+}
+
+func (s *StoreManager) CreateEntity(comps ...IComponentType) (storage.EntityID, error) {
+	ids, err := s.CreateManyEntities(1, comps...)
+	if err != nil {
+		return storage.BadID, nil
+	}
+	return ids[0], nil
+}
+
+func (s *StoreManager) CreateManyEntities(num int, comps ...IComponentType) ([]storage.EntityID, error) {
+	archetypeID, err := s.getArchetypeIDForComponents(comps)
+	if err != nil {
+		return nil, err
+	}
+	entities := make([]storage.EntityID, num)
+	for i := range entities {
+		e, err := s.createEntityFromArchetypeID(archetypeID)
+		if err != nil {
+			return nil, err
+		}
+		entities[i] = e
+	}
+	return entities, nil
+}
+
+func (s *StoreManager) createEntityFromArchetypeID(archID storage.ArchetypeID) (storage.EntityID, error) {
+	nextEntityID, err := s.store.EntityMgr.NewEntity()
+	if err != nil {
+		return storage.BadID, err
+	}
+	archetype := s.store.ArchAccessor.Archetype(archID)
+	components := archetype.Layout().Components()
+	componentIndex, err := s.store.CompStore.PushComponents(components, archID)
+	if err != nil {
+		return storage.BadID, err
+	}
+	if err := s.store.EntityLocStore.Insert(nextEntityID, archID, componentIndex); err != nil {
+		return storage.BadID, err
+	}
+	archetype.PushEntity(nextEntityID)
+	entity := storage.NewEntity(nextEntityID, storage.NewLocation(archID, componentIndex))
+	s.logger.LogEntity(zerolog.DebugLevel, entity, components)
+	return nextEntityID, nil
 }
 
 func (s *StoreManager) getEntityLocation(id storage.EntityID) (storage.Location, error) {
@@ -41,6 +153,14 @@ func (s *StoreManager) SetComponentForEntity(cType IComponentType, id storage.En
 	return s.store.CompStore.Storage(cType).SetComponent(loc.ArchID, loc.CompIndex, bz)
 }
 
+func (s *StoreManager) GetComponentTypesForEntity(id storage.EntityID) ([]IComponentType, error) {
+	loc, err := s.getEntityLocation(id)
+	if err != nil {
+		return nil, err
+	}
+	return s.getComponentsForArchetype(loc.ArchID), nil
+}
+
 func (s *StoreManager) GetComponentForEntity(cType IComponentType, id storage.EntityID) (any, error) {
 	loc, err := s.getEntityLocation(id)
 	if err != nil {
@@ -53,8 +173,8 @@ func (s *StoreManager) GetComponentForEntity(cType IComponentType, id storage.En
 	return cType.Decode(bz)
 }
 
-func (s *StoreManager) getComponentsForArchetype(archID storage.ArchetypeID) *storage.Layout {
-	return s.store.ArchAccessor.Archetype(archID).Layout()
+func (s *StoreManager) getComponentsForArchetype(archID storage.ArchetypeID) []component.IComponentType {
+	return s.store.ArchAccessor.Archetype(archID).Layout().Components()
 }
 
 func (s *StoreManager) hasDuplicates(components []IComponentType) bool {
@@ -69,13 +189,13 @@ func (s *StoreManager) hasDuplicates(components []IComponentType) bool {
 	return false
 }
 
-func (s *StoreManager) insertArchetype(layout *storage.Layout) storage.ArchetypeID {
+func (s *StoreManager) insertArchetype(components []component.IComponentType) storage.ArchetypeID {
+	layout := storage.NewLayout(components)
 	s.store.ArchCompIdxStore.Push(layout)
 	archID := storage.ArchetypeID(s.store.ArchAccessor.Count())
 
 	s.store.ArchAccessor.PushArchetype(archID, layout)
-	// TODO: Decide on a good way to get this logger object into this StoreManager
-	// s.logger.Debug().Int("archetype_id", int(archID)).Msg("created")
+	s.logger.Debug().Int("archetype_id", int(archID)).Msg("created")
 	return archID
 }
 
@@ -92,7 +212,7 @@ func (s *StoreManager) getArchetypeIDForComponents(components []IComponentType) 
 		return 0, fmt.Errorf("duplicate component types: %v", components)
 	}
 
-	return s.insertArchetype(storage.NewLayout(components)), nil
+	return s.insertArchetype(components), nil
 }
 
 func (s *StoreManager) transferArchetype(from, to storage.ArchetypeID, idx storage.ComponentIndex) (storage.ComponentIndex, error) {
@@ -158,10 +278,10 @@ func (s *StoreManager) AddComponentToEntity(cType IComponentType, id storage.Ent
 	}
 
 	currComponents := s.getComponentsForArchetype(loc.ArchID)
-	if currComponents.HasComponent(cType) {
+	if component.Contains(currComponents, cType) {
 		return storage.ErrorComponentAlreadyOnEntity
 	}
-	targetComponents := append(currComponents.Components(), cType)
+	targetComponents := append(currComponents, cType)
 	targetArchID, err := s.getArchetypeIDForComponents(targetComponents)
 	if err != nil {
 		return fmt.Errorf("unable to create new archetype: %w", err)
@@ -183,11 +303,11 @@ func (s *StoreManager) RemoveComponentFromEntity(cType IComponentType, id storag
 	}
 
 	currComponents := s.getComponentsForArchetype(loc.ArchID)
-	if !currComponents.HasComponent(cType) {
+	if !component.Contains(currComponents, cType) {
 		return storage.ErrorComponentNotOnEntity
 	}
-	targetComponents := make([]component.IComponentType, 0, len(currComponents.Components())-1)
-	for _, c2 := range currComponents.Components() {
+	targetComponents := make([]component.IComponentType, 0, len(currComponents)-1)
+	for _, c2 := range currComponents {
 		if c2 == cType {
 			continue
 		}

--- a/cardinal/log.go
+++ b/cardinal/log.go
@@ -1,6 +1,8 @@
 package cardinal
 
 import (
+	"fmt"
+
 	"github.com/rs/zerolog"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 )
@@ -20,7 +22,18 @@ func (l *Logger) LogSystem(world *World, level zerolog.Level) {
 
 // LogEntity logs entity info given an entityID
 func (l *Logger) LogEntity(world *World, level zerolog.Level, entityID EntityID) {
-	l.impl.LogEntity(world.impl, level, entityID)
+	entity, err := world.impl.StoreManager().GetEntity(entityID)
+	if err != nil {
+		l.impl.Warn().Err(fmt.Errorf("failed to get entity %d: %w", entityID, err))
+		return
+	}
+	components, err := world.impl.StoreManager().GetComponentTypesForEntity(entityID)
+	if err != nil {
+		l.impl.Warn().Err(fmt.Errorf("failed to get components for entity %d: %w", entityID, err))
+		return
+	}
+
+	l.impl.LogEntity(level, entity, components)
 }
 
 // LogWorld Logs everything about the world (components and Systems)

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -387,12 +387,10 @@ func registerReadHandlerSwagger(world *ecs.World, api *untyped.API, handler *Han
 		result := make([]cql.QueryResponse, 0)
 
 		ecs.NewQuery(resultFilter).Each(world, func(id storage.EntityID) bool {
-			var entity storage.Entity
-			entity, err = world.Entity(id)
+			components, err := world.StoreManager().GetComponentTypesForEntity(id)
 			if err != nil {
 				return false
 			}
-			components := entity.GetComponents(world)
 			resultElement := cql.QueryResponse{
 				id,
 				make([]json.RawMessage, 0),


### PR DESCRIPTION
Closes: #WORLD-321

## What is the purpose of the change

- Finish removing the WorldAccessor interface
- Move move the Create/Remove code for entities into the store_manager.go source file.
- Make an alternative way to check if a component is in a slice of components. This is a preparation step for the eventual removal of the Layout struct.


## Testing and Verifying

Existing unit tests verify that there are no functional changes.