### PR TITLE
feat(cardinal): cardinal.world now owns GameManager

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -5,10 +5,33 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
+
 	"pkg.world.dev/world-engine/cardinal"
 )
 
+// TODO this function needs to be moved to a utils package above cardinal to prevent circulars.
+func setTestTimeout(t *testing.T, timeout time.Duration) {
+	if _, ok := t.Deadline(); ok {
+		// A deadline has already been set. Don't add an additional deadline.
+		return
+	}
+	success := make(chan bool)
+	t.Cleanup(func() {
+		success <- true
+	})
+	go func() {
+		select {
+		case <-success:
+			// test was successful. Do nothing
+		case <-time.After(timeout):
+			//assert.Check(t, false, "test timed out")
+			panic("test timed out")
+		}
+	}()
+}
+
 func TestCanQueryInsideSystem(t *testing.T) {
+	setTestTimeout(t, 10*time.Second)
 	type Foo struct{}
 	nextTickCh := make(chan time.Time)
 	tickDoneCh := make(chan uint64)
@@ -32,10 +55,14 @@ func TestCanQueryInsideSystem(t *testing.T) {
 		return nil
 	})
 	go func() {
-		world.StartGame()
+		_ = world.StartGame()
 	}()
+	for !world.IsGameRunning() {
+		time.Sleep(time.Second) //starting game async, must wait until game is running before testing everything.
+	}
 	nextTickCh <- time.Now()
 	<-tickDoneCh
-
+	err = world.ShutDown()
+	assert.Assert(t, err)
 	assert.Equal(t, gotNumOfEntities, wantNumOfEntities)
 }

