### PR TITLE
chore(ci): publish relay/nakama container images

### DIFF
--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -1,4 +1,4 @@
-name: Docker Image Release
+name: Container Image Release
 
 ## workflow will trigger on below condition,
 ## except image release that have jobs condition to trigger only on tagging
@@ -101,7 +101,7 @@ jobs:
           gcloud auth configure-docker ${{ env.REGISTRY_URL }}
       - name: Docker - Build
         run: |
-          docker build -t chain-local-build:latest .
+          docker build -t nakama-local-build:latest .
       - name: Docker - Publish Image
         run: |
           ## Construct image_id

--- a/.github/workflows/image-release.yaml
+++ b/.github/workflows/image-release.yaml
@@ -1,4 +1,4 @@
-name: image-release-pipeline
+name: Docker Image Release
 
 ## workflow will trigger on below condition,
 ## except image release that have jobs condition to trigger only on tagging
@@ -8,12 +8,15 @@ on:
       - main
     tags:
       - 'chain/v*.*.*'
+      - 'relay/nakama/v*.*.*'
 
 env:
   REGISTRY_URL: us-docker.pkg.dev
 
 jobs:
   chain-release:
+    name: Chain Image Release
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/chain/v')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -62,3 +65,54 @@ jobs:
 
           docker tag chain-local-build:latest $IMAGE_ID_CHAIN:$VERSION
           docker push $IMAGE_ID_CHAIN:$VERSION
+  nakama-release:
+    name: Nakama Image Release
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/relay/nakama/v')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
+        working-directory: relay/nakama
+    # Add "id-token" with the intended permissions.
+    permissions:
+      contents: 'read'
+      id-token: 'write'
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Cache Docker images
+        uses: ScribeMD/docker-cache@0.3.4
+        with:
+          key: docker-${{ runner.os }}-${{ hashFiles('relay/nakama/Dockerfile') }}
+      - name: GCP auth
+        id: auth
+        uses: google-github-actions/auth@v1
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
+      - name: GCP - Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v1
+        with:
+          project_id: ${{ env.GCP_PROJECT_ID_PACKAGES }}
+      - name: Docker - Auth to artifact registry
+        run: |
+          gcloud auth configure-docker ${{ env.REGISTRY_URL }}
+      - name: Docker - Build
+        run: |
+          docker build -t chain-local-build:latest .
+      - name: Docker - Publish Image
+        run: |
+          ## Construct image_id
+          IMAGE_ID_NAKAMA=${{ env.REGISTRY_URL }}/${{ github.repository_owner }}/${{ github.event.repository.name }}/relay/nakama
+          IMAGE_ID_NAKAMA=$(echo $IMAGE_ID_NAKAMA | tr '[A-Z]' '[a-z]')
+
+          ## Get version from tag name (ex: relay/nakama/v0.0.0 --> registry/relay/nakama:v0.0.0)
+          ## Or use 'latest' when on main branch
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+          [ "$VERSION" == "main" ] && VERSION=latest
+          echo "Image to push: $IMAGE_ID_NAKAMA:$VERSION"
+
+          docker tag nakama-local-build:latest $IMAGE_ID_NAKAMA:$VERSION
+          docker push $IMAGE_ID_NAKAMA:$VERSION

--- a/relay/nakama/Dockerfile
+++ b/relay/nakama/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /backend
 
 COPY go.mod .
 COPY *.go .
-COPY vendor/ vendor/
+RUN go mod download
 
 RUN go build --trimpath --mod=vendor --buildmode=plugin -o ./backend.so
 

--- a/relay/nakama/Dockerfile
+++ b/relay/nakama/Dockerfile
@@ -6,6 +6,7 @@ ENV CGO_ENABLED 1
 WORKDIR /backend
 
 COPY go.mod .
+COPY go.sum .
 COPY *.go .
 RUN go mod vendor
 

--- a/relay/nakama/Dockerfile
+++ b/relay/nakama/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /backend
 
 COPY go.mod .
 COPY *.go .
-RUN go mod download
+RUN go mod vendor
 
 RUN go build --trimpath --mod=vendor --buildmode=plugin -o ./backend.so
 


### PR DESCRIPTION
Closes: #WORLD-381

## What is the purpose of the change

- Setup docker image CI deployment for Nakama

## Brief Changelog

- Add CI workflow to build & release Nakama container images to public registry.
   - on push to `main`: publish `us-docker.pkg.dev/argus-labs/world-engine/relay/nakama:latest`
   - on tag `relay/nakama/v0.0.0`: publish `us-docker.pkg.dev/argus-labs/world-engine/relay/nakama:v0.0.0`

## Testing and Verifying

- trigger the CI by using tag `relay/nakama:v0.0.0` or push to `main` branch.
![image](https://github.com/Argus-Labs/world-engine/assets/29672212/d22de5cd-95ba-4f62-9c33-d09d378a1790)

- CI run example: [[run-6498124375]](https://github.com/Argus-Labs/world-engine/actions/runs/6498124375)
![image](https://github.com/Argus-Labs/world-engine/assets/29672212/e51f9c24-b675-4601-adff-0d49e33660b1)

