### PR TITLE
feat(cardinal): Add ability to be notified when a tick has finished

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -1,0 +1,41 @@
+package cardinal_test
+
+import (
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+)
+
+func TestCanQueryInsideSystem(t *testing.T) {
+	type Foo struct{}
+	nextTickCh := make(chan time.Time)
+	tickDoneCh := make(chan uint64)
+
+	world, err := cardinal.NewMockWorld(
+		cardinal.WithTickChannel(nextTickCh),
+		cardinal.WithTickDoneChannel(tickDoneCh))
+	assert.NilError(t, err)
+	comp := cardinal.NewComponentType[Foo]("foo")
+	world.RegisterComponents(comp)
+
+	wantNumOfEntities := 10
+	_, err = world.CreateMany(wantNumOfEntities, comp)
+	assert.NilError(t, err)
+	gotNumOfEntities := 0
+	world.RegisterSystems(func(world *cardinal.World, queue *cardinal.TransactionQueue, logger *cardinal.Logger) error {
+		cardinal.NewQuery(cardinal.Exact(comp)).Each(world, func(cardinal.EntityID) bool {
+			gotNumOfEntities++
+			return true
+		})
+		return nil
+	})
+	go func() {
+		world.StartGame()
+	}()
+	nextTickCh <- time.Now()
+	<-tickDoneCh
+
+	assert.Equal(t, gotNumOfEntities, wantNumOfEntities)
+}

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -375,11 +375,12 @@ func (w *World) StartGameLoop(ctx context.Context, tickStart <-chan time.Time, t
 
 	go func() {
 		tickTheWorld := func() {
+			currTick := w.CurrentTick()
 			if err := w.Tick(ctx); err != nil {
 				w.Logger.Panic().Err(err).Msg("Error running Tick in Game Loop.")
 			}
 			if tickDone != nil {
-				tickDone <- w.CurrentTick()
+				tickDone <- currTick
 			}
 		}
 		w.isGameLoopRunning.Store(true)

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -356,7 +356,7 @@ func (w *World) Tick(ctx context.Context) error {
 	return nil
 }
 
-func (w *World) StartGameLoop(ctx context.Context, loopInterval time.Duration) {
+func (w *World) StartGameLoop(ctx context.Context, tickStart <-chan time.Time, tickDone chan<- uint64) {
 	w.Logger.Info().Msg("Game loop started")
 	w.Logger.LogWorld(w, zerolog.InfoLevel)
 	//todo: add links to docs related to each warning
@@ -378,21 +378,21 @@ func (w *World) StartGameLoop(ctx context.Context, loopInterval time.Duration) {
 			if err := w.Tick(ctx); err != nil {
 				w.Logger.Panic().Err(err).Msg("Error running Tick in Game Loop.")
 			}
+			if tickDone != nil {
+				tickDone <- w.CurrentTick()
+			}
 		}
-		intervalTicker := time.NewTicker(loopInterval)
 		w.isGameLoopRunning.Store(true)
 	loop:
 		for {
 			select {
-			case <-intervalTicker.C:
+			case <-tickStart:
 				tickTheWorld()
 			case <-w.endGameLoopCh:
 				if w.GetTxQueueAmount() > 0 {
 					tickTheWorld() //immediately tick if queue is not empty to process all txs if queue is not empty.
 				}
 				break loop
-			default:
-				continue
 			}
 		}
 		w.isGameLoopRunning.Store(false)

--- a/cardinal/option.go
+++ b/cardinal/option.go
@@ -55,11 +55,23 @@ func WithDisableSignatureVerification() WorldOption {
 	}
 }
 
-// WithLoopInterval sets the time between ticks. If left unset, 1 second is used as a default.
-func WithLoopInterval(interval time.Duration) WorldOption {
+// WithTickChannel sets the channel that will be used to decide when world.Tick is executed. If unset, a loop interval
+// of 1 second will be set. To set some other time, use: WithTickChannel(time.Tick(<some-duration>)). Tests can pass
+// in a channel controlled by the test for fine-grained control over when ticks are executed.
+func WithTickChannel(ch <-chan time.Time) WorldOption {
 	return WorldOption{
 		cardinalOption: func(world *World) {
-			world.loopInterval = interval
+			world.tickChannel = ch
+		},
+	}
+}
+
+// WithTickDoneChannel sets a channel that will be notified each time a tick completes. The completed tick will be
+// pushed to the channel. This option is useful in tests when assertions need to be performed at the end of a tick.
+func WithTickDoneChannel(ch chan<- uint64) WorldOption {
+	return WorldOption{
+		cardinalOption: func(world *World) {
+			world.tickDoneChannel = ch
 		},
 	}
 }

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -134,7 +134,7 @@ func TestShutDownViaMethod(t *testing.T) {
 	resp, err := http.Get("http://localhost:4040/health")
 	assert.Equal(t, resp.StatusCode, 200)
 	ctx := context.Background()
-	w.StartGameLoop(ctx, 1*time.Second)
+	w.StartGameLoop(ctx, time.Tick(1*time.Second), nil)
 	for !w.IsGameLoopRunning() {
 		//wait until game loop is running.
 		time.Sleep(1 * time.Millisecond)
@@ -160,7 +160,7 @@ func TestShutDownViaSignal(t *testing.T) {
 	resp, err := http.Get("http://localhost:4040/health")
 	assert.Equal(t, resp.StatusCode, 200)
 	ctx := context.Background()
-	w.StartGameLoop(ctx, 1*time.Second)
+	w.StartGameLoop(ctx, time.Tick(1*time.Second), nil)
 	for !w.IsGameLoopRunning() {
 		//wait until game loop is running
 		time.Sleep(500 * time.Millisecond)

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -15,9 +15,10 @@ import (
 )
 
 type World struct {
-	impl          *ecs.World
-	loopInterval  time.Duration
-	serverOptions []server.Option
+	impl            *ecs.World
+	tickChannel     <-chan time.Time
+	tickDoneChannel chan<- uint64
+	serverOptions   []server.Option
 }
 
 type (
@@ -96,7 +97,7 @@ func (w *World) Remove(id EntityID) error {
 	return w.impl.Remove(id)
 }
 
-// StartGame starts running the world game loop. After loopInterval time passes, a world tick is attempted.
+// StartGame starts running the world game loop. Each time a message arrives on the tickChannel, a world tick is attempted.
 // In addition, an HTTP server (listening on the given port) is created so that game transactions can be sent
 // to this world. After StartGame is called, RegisterComponents, RegisterTransactions, RegisterReads, and AddSystem may
 // not be called. If StartGame doesn't encounter any errors, it will block forever, running the server and ticking
@@ -109,10 +110,10 @@ func (w *World) StartGame() error {
 	if err != nil {
 		return err
 	}
-	if w.loopInterval == 0 {
-		w.loopInterval = time.Second
+	if w.tickChannel == nil {
+		w.tickChannel = time.Tick(time.Second)
 	}
-	w.impl.StartGameLoop(context.Background(), w.loopInterval)
+	w.impl.StartGameLoop(context.Background(), w.tickChannel, w.tickDoneChannel)
 	go func() {
 		if err := txh.Serve(); err != nil {
 			log.Fatal().Err(err)


### PR DESCRIPTION
Closes: #WORLD-306

## What is the purpose of the change

- Verify that a Query can be called inside of a cardinal based system (without needing the ecs package).
- Add a mechanism to manually start ticks, and be notified when ticks are completed.
- remove some code that was causing a for loop to unnecessarily spin.

## Testing and Verifying

Added a test to the cardinal package to demonstrate the usage of Query inside a system, as well as the new mechanism for starting a tick and blocking until the tick is done.
