### PR TITLE
feat(cardinal): allow for looping over transactions

### DIFF
--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -147,6 +147,16 @@ func (t *TransactionType[In, Out]) GetReceipt(world *World, hash transaction.TxH
 	return value, errs, true
 }
 
+func (t *TransactionType[In, Out]) ForEach(world *World, tq *transaction.TxQueue, fn func(TxData[In]) (Out, error)) {
+	for _, tx := range t.In(tq) {
+		if result, err := fn(tx); err != nil {
+			t.AddError(world, tx.TxHash, err)
+		} else {
+			t.SetResult(world, tx.TxHash, result)
+		}
+	}
+}
+
 // In extracts all the transactions in the transaction queue that match this TransactionType's ID.
 func (t *TransactionType[In, Out]) In(tq *transaction.TxQueue) []TxData[In] {
 	var txs []TxData[In]

--- a/cardinal/ecs/transaction_test.go
+++ b/cardinal/ecs/transaction_test.go
@@ -1,0 +1,65 @@
+package ecs_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
+	"pkg.world.dev/world-engine/cardinal/ecs/log"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
+)
+
+func TestForEachTransaction(t *testing.T) {
+	world := ecs.NewTestWorld(t)
+	type SomeTxRequest struct {
+		GenerateError bool
+	}
+	type SomeTxResponse struct {
+		Successful bool
+	}
+
+	someTx := ecs.NewTransactionType[SomeTxRequest, SomeTxResponse]("some_tx")
+	assert.NilError(t, world.RegisterTransactions(someTx))
+
+	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, logger *log.Logger) error {
+		someTx.ForEach(world, queue, func(t ecs.TxData[SomeTxRequest]) (result SomeTxResponse, err error) {
+			if t.Value.GenerateError {
+				return result, errors.New("some error")
+			}
+			return SomeTxResponse{
+				Successful: true,
+			}, nil
+		})
+		return nil
+	})
+	assert.NilError(t, world.LoadGameState())
+
+	// Add 10 transactions to the tx queue and keep track of the hashes that we just created
+	knownTxHashes := map[transaction.TxHash]SomeTxRequest{}
+	for i := 0; i < 10; i++ {
+		req := SomeTxRequest{GenerateError: i%2 == 0}
+		txHash := someTx.AddToQueue(world, req, testutil.UniqueSignature(t))
+		knownTxHashes[txHash] = req
+	}
+
+	// Perform a world tick
+	assert.NilError(t, world.Tick(context.Background()))
+
+	// Verify the receipts for the previous tick are what we expect
+	receipts, err := world.GetTransactionReceiptsForTick(world.CurrentTick() - 1)
+	assert.NilError(t, err)
+	assert.Equal(t, len(knownTxHashes), len(receipts))
+	for _, receipt := range receipts {
+		request, ok := knownTxHashes[receipt.TxHash]
+		assert.Check(t, ok)
+		if request.GenerateError {
+			assert.Check(t, len(receipt.Errs) > 0)
+		} else {
+			assert.Equal(t, 0, len(receipt.Errs))
+			assert.Equal(t, receipt.Result.(SomeTxResponse), SomeTxResponse{Successful: true})
+		}
+	}
+}


### PR DESCRIPTION
Closes: #WORLD-365

## What is the purpose of the change

Add an ability to loop over a number of transactions, and using the returned result/error to set the transaction receipts result/error.

## Testing and Verifying

Unit test added
