### PR TITLE
feat(cardinal): prepare swagger routes for starter-template

### DIFF
--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -326,6 +326,7 @@ func createAllEndpoints(world *ecs.World) (*EndpointsResult, error) {
 	queryEndpoints = append(queryEndpoints, "/query/http/endpoints")
 	queryEndpoints = append(queryEndpoints, "/query/persona/signer")
 	queryEndpoints = append(queryEndpoints, "/query/receipt/list")
+	queryEndpoints = append(queryEndpoints, "/query/game/cql")
 	return &EndpointsResult{
 		TxEndpoints:    txEndpoints,
 		QueryEndpoints: queryEndpoints,

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -60,6 +60,8 @@ const (
 )
 
 // NewHandler instantiates handler function for creating a swagger server that validates itself based on a swagger spec.
+// transaction and read registered with the given world is automatically created. The server runs on a default port
+// of 4040, but can be changed via options or by setting an environment variable with key CARDINAL_PORT.
 func NewHandler(w *ecs.World, opts ...Option) (*Handler, error) {
 	h, err := newSwaggerHandlerEmbed(w, opts...)
 	if err != nil {
@@ -450,8 +452,7 @@ func registerReadHandlerSwagger(world *ecs.World, api *untyped.API, handler *Han
 }
 
 // OldHandler returns a new Handler that can handle HTTP requests. An HTTP endpoint for each
-// transaction and read registered with the given world is automatically created. The server runs on a default port
-// of 4040, but can be changed via options or by setting an environment variable with key CARDINAL_PORT.
+// deprecated
 func OldHandler(w *ecs.World, opts ...Option) (*Handler, error) {
 	th := &Handler{
 		w:   w,

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -59,8 +59,8 @@ const (
 	getSignerForPersonaStatusAssigned  = "assigned"
 )
 
-// NewSwaggerHandler instantiates handler function for creating a swagger server that validates itself based on a swagger spec.
-func NewSwaggerHandler(w *ecs.World, opts ...Option) (*Handler, error) {
+// NewHandler instantiates handler function for creating a swagger server that validates itself based on a swagger spec.
+func NewHandler(w *ecs.World, opts ...Option) (*Handler, error) {
 	h, err := newSwaggerHandlerEmbed(w, opts...)
 	if err != nil {
 		return nil, err
@@ -80,43 +80,6 @@ func newSwaggerHandlerEmbed(w *ecs.World, opts ...Option) (*Handler, error) {
 		opt(th)
 	}
 	specDoc, err := loads.Analyzed(swaggerData, "")
-	if err != nil {
-		return nil, err
-	}
-	api := untyped.NewAPI(specDoc).WithoutJSONDefaults()
-	api.RegisterConsumer("application/json", runtime.JSONConsumer())
-	api.RegisterProducer("application/json", runtime.JSONProducer())
-	err = registerTxHandlerSwagger(w, api, th)
-	if err != nil {
-		return nil, err
-	}
-	err = registerReadHandlerSwagger(w, api, th)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := api.Validate(); err != nil {
-		return nil, err
-	}
-
-	app := middleware.NewContext(specDoc, api, nil)
-
-	th.mux.Handle("/", app.APIHandler(nil))
-	th.initialize()
-
-	return th, nil
-}
-
-func newSwaggerHandlerWithPath(w *ecs.World, pathToSwaggerSpec string, opts ...Option) (*Handler, error) {
-
-	th := &Handler{
-		w:   w,
-		mux: http.NewServeMux(),
-	}
-	for _, opt := range opts {
-		opt(th)
-	}
-	specDoc, err := loads.Spec(pathToSwaggerSpec)
 	if err != nil {
 		return nil, err
 	}
@@ -486,10 +449,10 @@ func registerReadHandlerSwagger(world *ecs.World, api *untyped.API, handler *Han
 	return nil
 }
 
-// NewHandler returns a new Handler that can handle HTTP requests. An HTTP endpoint for each
+// OldHandler returns a new Handler that can handle HTTP requests. An HTTP endpoint for each
 // transaction and read registered with the given world is automatically created. The server runs on a default port
 // of 4040, but can be changed via options or by setting an environment variable with key CARDINAL_PORT.
-func NewHandler(w *ecs.World, opts ...Option) (*Handler, error) {
+func OldHandler(w *ecs.World, opts ...Option) (*Handler, error) {
 	th := &Handler{
 		w:   w,
 		mux: http.NewServeMux(),

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -58,9 +58,9 @@ func makeTestTransactionHandler(t *testing.T, world *ecs.World, swaggerFilePath 
 	var txh *Handler
 	var err error
 	if len(swaggerFilePath) == 0 {
-		txh, err = NewHandler(world, opts...)
+		txh, err = OldHandler(world, opts...)
 	} else {
-		txh, err = NewSwaggerHandler(world, opts...)
+		txh, err = NewHandler(world, opts...)
 	}
 	assert.NilError(t, err)
 
@@ -113,9 +113,9 @@ func TestIfServeSetEnvVarForPort(t *testing.T) {
 		var txh *Handler
 		var err error
 		if !isTestingSwagger {
-			txh, err = NewHandler(world, DisableSignatureVerification())
+			txh, err = OldHandler(world, DisableSignatureVerification())
 		} else if isTestingSwagger {
-			txh, err = NewSwaggerHandler(world, DisableSignatureVerification())
+			txh, err = NewHandler(world, DisableSignatureVerification())
 		} else {
 			t.Fail()
 		}

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -60,7 +60,7 @@ func makeTestTransactionHandler(t *testing.T, world *ecs.World, swaggerFilePath 
 	if len(swaggerFilePath) == 0 {
 		txh, err = NewHandler(world, opts...)
 	} else {
-		txh, err = NewSwaggerHandler(world, swaggerFilePath, opts...)
+		txh, err = NewSwaggerHandler(world, opts...)
 	}
 	assert.NilError(t, err)
 
@@ -115,7 +115,7 @@ func TestIfServeSetEnvVarForPort(t *testing.T) {
 		if !isTestingSwagger {
 			txh, err = NewHandler(world, DisableSignatureVerification())
 		} else if isTestingSwagger {
-			txh, err = NewSwaggerHandler(world, "./swagger.yml", DisableSignatureVerification())
+			txh, err = NewSwaggerHandler(world, DisableSignatureVerification())
 		} else {
 			t.Fail()
 		}

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -227,7 +227,9 @@ func TestHandleTransactionWithNoSignatureVerification(t *testing.T) {
 
 		assert.NilError(t, w.Tick(context.Background()))
 		assert.Equal(t, 1, count)
-		txh.Close()
+		err = txh.Close()
+		assert.NilError(t, err)
+
 	}
 }
 
@@ -307,7 +309,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 	//Test /query/http/endpoints
 	expectedEndpointResult := EndpointsResult{
 		TxEndpoints:    []string{"/tx/persona/create-persona", "/tx/persona/authorize-persona-address", "/tx/game/send-energy"},
-		QueryEndpoints: []string{"/query/game/foo", "/query/http/endpoints", "/query/persona/signer", "/query/receipt/list"},
+		QueryEndpoints: []string{"/query/game/foo", "/query/http/endpoints", "/query/persona/signer", "/query/receipt/list", "/query/game/cql"},
 	}
 	resp1, err := http.Post(txh.makeURL("query/http/endpoints"), "application/json", nil)
 	assert.NilError(t, err)

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -104,7 +104,7 @@ func (w *World) StartGame() error {
 	if err := w.impl.LoadGameState(); err != nil {
 		return err
 	}
-	txh, err := server.NewSwaggerHandler(w.impl, "./server/swagger.yml", w.serverOptions...)
+	txh, err := server.NewSwaggerHandler(w.impl, w.serverOptions...)
 	if err != nil {
 		return err
 	}

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -104,7 +104,7 @@ func (w *World) StartGame() error {
 	if err := w.impl.LoadGameState(); err != nil {
 		return err
 	}
-	txh, err := server.NewSwaggerHandler(w.impl, w.serverOptions...)
+	txh, err := server.NewHandler(w.impl, w.serverOptions...)
 	if err != nil {
 		return err
 	}

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -104,7 +104,7 @@ func (w *World) StartGame() error {
 	if err := w.impl.LoadGameState(); err != nil {
 		return err
 	}
-	txh, err := server.NewHandler(w.impl, w.serverOptions...)
+	txh, err := server.NewSwaggerHandler(w.impl, "./server/swagger.yml", w.serverOptions...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes: #WORLD-317

## What is the purpose of the change

Added new route /query/game/cql for the endpoint route.
Used some macro library to embedd the swagger.yml into the library so it doesn't have to be referenced by path. 
Replaced NewHandler with the swagger definition and retitled the old definition to OldHandler

When this is approved I will tag this with a new version and use it in the starter-template. 


## Testing and Verifying

ran go test ./... in cardinal. 