### PR TITLE
refactor(cardinal): Move encode and decode out of storage and into a codec package

### DIFF
--- a/cardinal/ecs/codec/codec.go
+++ b/cardinal/ecs/codec/codec.go
@@ -1,4 +1,4 @@
-package storage
+package codec
 
 import (
 	"bytes"

--- a/cardinal/ecs/component.go
+++ b/cardinal/ecs/component.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"unsafe"
 
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
@@ -146,15 +147,15 @@ func (c *ComponentType[T]) New() ([]byte, error) {
 	if c.defaultVal != nil {
 		comp = c.defaultVal.(T)
 	}
-	return storage.Encode(comp)
+	return codec.Encode(comp)
 }
 
 func (c *ComponentType[T]) Encode(v any) ([]byte, error) {
-	return storage.Encode(v)
+	return codec.Encode(v)
 }
 
 func (c *ComponentType[T]) Decode(bz []byte) (any, error) {
-	return storage.Decode[T](bz)
+	return codec.Decode[T](bz)
 }
 
 func (c *ComponentType[T]) setDefaultVal(ptr unsafe.Pointer) {

--- a/cardinal/ecs/component/components_test.go
+++ b/cardinal/ecs/component/components_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
@@ -57,11 +58,11 @@ func TestComponents(t *testing.T) {
 				t.Errorf("storage should contain the component at %d, %d", tt.archID, tt.compIdx)
 			}
 			bz, _ := st.Component(tt.archID, tt.compIdx)
-			dat, err := storage2.Decode[ComponentData](bz)
+			dat, err := codec.Decode[ComponentData](bz)
 			assert.NilError(t, err)
 			dat.ID = tt.ID
 
-			compBz, err := storage2.Encode(dat)
+			compBz, err := codec.Encode(dat)
 			assert.NilError(t, err)
 
 			err = st.SetComponent(tt.archID, tt.compIdx, compBz)
@@ -94,7 +95,7 @@ func TestComponents(t *testing.T) {
 	}
 
 	bz, _ := storage.Component(dstArchIdx, newCompIdx)
-	dat, err := storage2.Decode[ComponentData](bz)
+	dat, err := codec.Decode[ComponentData](bz)
 	assert.NilError(t, err)
 	if dat.ID != target.ID {
 		t.Errorf("component should have ID '%s', got ID '%s'", target.ID, dat.ID)

--- a/cardinal/ecs/storage/archetype.go
+++ b/cardinal/ecs/storage/archetype.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
@@ -57,7 +58,7 @@ func (a *archetypeStorageImpl) Marshal() ([]byte, error) {
 			archs[i].ComponentIDs = append(archs[i].ComponentIDs, c.ID())
 		}
 	}
-	return Encode(archs)
+	return codec.Encode(archs)
 }
 
 var (
@@ -95,7 +96,7 @@ func (c idsToComponents) convert(ids []component.TypeID) (comps []component.ICom
 // an archetypeStorageImpl. The slice of components is required because the interfaces were not
 // actually serialized to bytes, just their IDs.
 func (a *archetypeStorageImpl) UnmarshalWithComps(bytes []byte, components []component.IComponentType) error {
-	archetypesFromStorage, err := Decode[[]archForStorage](bytes)
+	archetypesFromStorage, err := codec.Decode[[]archForStorage](bytes)
 	if err != nil {
 		return err
 	}

--- a/cardinal/ecs/storage/legacy_storage.go
+++ b/cardinal/ecs/storage/legacy_storage.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"fmt"
 
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 )
@@ -269,11 +270,11 @@ func (idx *Index) Marshal() ([]byte, error) {
 		}
 		layouts = append(layouts, currIDs)
 	}
-	return Encode(layouts)
+	return codec.Encode(layouts)
 }
 
 func (idx *Index) UnmarshalWithComps(bytes []byte, comps []component.IComponentType) error {
-	layouts, err := Decode[[][]component.TypeID](bytes)
+	layouts, err := codec.Decode[[][]component.TypeID](bytes)
 	if err != nil {
 		return err
 	}

--- a/cardinal/ecs/storage/legacy_storage_test.go
+++ b/cardinal/ecs/storage/legacy_storage_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
@@ -30,7 +31,7 @@ func TestStorage_Bytes(t *testing.T) {
 	for _, test := range tests {
 		err := store.PushComponent(componentType, archIdx)
 		assert.NilError(t, err)
-		bz, err := storage.Encode(Component{ID: test.ID})
+		bz, err := codec.Encode(Component{ID: test.ID})
 		assert.NilError(t, err)
 		fmt.Println(string(bz))
 		store.SetComponent(archIdx, compIdx, bz)
@@ -40,7 +41,7 @@ func TestStorage_Bytes(t *testing.T) {
 	compIdx = 0
 	for _, test := range tests {
 		bz, _ := store.Component(archIdx, compIdx)
-		c, err := storage.Decode[*Component](bz)
+		c, err := codec.Decode[*Component](bz)
 		assert.NilError(t, err)
 		assert.Equal(t, c.ID, test.expected)
 		compIdx++
@@ -48,7 +49,7 @@ func TestStorage_Bytes(t *testing.T) {
 
 	removed, _ := store.SwapRemove(archIdx, 1)
 	assert.Assert(t, removed != nil, "removed component should not be nil")
-	comp, err := storage.Decode[Component](removed)
+	comp, err := codec.Decode[Component](removed)
 	assert.NilError(t, err)
 	assert.Equal(t, comp.ID, "b", "removed component should have ID 'b'")
 
@@ -63,7 +64,7 @@ func TestStorage_Bytes(t *testing.T) {
 
 	for _, test := range tests2 {
 		compBz, _ := store.Component(test.archIdx, test.cmpIdx)
-		comp, err := storage.Decode[Component](compBz)
+		comp, err := codec.Decode[Component](compBz)
 		assert.NilError(t, err)
 		assert.Equal(t, comp.ID, test.expectedID)
 		compIdx++

--- a/cardinal/ecs/storage/location_map.go
+++ b/cardinal/ecs/storage/location_map.go
@@ -1,1 +1,0 @@
-package storage

--- a/cardinal/ecs/storage/mock.go
+++ b/cardinal/ecs/storage/mock.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"unsafe"
 
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
@@ -42,7 +43,7 @@ func (m *MockComponentType[T]) New() ([]byte, error) {
 	if m.defaultVal != nil {
 		comp = m.defaultVal.(T)
 	}
-	return Encode(comp)
+	return codec.Encode(comp)
 }
 
 func (m *MockComponentType[T]) setDefaultVal(ptr unsafe.Pointer) {
@@ -57,9 +58,9 @@ func (m *MockComponentType[T]) Name() string {
 var _ component.IComponentType = &MockComponentType[int]{}
 
 func (m *MockComponentType[T]) Decode(bytes []byte) (any, error) {
-	return Decode[T](bytes)
+	return codec.Decode[T](bytes)
 }
 
 func (m *MockComponentType[T]) Encode(a any) ([]byte, error) {
-	return Encode(a)
+	return codec.Encode(a)
 }

--- a/cardinal/ecs/storage/redis_storage.go
+++ b/cardinal/ecs/storage/redis_storage.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 	"pkg.world.dev/world-engine/sign"
@@ -262,7 +263,7 @@ func (r *RedisStorage) Insert(id EntityID, archID ArchetypeID, componentIndex Co
 	ctx := context.Background()
 	key := r.entityLocationKey(id)
 	loc := NewLocation(archID, componentIndex)
-	bz, err := Encode(loc)
+	bz, err := codec.Encode(loc)
 	if err != nil {
 		return err
 	}
@@ -281,7 +282,7 @@ func (r *RedisStorage) Insert(id EntityID, archID ArchetypeID, componentIndex Co
 func (r *RedisStorage) SetLocation(id EntityID, location Location) error {
 	ctx := context.Background()
 	key := r.entityLocationKey(id)
-	bz, err := Encode(location)
+	bz, err := codec.Encode(location)
 	if err != nil {
 		return err
 	}
@@ -303,7 +304,7 @@ func (r *RedisStorage) GetLocation(id EntityID) (loc Location, err error) {
 	if err != nil {
 		return loc, err
 	}
-	loc, err = Decode[Location](bz)
+	loc, err = codec.Decode[Location](bz)
 	if err != nil {
 		return loc, err
 	}
@@ -431,7 +432,7 @@ func (r *RedisStorage) getTickDetails(ctx context.Context) (tickDetails, error) 
 		return tickDetails{}, err
 	}
 
-	details, err := Decode[tickDetails](buf)
+	details, err := codec.Decode[tickDetails](buf)
 	if err != nil {
 		return tickDetails{}, err
 	}
@@ -439,7 +440,7 @@ func (r *RedisStorage) getTickDetails(ctx context.Context) (tickDetails, error) 
 }
 
 func (r *RedisStorage) setTickDetails(ctx context.Context, details tickDetails) error {
-	buf, err := Encode(details)
+	buf, err := codec.Encode(details)
 	if err != nil {
 		return err
 	}
@@ -485,7 +486,7 @@ func (r *RedisStorage) storeTransactions(ctx context.Context, txs []transaction.
 }
 
 func (r *RedisStorage) storePendingTransactionsInRedis(ctx context.Context, pending []pendingTransaction) error {
-	buf, err := Encode(pending)
+	buf, err := codec.Encode(pending)
 	if err != nil {
 		return err
 	}
@@ -499,7 +500,7 @@ func (r *RedisStorage) getPendingTransactionsFromRedis(ctx context.Context) ([]p
 	if err != nil {
 		return nil, err
 	}
-	return Decode[[]pendingTransaction](buf)
+	return codec.Decode[[]pendingTransaction](buf)
 }
 
 func (r *RedisStorage) StartNextTick(txs []transaction.ITransaction, queue *transaction.TxQueue) error {

--- a/cardinal/ecs/storage/redis_test.go
+++ b/cardinal/ecs/storage/redis_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"testing"
 
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
 
 	"github.com/ethereum/go-ethereum/crypto"
@@ -54,7 +55,7 @@ func TestList(t *testing.T) {
 	assert.NilError(t, err)
 
 	bz, _ := compStore.Component(1, 1)
-	foo, err := storage.Decode[SomeComp](bz)
+	foo, err := codec.Decode[SomeComp](bz)
 	assert.NilError(t, err)
 	assert.Equal(t, foo.Foo, 20)
 
@@ -165,7 +166,7 @@ func TestCanSaveAndRecoverArbitraryData(t *testing.T) {
 			"gamma": 300,
 		},
 	}
-	buf, err := storage.Encode(wantData)
+	buf, err := codec.Encode(wantData)
 	assert.NilError(t, err)
 
 	const key = "foobar"
@@ -176,7 +177,7 @@ func TestCanSaveAndRecoverArbitraryData(t *testing.T) {
 	assert.Equal(t, true, ok)
 	assert.NilError(t, err)
 
-	gotData, err := storage.Decode[*SomeData](gotBytes)
+	gotData, err := codec.Decode[*SomeData](gotBytes)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, gotData, wantData)
 }

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/invopop/jsonschema"
-	"pkg.world.dev/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 	"pkg.world.dev/world-engine/sign"
 )
@@ -147,11 +147,11 @@ func (t *TransactionType[In, Out]) In(tq *transaction.TxQueue) []TxData[In] {
 }
 
 func (t *TransactionType[In, Out]) Encode(a any) ([]byte, error) {
-	return storage.Encode(a)
+	return codec.Encode(a)
 }
 
 func (t *TransactionType[In, Out]) Decode(bytes []byte) (any, error) {
-	return storage.Decode[In](bytes)
+	return codec.Decode[In](bytes)
 }
 
 // ABIEncode encodes the input to the transactions matching evm type. If the input is not either of the transactions


### PR DESCRIPTION

## What is the purpose of the change

Create a codec package to contain our Encode and Decode code. There no reason this needs to be in storage, and we break up storage into different packages, we want those other packages to easily be able to use Encode and Decode.

