### PR TITLE
refactor(chain): defaults for shard sequencer

### DIFF
--- a/chain/Dockerfile
+++ b/chain/Dockerfile
@@ -10,7 +10,8 @@ RUN CGO_ENABLED=1 make install
 # build on ubuntu
 FROM ubuntu:18.04
 COPY --from=argusd-builder /go/bin/world /usr/local/bin/
-EXPOSE 26656 26657 1317 9090
+EXPOSE 26656 26657 1317 9090 8546 8545 9601
+
 USER 0
 
 COPY scripts/start-rollup.sh start-rollup.sh

--- a/chain/README.md
+++ b/chain/README.md
@@ -141,12 +141,47 @@ Start the `chain` and `celestia-devnet` using `chain/docker-compose.yml`, make s
   docker compose up chain --build --detach
   ```
 
+## Features
+
+### Game Shard Tx Sequencer
+
+The rollup is extended via a special gRPC server that game shards can connect to for the purpose of submitting and storing transactions to the base shard.
+
+This gRPC server runs, by default, at port `9601`, but can be configured by setting the `SHARD_SEQUENCER_PORT` environment variable.
+
+### Router
+
+The rollup provides an extension to it's underlying EVM environment with a specialized precompile that allows messages to be forwarded from smart contracts to game shards that implement the router server.
+
+The router must be informed of the game shard's server address by setting the environment variable `CARDINAL_EVM_LISTENER_ADDR`. 
+
+#### Using the Router in Solidity
+
+In order to use the precompile, you first need to copy over the precompile contract code. The contract lives at:
+
+`chain/contracts/src/cosmos/precompile/router.sol`
+
+The precompile address will always be `0x356833c4666fFB6bFccbF8D600fa7282290dE073`.
+
+Instantiating the precompile is done like so:
+
+```solidity
+// the path of import will change depending on where you copied the 
+// precompile contract code to.
+import {IRouter} from "./precompile/router.sol";
+
+contract SomeGame {
+    IRouter public immutable router;
+
+    constructor () {
+        router = IRouter(0x356833c4666fFB6bFccbF8D600fa7282290dE073);
+    }
+}
+
+```
+
 ## Environment Variables
 The following env variables must be set for the following features.
-
-### Game Shard Tx Storage
-- USE_SHARD_LISTENER=true
-- SHARD_HANDLER_LISTEN_ADDR=<the address you want this server to listen on (i.e. 10.209.21:3090)
 
 ### Secure gRPC Connections
 For production environments, you'll likely want to setup secure connections between gRPC servers handling system transactions.

--- a/chain/app/app.go
+++ b/chain/app/app.go
@@ -147,6 +147,7 @@ func NewApp(
 	baseAppOptions ...func(*baseapp.BaseApp),
 ) *App {
 	app := &App{}
+	app.setPlugins()
 	var (
 		appBuilder   *runtime.AppBuilder
 		ethTxMempool = evmmempool.NewPolarisEthereumTxPool()
@@ -310,8 +311,6 @@ func NewApp(
 	if err = app.Load(loadLatest); err != nil {
 		panic(err)
 	}
-
-	app.setPlugins()
 
 	return app
 }

--- a/chain/app/plugins.go
+++ b/chain/app/plugins.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"github.com/rs/zerolog/log"
 	"os"
 	"pkg.world.dev/world-engine/chain/router"
 	"pkg.world.dev/world-engine/chain/shard"
@@ -12,7 +13,7 @@ func (app *App) setPlugins() {
 	keyPath := os.Getenv("SERVER_KEY_PATH")
 	var opt shard.Option
 	if certPath == "" && keyPath == "" {
-		app.Logger().Info("WARNING: running shard sequencer without SSL certs")
+		log.Warn().Msg("running shard sequencer without SSL certs")
 	} else {
 		opt = shard.WithCredentials(certPath, keyPath)
 	}
@@ -24,6 +25,6 @@ func (app *App) setPlugins() {
 		clientCert := os.Getenv("CLIENT_CERT_PATH")
 		app.Router = router.NewRouter(cardinalShardAddr, router.WithCredentials(clientCert))
 	} else {
-		app.Logger().Info("WARNING: router is not running")
+		log.Warn().Msg("router is not running")
 	}
 }

--- a/chain/app/plugins.go
+++ b/chain/app/plugins.go
@@ -11,13 +11,13 @@ func (app *App) setPlugins() {
 	// TODO: clean this up. maybe a config?
 	certPath := os.Getenv("SERVER_CERT_PATH")
 	keyPath := os.Getenv("SERVER_KEY_PATH")
-	var opt shard.Option
-	if certPath == "" && keyPath == "" {
+	if certPath == "" || keyPath == "" {
 		log.Warn().Msg("running shard sequencer without SSL certs")
+		app.ShardSequencer = shard.NewShardSequencer()
 	} else {
-		opt = shard.WithCredentials(certPath, keyPath)
+		app.ShardSequencer = shard.NewShardSequencer(shard.WithCredentials(certPath, keyPath))
 	}
-	app.ShardSequencer = shard.NewShardSequencer(opt)
+
 	app.ShardSequencer.Serve()
 
 	cardinalShardAddr := os.Getenv("CARDINAL_EVM_LISTENER_ADDR")

--- a/chain/app/plugins.go
+++ b/chain/app/plugins.go
@@ -8,17 +8,22 @@ import (
 
 func (app *App) setPlugins() {
 	// TODO: clean this up. maybe a config?
-	shardHandlerListener := os.Getenv("SHARD_HANDLER_LISTEN_ADDR")
-	if shardHandlerListener != "" {
-		certPath := os.Getenv("SERVER_CERT_PATH")
-		keyPath := os.Getenv("SERVER_KEY_PATH")
-		app.ShardHandler = shard.NewShardServer(shard.WithCredentials(certPath, keyPath))
-		app.ShardHandler.Serve(shardHandlerListener)
+	certPath := os.Getenv("SERVER_CERT_PATH")
+	keyPath := os.Getenv("SERVER_KEY_PATH")
+	var opt shard.Option
+	if certPath == "" && keyPath == "" {
+		app.Logger().Info("WARNING: running shard sequencer without SSL certs")
+	} else {
+		opt = shard.WithCredentials(certPath, keyPath)
 	}
+	app.ShardSequencer = shard.NewShardSequencer(opt)
+	app.ShardSequencer.Serve()
 
 	cardinalShardAddr := os.Getenv("CARDINAL_EVM_LISTENER_ADDR")
 	if cardinalShardAddr != "" {
 		clientCert := os.Getenv("CLIENT_CERT_PATH")
 		app.Router = router.NewRouter(cardinalShardAddr, router.WithCredentials(clientCert))
+	} else {
+		app.Logger().Info("WARNING: router is not running")
 	}
 }

--- a/chain/precompile/router/router_test.go
+++ b/chain/precompile/router/router_test.go
@@ -21,6 +21,7 @@
 package router
 
 import (
+	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"testing"
 
@@ -35,6 +36,7 @@ import (
 )
 
 func TestRouterPrecompile(t *testing.T) {
+	fmt.Println(common.BytesToAddress(authtypes.NewModuleAddress(name)))
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "cosmos/precompile/router")
 }

--- a/chain/precompile/router/router_test.go
+++ b/chain/precompile/router/router_test.go
@@ -21,7 +21,6 @@
 package router
 
 import (
-	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"testing"
 
@@ -36,7 +35,6 @@ import (
 )
 
 func TestRouterPrecompile(t *testing.T) {
-	fmt.Println(common.BytesToAddress(authtypes.NewModuleAddress(name)))
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "cosmos/precompile/router")
 }

--- a/chain/shard/option.go
+++ b/chain/shard/option.go
@@ -1,9 +1,9 @@
 package shard
 
-type Option func(*Server)
+type Option func(*Sequencer)
 
 func WithCredentials(certPath, keyPath string) Option {
-	return func(server *Server) {
+	return func(server *Sequencer) {
 		creds, err := loadCredentials(certPath, keyPath)
 		if err != nil {
 			panic(err)

--- a/chain/shard/server.go
+++ b/chain/shard/server.go
@@ -13,17 +13,23 @@ import (
 	"log"
 	"net"
 	"os"
+	"strconv"
 	"sync"
 
 	"pkg.world.dev/world-engine/chain/x/shard/types"
 )
 
-var (
-	Name                              = "shard_handler_server"
-	_    shardgrpc.ShardHandlerServer = &Server{}
+const (
+	defaultPort = "9601"
 )
 
-type Server struct {
+var (
+	Name                              = "shard_sequencer"
+	_    shardgrpc.ShardHandlerServer = &Sequencer{}
+)
+
+// Sequencer handles sequencing game shard transactions.
+type Sequencer struct {
 	moduleAddr sdk.AccAddress
 	tq         *TxQueue
 
@@ -31,13 +37,19 @@ type Server struct {
 	creds credentials.TransportCredentials
 }
 
-func NewShardServer(opts ...Option) *Server {
+// NewShardSequencer returns a new game shardsequencer server. It runs on a default port of 9601,
+// unless the SHARD_SEQUENCER_PORT environment variable is set.
+//
+// The sequencer exposes a single gRPC endpoint, SubmitShardTx, which will take in transactions from game shards,
+// indexed by namespace. At every block, the sequencer tx queue is flushed, and processed in the storage shard storage
+// module, persisting the data to the blockchain.
+func NewShardSequencer(opts ...Option) *Sequencer {
 	addr := authtypes.NewModuleAddress(Name)
-	s := &Server{
+	s := &Sequencer{
 		moduleAddr: addr,
 		tq: &TxQueue{
 			lock:       sync.Mutex{},
-			ntx:        make(NamespacedTxs, 0),
+			ntx:        make(NamespacedTxs),
 			outbox:     make([]*types.SubmitShardTxRequest, 0),
 			moduleAddr: addr.String(),
 		},
@@ -72,11 +84,18 @@ func loadCredentials(certPath, keyPath string) (credentials.TransportCredentials
 	return credentials.NewTLS(config), nil
 }
 
-// Serve serves the application in a new go routine. The routine panics if serve fails.
-func (s *Server) Serve(listenAddr string) {
+// Serve serves the server in a new go routine.
+func (s *Sequencer) Serve() {
 	grpcServer := grpc.NewServer(grpc.Creds(s.creds))
 	shardgrpc.RegisterShardHandlerServer(grpcServer, s)
-	listener, err := net.Listen("tcp", listenAddr)
+	port := defaultPort
+	// check if a custom port was set
+	if setPort := os.Getenv("SHARD_SEQUENCER_PORT"); setPort != "" {
+		if _, err := strconv.Atoi(setPort); err == nil {
+			port = setPort
+		}
+	}
+	listener, err := net.Listen("tcp", ":"+port)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -88,14 +107,13 @@ func (s *Server) Serve(listenAddr string) {
 	}()
 }
 
-// FlushMessages gets the next available batch of transactions ready to be stored.
-func (s *Server) FlushMessages() []*types.SubmitShardTxRequest {
+// FlushMessages empties and returns all messages stored in the queue.
+func (s *Sequencer) FlushMessages() []*types.SubmitShardTxRequest {
 	return s.tq.GetTxs()
 }
 
-// SubmitShardTx appends the game shard tx submission to the tx queue, which eventually gets executed during
-// abci.EndBlock.
-func (s *Server) SubmitShardTx(_ context.Context, req *shard.SubmitShardTxRequest) (
+// SubmitShardTx appends the game shard tx submission to the tx queue.
+func (s *Sequencer) SubmitShardTx(_ context.Context, req *shard.SubmitShardTxRequest) (
 	*shard.SubmitShardTxResponse, error) {
 	bz, err := proto.Marshal(req.Tx)
 	if err != nil {

--- a/chain/shard/server_test.go
+++ b/chain/shard/server_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestServer(t *testing.T) {
-	s := NewShardServer()
+	s := NewShardSequencer()
 	ctx := context.Background()
 	_, err := s.SubmitShardTx(ctx, &shardv1.SubmitShardTxRequest{
 		Epoch: 1,


### PR DESCRIPTION
## What is the purpose of the change

streamlines the shard sequencer code, and adds light documentation about the two main rollup features.


## Brief Changelog

- simplifies the shard sequencer server, by using a default port instead of requiring one to be explicitly set.
- changes shard handler server to `Sequencer` to be more specific about what this component does
- updates some comments
- add light explainer for the two custom features of the rollup chain

## Testing and Verifying

_(Please pick one of the following options)_

This change is a trivial rework/code cleanup without any test coverage.

_(or)_

This change is already covered by existing tests, such as _(please describe tests)_.

_(or)_

This change added tests and can be verified as follows:

_(example:)_

- _Added unit test that validates ..._
- _Added integration tests for end-to-end deployment with ..._
- _Extended integration test for ..._
- _Manually verified the change by ..._