--- a/cardinal/component.go
+++ b/cardinal/component.go
@@ -48,29 +48,29 @@ func (c *ComponentType[T]) Name() string {
 
 // RemoveFrom removes this component from the given entity.
 func (c *ComponentType[T]) RemoveFrom(w *World, id EntityID) error {
-	return c.impl.RemoveFrom(w.impl, id)
+	return c.impl.RemoveFrom(w.implWorld, id)
 }
 
 // AddTo adds this component to the given entity.
 func (c *ComponentType[T]) AddTo(w *World, id EntityID) error {
-	return c.impl.AddTo(w.impl, id)
+	return c.impl.AddTo(w.implWorld, id)
 }
 
 // Get returns the component data that is associated with the given id. An error is returned if this entity
 // is not actually associated with this component type.
 func (c *ComponentType[T]) Get(w *World, id EntityID) (comp T, err error) {
-	return c.impl.Get(w.impl, id)
+	return c.impl.Get(w.implWorld, id)
 }
 
 // Set sets the component data for a specific EntityID.
 func (c *ComponentType[T]) Set(w *World, id EntityID, comp T) error {
-	return c.impl.Set(w.impl, id, comp)
+	return c.impl.Set(w.implWorld, id, comp)
 }
 
 // Update updates the component data that is associated with the given EntityID. It is a convenience wrapper
 // for a Get followed by a Set.
 func (c *ComponentType[T]) Update(w *World, id EntityID, fn func(T) T) error {
-	return c.impl.Update(w.impl, id, fn)
+	return c.impl.Update(w.implWorld, id, fn)
 }
 
 // Convert implements the AnyComponentType interface which allows a ComponentType to be registered

--- a/cardinal/log.go
+++ b/cardinal/log.go
@@ -12,22 +12,22 @@ type Logger struct {
 }
 
 func (l *Logger) LogComponents(world *World, level zerolog.Level) {
-	l.impl.LogComponents(world.impl, level)
+	l.impl.LogComponents(world.implWorld, level)
 }
 
 // LogSystem logs all system info related to the world
 func (l *Logger) LogSystem(world *World, level zerolog.Level) {
-	l.impl.LogSystem(world.impl, level)
+	l.impl.LogSystem(world.implWorld, level)
 }
 
 // LogEntity logs entity info given an entityID
 func (l *Logger) LogEntity(world *World, level zerolog.Level, entityID EntityID) {
-	entity, err := world.impl.StoreManager().GetEntity(entityID)
+	entity, err := world.implWorld.StoreManager().GetEntity(entityID)
 	if err != nil {
 		l.impl.Warn().Err(fmt.Errorf("failed to get entity %d: %w", entityID, err))
 		return
 	}
-	components, err := world.impl.StoreManager().GetComponentTypesForEntity(entityID)
+	components, err := world.implWorld.StoreManager().GetComponentTypesForEntity(entityID)
 	if err != nil {
 		l.impl.Warn().Err(fmt.Errorf("failed to get components for entity %d: %w", entityID, err))
 		return
@@ -38,7 +38,7 @@ func (l *Logger) LogEntity(world *World, level zerolog.Level, entityID EntityID)
 
 // LogWorld Logs everything about the world (components and Systems)
 func (l *Logger) LogWorld(world *World, level zerolog.Level) {
-	l.impl.LogWorld(world.impl, level)
+	l.impl.LogWorld(world.implWorld, level)
 }
 
 // CreateSystemLogger creates a Sub logger with the entry {"system" : systemName}

--- a/cardinal/query.go
+++ b/cardinal/query.go
@@ -23,19 +23,19 @@ type QueryCallBackFn func(EntityID) bool
 // Each executes the given callback function on every EntityID that matches this query. If any call to callback returns
 // falls, no more entities will be processed.
 func (q *Query) Each(w *World, callback QueryCallBackFn) {
-	q.impl.Each(w.impl, func(eid entity.ID) bool {
+	q.impl.Each(w.implWorld, func(eid entity.ID) bool {
 		return callback(eid)
 	})
 }
 
 // Count returns the number of entities that match this query.
 func (q *Query) Count(w *World) int {
-	return q.impl.Count(w.impl)
+	return q.impl.Count(w.implWorld)
 }
 
 // First returns the first entity that matches this query.
 func (q *Query) First(w *World) (id EntityID, err error) {
-	return q.impl.First(w.impl)
+	return q.impl.First(w.implWorld)
 }
 
 // ComponentFilter represents a filter that will be passed to NewQuery to help decide which entities should be

--- a/cardinal/read.go
+++ b/cardinal/read.go
@@ -22,7 +22,7 @@ func NewReadType[Request any, Reply any](
 ) *ReadType[Request, Reply] {
 	return &ReadType[Request, Reply]{
 		impl: ecs.NewReadType[Request, Reply](name, func(world *ecs.World, req Request) (Reply, error) {
-			outerWorld := &World{impl: world}
+			outerWorld := &World{implWorld: world}
 			return handler(outerWorld, req)
 		}),
 	}
@@ -33,7 +33,7 @@ func NewReadType[Request any, Reply any](
 func NewReadTypeWithEVMSupport[Request, Reply any](name string, handler func(*World, Request) (Reply, error)) *ReadType[Request, Reply] {
 	return &ReadType[Request, Reply]{
 		impl: ecs.NewReadType[Request, Reply](name, func(world *ecs.World, req Request) (Reply, error) {
-			outerWorld := &World{impl: world}
+			outerWorld := &World{implWorld: world}
 			return handler(outerWorld, req)
 		}, ecs.WithReadEVMSupport[Request, Reply]),
 	}

--- a/cardinal/server/game_manager.go
+++ b/cardinal/server/game_manager.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"errors"
 	"os"
 	"os/signal"
 	"syscall"
@@ -40,6 +41,9 @@ func NewGameManager(world *ecs.World, handler *Handler) GameManager {
 
 func (s *GameManager) Shutdown() error {
 	log.Info().Msg("Shutting down server.")
+	if s.handler == nil {
+		return errors.New("game manager has no server, can't shutdown")
+	}
 	err := s.handler.Shutdown()
 	if err != nil {
 		return err

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -101,6 +101,8 @@ func makeTestTransactionHandler(t *testing.T, world *ecs.World, opts ...Option) 
 	}
 }
 
+// TODO this function is duplicated in cardinal_test.go. Please eventually move both of these functions
+// into a utils package that lives outside of cardinal.
 func setTestTimeout(t *testing.T, timeout time.Duration) {
 	if _, ok := t.Deadline(); ok {
 		// A deadline has already been set. Don't add an additional deadline.

--- a/cardinal/transaction.go
+++ b/cardinal/transaction.go
@@ -47,19 +47,19 @@ func NewTransactionTypeWithEVMSupport[Msg, Result any](name string) *Transaction
 // AddError adds the given error to the transaction identified by the given hash. Multiple errors can be
 // added to the same transaction hash.
 func (t *TransactionType[Msg, Result]) AddError(world *World, hash TxHash, err error) {
-	world.impl.AddTransactionError(hash, err)
+	world.implWorld.AddTransactionError(hash, err)
 }
 
 // SetResult sets the result of the transaction identified by the given hash. Only one result may be associated
 // with a transaction hash, so calling this multiple times will clobber previously set results.
 func (t *TransactionType[Msg, Result]) SetResult(world *World, hash TxHash, result Result) {
-	world.impl.SetTransactionResult(hash, result)
+	world.implWorld.SetTransactionResult(hash, result)
 }
 
 // GetReceipt returns the result (if any) and errors (if any) associated with the given hash. If false is returned,
 // the hash is not recognized, so the returned result and errors will be empty.
 func (t *TransactionType[Msg, Result]) GetReceipt(world *World, hash TxHash) (r Result, errs []error, ok bool) {
-	return t.impl.GetReceipt(world.impl, hash)
+	return t.impl.GetReceipt(world.implWorld, hash)
 }
 
 // In returns the transactions in the given transaction queue that match this transaction's type.

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21.0
+go 1.21
 
 use (
 	cardinal

--- a/go.work
+++ b/go.work
@@ -1,4 +1,4 @@
-go 1.21
+go 1.21.0
 
 use (
 	cardinal


### PR DESCRIPTION
Closes: #WORLD-358
## What is the purpose of the change

Move game manager into cardinal.world so that cardinal.world now has the ability to shutdown. 

## Brief Changelog

- renamed impl to implWorld, because now cardinal.world will own a server, gameManager and the ecs.World. A name like impl doesn't give any information about what that variable is and is even more ambiguose with cardinal.World owning other entities. 
- added a method IsGameRunning for aspects of our library and the user to detect if the game is already running. Game will not start if a game is already running. Just a note here, this method is NOT only used it tests. This method IS used before starting the game. 
- had to duplicate a utility function setTestTimeout. This is technical debt that will need to be handled in another ticket which I commented on here: https://linear.app/arguslabs/issue/WORLD-345/clean-up-cardinalserver-code

## Testing and Verifying

Tested shutdown in cardinal tests. 