### PR TITLE
refactor(cardinal): update game loop to tick exactly at the specified interval

### DIFF
--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -562,9 +562,15 @@ func (w *World) StartGameLoop(ctx context.Context, loopInterval time.Duration) {
 		w.Logger.Warn().Msg("No systems registered.")
 	}
 	go func() {
-		for range time.Tick(loopInterval) {
+		for {
+			tickStart := time.Now()
 			if err := w.Tick(ctx); err != nil {
-				w.Logger.Panic().Err(err).Msg("Error running Tick in Game Loop.")
+				w.Logger.Fatal().Err(err).Msg("error running tick in game loop")
+			}
+			tickEnd := time.Now()
+			result := tickEnd.Sub(tickStart)
+			if result < loopInterval {
+				time.Sleep(loopInterval - result)
 			}
 		}
 	}()


### PR DESCRIPTION
## What is the purpose of the change

before, we our ticks would run at `loopInterval` + the time taken to execute the systems. 

this PR introduces a change that calculates the time it takes to execute the systems, and then sleeps if there is remaining time in the specified loop interval. 

also changes the `panic` if errors occur to a `log.Fatal` so that the entire system shuts down, instead of just the go game loop routine.

## Brief Changelog

- update tick timing logic
- change panic to log.Fatal if error returned in system

## Testing and Verifying

