### PR TITLE
chore(cardinal): change name for CQL from component query language to cardinal query l…

### DIFF
--- a/cardinal/server/swagger.yml
+++ b/cardinal/server/swagger.yml
@@ -85,8 +85,8 @@ paths:
 
     /query/game/cql:
         post:
-            summary: Query the ecs with CQL (component query language)
-            description: Query the ecs with CQL (component query language)
+            summary: Query the ecs with CQL (cardinal query language)
+            description: Query the ecs with CQL (cardinal query language)
             consumes:
                 - application/json
             produces:
@@ -99,7 +99,7 @@ paths:
                         $ref: '#/definitions/CQLResponse'
             parameters:
                 - name: cql
-                  description: cql (component query language)
+                  description: cql (cardinal query language)
                   in: body
                   required: true
                   schema:

--- a/docs/pages/Cardinal/API-Reference/_meta.json
+++ b/docs/pages/Cardinal/API-Reference/_meta.json
@@ -11,6 +11,6 @@
     "title": "EVM Support"
   },
   "cql": {
-    "title": "Component Query Language (CQL)"
+    "title": "Cardinal Query Language (CQL)"
   }
 }

--- a/docs/pages/Cardinal/API-Reference/cql.mdx
+++ b/docs/pages/Cardinal/API-Reference/cql.mdx
@@ -1,8 +1,8 @@
-# Component Query Language
+# Cardinal Query Language
 
 ## Language Description
 
-CQL (Component Query Language) is a simple query language that queries entities based on components contained in the entity.
+CQL (Cardinal Query Language) is a simple query language that queries entities based on components contained in the entity.
 
 ### Components
 


### PR DESCRIPTION


Closes: #WORLD-337

## What is the purpose of the change

Change Component Query Language to Cardinal Query Language

## Brief Changelog

Just command shift F all component query language words and change it to Cardinal Query language 

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage.