### PR TITLE
feat(cardinal): create events file. test websocket library.

### DIFF
--- a/cardinal/go.mod
+++ b/cardinal/go.mod
@@ -90,6 +90,7 @@ require (
 	github.com/golang/snappy v0.0.5-0.20220116011046-fa5810519dcb // indirect
 	github.com/google/btree v1.1.2 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
+	github.com/gorilla/websocket v1.5.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway v1.16.0 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-metrics v0.5.1 // indirect

--- a/cardinal/server/events.go
+++ b/cardinal/server/events.go
@@ -1,0 +1,32 @@
+package server
+
+import (
+	"log"
+	"net/http"
+
+	"github.com/gorilla/websocket"
+)
+
+var upgrader = websocket.Upgrader{}
+
+func Echo(w http.ResponseWriter, r *http.Request) {
+	c, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		log.Print("upgrade:", err)
+		return
+	}
+	defer c.Close()
+	for {
+		mt, message, err := c.ReadMessage()
+		if err != nil {
+			log.Println("read:", err)
+			break
+		}
+		log.Printf("recv: %s", message)
+		err = c.WriteMessage(mt, message)
+		if err != nil {
+			log.Println("write:", err)
+			break
+		}
+	}
+}

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gorilla/websocket"
 	"pkg.world.dev/world-engine/cardinal/shard"
 	"pkg.world.dev/world-engine/chain/x/shard/types"
 
@@ -39,19 +40,23 @@ type SendEnergyTxResult struct{}
 // testTransactionHandler is a helper struct that can start an HTTP server on port 4040 with the given world.
 type testTransactionHandler struct {
 	*Handler
-	t         *testing.T
-	urlPrefix string
+	t    *testing.T
+	host string
 }
 
-func (t *testTransactionHandler) makeURL(path string) string {
-	return t.urlPrefix + "/" + path
+func (t *testTransactionHandler) makeHttpURL(path string) string {
+	return "http://" + t.host + "/" + path
+}
+
+func (t *testTransactionHandler) makeWebSocketURL(path string) string {
+	return "ws://" + t.host + "/" + path
 }
 
 func (t *testTransactionHandler) post(path string, payload any) *http.Response {
 	bz, err := json.Marshal(payload)
 	assert.NilError(t.t, err)
 
-	res, err := http.Post(t.makeURL(path), "application/json", bytes.NewReader(bz))
+	res, err := http.Post(t.makeHttpURL(path), "application/json", bytes.NewReader(bz))
 	assert.NilError(t.t, err)
 	return res
 }
@@ -61,6 +66,9 @@ func makeTestTransactionHandler(t *testing.T, world *ecs.World, opts ...Option) 
 	opts = append(opts, WithPort(port))
 	txh, err := NewHandler(world, opts...)
 	assert.NilError(t, err)
+
+	//add test websocket handler.
+	txh.mux.HandleFunc("/echo", Echo)
 
 	healthPath := "/health"
 	t.Cleanup(func() {
@@ -80,13 +88,13 @@ func makeTestTransactionHandler(t *testing.T, world *ecs.World, opts ...Option) 
 		_ = gameObject.Shutdown()
 	})
 
-	urlPrefix := "http://localhost:" + port
-	healthURL := urlPrefix + healthPath
+	host := "localhost:" + port
+	healthURL := host + healthPath
 	start := time.Now()
 	for {
 		assert.Check(t, time.Since(start) < time.Second, "timeout while waiting for a healthy server")
 
-		resp, err := http.Get(healthURL)
+		resp, err := http.Get("http://" + healthURL)
 		if err == nil && resp.StatusCode == 200 {
 			// the health check endpoint was successfully queried.
 			break
@@ -94,9 +102,9 @@ func makeTestTransactionHandler(t *testing.T, world *ecs.World, opts ...Option) 
 	}
 
 	return &testTransactionHandler{
-		Handler:   txh,
-		t:         t,
-		urlPrefix: urlPrefix,
+		Handler: txh,
+		t:       t,
+		host:    host,
 	}
 }
 
@@ -237,7 +245,7 @@ func TestCanListTransactionEndpoints(t *testing.T) {
 	assert.NilError(t, w.RegisterTransactions(alphaTx, betaTx, gammaTx))
 	txh := makeTestTransactionHandler(t, w, DisableSignatureVerification())
 
-	resp, err := http.Post(txh.makeURL("query/http/endpoints"), "application/json", nil)
+	resp, err := http.Post(txh.makeHttpURL("query/http/endpoints"), "application/json", nil)
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 	var gotEndpoints map[string][]string
@@ -305,7 +313,7 @@ func TestHandleTransactionWithNoSignatureVerification(t *testing.T) {
 
 	txh := makeTestTransactionHandler(t, w, DisableSignatureVerification())
 
-	resp, err := http.Post(txh.makeURL(url), "application/json", bytes.NewReader(bogusSignatureBz))
+	resp, err := http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bogusSignatureBz))
 	assert.NilError(t, err)
 	assert.Equal(t, 200, resp.StatusCode, "request failed with body: %v", mustReadBody(t, resp))
 
@@ -393,7 +401,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 		TxEndpoints:    []string{"/tx/persona/create-persona", "/tx/persona/authorize-persona-address", "/tx/game/send-energy"},
 		QueryEndpoints: []string{"/query/game/foo", "/query/http/endpoints", "/query/persona/signer", "/query/receipt/list", "/query/game/cql"},
 	}
-	resp1, err := http.Post(txh.makeURL("query/http/endpoints"), "application/json", nil)
+	resp1, err := http.Post(txh.makeHttpURL("query/http/endpoints"), "application/json", nil)
 	assert.NilError(t, err)
 	defer resp1.Body.Close()
 	var endpointResult EndpointsResult
@@ -410,7 +418,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 	}
 	readPersonaRequestData, err := json.Marshal(readPersonaRequest)
 	assert.NilError(t, err)
-	req, err := http.NewRequest("POST", txh.makeURL("query/persona/signer"), bytes.NewBuffer(readPersonaRequestData))
+	req, err := http.NewRequest("POST", txh.makeHttpURL("query/persona/signer"), bytes.NewBuffer(readPersonaRequestData))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-Length", strconv.Itoa(len(readPersonaRequestData)))
 	req.Header.Set("Accept", "application/json")
@@ -433,7 +441,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 	if err != nil {
 		assert.NilError(t, err)
 	}
-	resp3, err := http.Post(txh.makeURL("query/game/foo"), "application/json", bytes.NewBuffer(fooData))
+	resp3, err := http.Post(txh.makeHttpURL("query/game/foo"), "application/json", bytes.NewBuffer(fooData))
 	if err != nil {
 		assert.NilError(t, err)
 	}
@@ -465,16 +473,16 @@ func TestHandleSwaggerServer(t *testing.T) {
 		Tick:   1,
 	}
 	gotTxReply := TransactionReply{}
-	resp4, err := http.Post(txh.makeURL("tx/persona/authorize-persona-address"), "application/json", bytes.NewBuffer(signedTxJson))
+	resp4, err := http.Post(txh.makeHttpURL("tx/persona/authorize-persona-address"), "application/json", bytes.NewBuffer(signedTxJson))
 	assert.NilError(t, err)
 	err = json.NewDecoder(resp4.Body).Decode(&gotTxReply)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, gotTxReply, expectedTxReply)
 
-	resp5, err := http.Post(txh.makeURL("tx/game/dsakjsdlfksdj"), "application/json", bytes.NewBuffer(signedTxJson))
+	resp5, err := http.Post(txh.makeHttpURL("tx/game/dsakjsdlfksdj"), "application/json", bytes.NewBuffer(signedTxJson))
 	assert.NilError(t, err)
 	assert.Equal(t, resp5.StatusCode, 404)
-	resp6, err := http.Post(txh.makeURL("query/game/sdsdfsdfsdf"), "application/json", bytes.NewBuffer(signedTxJson))
+	resp6, err := http.Post(txh.makeHttpURL("query/game/sdsdfsdfsdf"), "application/json", bytes.NewBuffer(signedTxJson))
 	assert.NilError(t, err)
 	assert.Equal(t, resp6.StatusCode, 404)
 
@@ -495,7 +503,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 		jsonQuery := struct{ CQL string }{v.cql}
 		jsonQueryBytes, err := json.Marshal(jsonQuery)
 		assert.NilError(t, err)
-		resp7, err := http.Post(txh.makeURL("query/game/cql"), "application/json", bytes.NewBuffer(jsonQueryBytes))
+		resp7, err := http.Post(txh.makeHttpURL("query/game/cql"), "application/json", bytes.NewBuffer(jsonQueryBytes))
 		assert.NilError(t, err)
 		assert.Equal(t, resp7.StatusCode, v.expectedStatus)
 		var entities []cql.QueryResponse
@@ -506,7 +514,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 	jsonQuery := struct{ CQL string }{"blah"}
 	jsonQueryBytes, err := json.Marshal(jsonQuery)
 	assert.NilError(t, err)
-	resp8, err := http.Post(txh.makeURL("query/game/cql"), "application/json", bytes.NewBuffer(jsonQueryBytes))
+	resp8, err := http.Post(txh.makeHttpURL("query/game/cql"), "application/json", bytes.NewBuffer(jsonQueryBytes))
 	assert.NilError(t, err)
 	assert.Equal(t, resp8.StatusCode, 422)
 }
@@ -547,7 +555,7 @@ func TestHandleWrappedTransactionWithNoSignatureVerification(t *testing.T) {
 
 	bz, err = json.Marshal(&signedTx)
 	assert.NilError(t, err)
-	_, err = http.Post(txh.makeURL(url), "application/json", bytes.NewReader(bz))
+	_, err = http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 
 	assert.NilError(t, w.LoadGameState())
@@ -585,7 +593,7 @@ func TestCanCreateAndVerifyPersonaSigner(t *testing.T) {
 	bz, err := signedPayload.Marshal()
 	assert.NilError(t, err)
 
-	resp, err := http.Post(txh.makeURL(urlSet[0]), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.makeHttpURL(urlSet[0]), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	body := mustReadBody(t, resp)
 	assert.Equal(t, 200, resp.StatusCode, "request failed with body: %s", body)
@@ -602,7 +610,7 @@ func TestCanCreateAndVerifyPersonaSigner(t *testing.T) {
 			Tick:       tick,
 		})
 		assert.NilError(t, err)
-		resp, err = http.Post(txh.makeURL(urlSet[1]), "application/json", bytes.NewReader(bz))
+		resp, err = http.Post(txh.makeHttpURL(urlSet[1]), "application/json", bytes.NewReader(bz))
 		assert.NilError(t, err)
 		assert.Equal(t, resp.StatusCode, 200)
 		var readPersonaSignerResponse ReadPersonaSignerResponse
@@ -650,7 +658,7 @@ func TestSigVerificationChecksNamespace(t *testing.T) {
 
 	bz, err := sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err := http.Post(txh.makeURL(url), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	// This should fail because the namespace does not match the world's namespace
 	assert.Equal(t, resp.StatusCode, 401)
@@ -660,7 +668,7 @@ func TestSigVerificationChecksNamespace(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err = http.Post(txh.makeURL(url), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.Equal(t, resp.StatusCode, 200)
 	txh.Close()
 }
@@ -688,12 +696,12 @@ func TestSigVerificationChecksNonce(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Register a persona. This should succeed
-	resp, err := http.Post(txh.makeURL(url), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 
 	// Repeat the request. Since the nonce is the same, this should fail
-	resp, err = http.Post(txh.makeURL(url), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 401)
 
@@ -702,7 +710,7 @@ func TestSigVerificationChecksNonce(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err = http.Post(txh.makeURL(url), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 401)
 
@@ -711,7 +719,7 @@ func TestSigVerificationChecksNonce(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err = http.Post(txh.makeURL(url), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 	err = txh.Close()
@@ -746,7 +754,7 @@ func TestCanListReads(t *testing.T) {
 
 	txh := makeTestTransactionHandler(t, world, DisableSignatureVerification())
 
-	resp, err := http.Post(txh.makeURL("query/http/endpoints"), "application/json", nil)
+	resp, err := http.Post(txh.makeHttpURL("query/http/endpoints"), "application/json", nil)
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 	var gotEndpoints map[string][]string
@@ -799,7 +807,7 @@ func TestReadEncodeDecode(t *testing.T) {
 	bz, err := json.Marshal(req)
 	assert.NilError(t, err)
 
-	res, err := http.Post(txh.makeURL(url), "application/json", bytes.NewReader(bz))
+	res, err := http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 
 	buf, err := io.ReadAll(res.Body)
@@ -1068,7 +1076,7 @@ func TestTransactionIDIsReturned(t *testing.T) {
 	bz, err := sigPayload.Marshal()
 	assert.NilError(t, err)
 
-	resp, err := http.Post(txh.makeURL(urls[0]), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.makeHttpURL(urls[0]), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 
@@ -1090,7 +1098,7 @@ func TestTransactionIDIsReturned(t *testing.T) {
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
 
-	resp, err = http.Post(txh.makeURL(urls[1]), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.makeHttpURL(urls[1]), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.NilError(t, json.NewDecoder(resp.Body).Decode(&txReply))
@@ -1144,7 +1152,7 @@ func TestTransactionsSubmittedToChain(t *testing.T) {
 	bz, err := sigPayload.Marshal()
 	assert.NilError(t, err)
 
-	resp, err := http.Post(txh.makeURL(createPersonaEndpoint), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.makeHttpURL(createPersonaEndpoint), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, adapter.called, 1)
@@ -1153,7 +1161,7 @@ func TestTransactionsSubmittedToChain(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err = http.Post(txh.makeURL(moveEndpoint), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.makeHttpURL(moveEndpoint), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, adapter.called, 2)
@@ -1182,10 +1190,28 @@ func TestTransactionNotSubmittedWhenRecovering(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err := sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err := http.Post(txh.makeURL(moveEndpoint), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.makeHttpURL(moveEndpoint), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, 500, resp.StatusCode)
 	bz, err = io.ReadAll(resp.Body)
 	assert.NilError(t, err)
 	assert.ErrorContains(t, errors.New(string(bz)), "game world is recovering state")
+}
+
+func TestWebSocket(t *testing.T) {
+	w := ecs.NewTestWorld(t)
+	assert.NilError(t, w.LoadGameState())
+	txh := makeTestTransactionHandler(t, w, DisableSignatureVerification())
+	url := txh.makeWebSocketURL("echo")
+	dial, _, err := websocket.DefaultDialer.Dial(url, nil)
+	assert.NilError(t, err)
+	messageToSend := "test"
+	err = dial.WriteMessage(websocket.TextMessage, []byte(messageToSend))
+	assert.NilError(t, err)
+	messageType, message, err := dial.ReadMessage()
+	assert.NilError(t, err)
+	assert.Equal(t, messageType, websocket.TextMessage)
+	assert.Equal(t, string(message), messageToSend)
+	err = dial.Close()
+	assert.NilError(t, err)
 }


### PR DESCRIPTION
Closes: #402

## What is the purpose of the change

Preliminary boostrap work and testing for web-socket library that will be used make an event route. 

> Add a description of the overall background and high-level changes that this PR introduces

Adds a test Websocket echo handler.

## Brief Changelog

new events.go file. 
In that file is a websocket event handler. 

Refactored testHandler to be able to create Websocket routes and http routes. 

## Testing and Verifying

Added new test that tests the echo handler. 