### PR TITLE
feat(cardinal): ecb for entity management

### DIFF
--- a/cardinal/ecs/benchmark/benchmark_test.go
+++ b/cardinal/ecs/benchmark/benchmark_test.go
@@ -72,11 +72,11 @@ func setupWorld(t testing.TB, numOfEntities int, enableHealthSystem bool) *ecs.W
 	return world
 }
 
-func BenchmarkWorld_Tick(b *testing.B) {
-	maxEntities := 1000
+func BenchmarkWorld_TickNoSystems(b *testing.B) {
+	maxEntities := 10000
 	enableHealthSystem := false
 
-	for i := maxEntities; i <= maxEntities; i *= 10 {
+	for i := 1; i <= maxEntities; i *= 10 {
 		world := setupWorld(b, i, enableHealthSystem)
 		name := fmt.Sprintf("%d entities", i)
 		b.Run(name, func(b *testing.B) {

--- a/cardinal/ecs/benchmark/benchmark_test.go
+++ b/cardinal/ecs/benchmark/benchmark_test.go
@@ -1,0 +1,103 @@
+// Package benchmark_test contains benchmarks that were initially used to compare the performance between different data
+// recovery methods (snapshotting all redis keys vs the entity-command-buffer).
+package benchmark_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/ecb"
+	"pkg.world.dev/world-engine/cardinal/ecs/entity"
+	ecslog "pkg.world.dev/world-engine/cardinal/ecs/log"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
+)
+
+// newWorldWithRealRedis returns an *ecs.World that is connected to a redis DB hosted at localhost:6379. The target
+// database is CLEARED OF ALL DATA so that the *ecs.World object can start from a clean slate.
+func newWorldWithRealRedis(t testing.TB) *ecs.World {
+	rs := storage.NewRedisStorage(storage.Options{
+		Addr:     "127.0.0.1:6379",
+		Password: "",
+		DB:       0,
+	}, "real-world")
+	assert.NilError(t, rs.Client.FlushDB(context.Background()).Err())
+	ws := storage.NewWorldStorage(&rs)
+
+	sm, err := ecb.NewManager(rs.Client)
+	assert.NilError(t, err)
+	world, err := ecs.NewWorld(ws, sm)
+
+	assert.NilError(t, err)
+	return world
+}
+
+// setupWorld creates a new *ecs.World and initializes the world to have numOfEntities already created. If enableHealthSystem
+// is set, a System will be added to the world that increments every entity's "health" by 1 every tick.
+func setupWorld(t testing.TB, numOfEntities int, enableHealthSystem bool) *ecs.World {
+	type Health struct {
+		Value int
+	}
+
+	//world := ecs.NewTestWorld(t)
+	world := newWorldWithRealRedis(t)
+
+	disabledLogger := world.Logger.Level(zerolog.Disabled)
+	world.InjectLogger(&ecslog.Logger{&disabledLogger})
+	healthComp := ecs.NewComponentType[Health]("health")
+	if enableHealthSystem {
+		world.AddSystem(func(w *ecs.World, queue *transaction.TxQueue, logger *ecslog.Logger) error {
+			healthComp.Each(w, func(id entity.ID) bool {
+				health, err := healthComp.Get(w, id)
+				assert.NilError(t, err)
+				health.Value++
+				assert.NilError(t, healthComp.Set(w, id, health))
+				return true
+			})
+			return nil
+		})
+	}
+
+	assert.NilError(t, world.RegisterComponents(healthComp))
+	assert.NilError(t, world.LoadGameState())
+	_, err := world.CreateMany(numOfEntities, healthComp)
+	assert.NilError(t, err)
+	// Perform a game tick to ensure the newly created entities have been committed to the DB
+	ctx := context.Background()
+	assert.NilError(t, world.Tick(ctx))
+	return world
+}
+
+func BenchmarkWorld_Tick(b *testing.B) {
+	maxEntities := 1000
+	enableHealthSystem := false
+
+	for i := maxEntities; i <= maxEntities; i *= 10 {
+		world := setupWorld(b, i, enableHealthSystem)
+		name := fmt.Sprintf("%d entities", i)
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				world.Tick(context.Background())
+			}
+		})
+	}
+}
+
+func BenchmarkWorld_TickWithSystem(b *testing.B) {
+	maxEntities := 10000
+	enableHealthSystem := true
+
+	for i := 1; i <= maxEntities; i *= 10 {
+		world := setupWorld(b, i, enableHealthSystem)
+		name := fmt.Sprintf("%d entities", i)
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				world.Tick(context.Background())
+			}
+		})
+	}
+}

--- a/cardinal/ecs/ecb/doc.go
+++ b/cardinal/ecs/ecb/doc.go
@@ -52,6 +52,17 @@ value:	JSON serialized bytes that can be deserialized to a map of archetype.ID t
 what archetype IDs have already been assigned and what groups of components each archetype ID corresponds to. This field
 must be loaded into memory before any entity creation or component addition/removals take place.
 
+key: 	"ECB:START-TICK"
+value:  An integer that represents the last tick that was started.
+
+key: 	"ECB:END-TICK"
+value: 	An integer that represents the last tick that was successfully completed.
+
+key: 	"ECB:PENDING-TRANSACTIONS"
+value:  JSON serialized bytes that can be deserialized to a list of transactions. These are the transactions that were
+processed in the last started tick. This data is only relevant when the START-TICK number does not match the END-TICK
+number.
+
 # In-memory storage model
 
 The in-memory data model roughly matches the model that is stored in redis, but there are some differences:

--- a/cardinal/ecs/ecb/keys.go
+++ b/cardinal/ecs/ecb/keys.go
@@ -39,3 +39,15 @@ func redisActiveEntityIDKey(archID archetype.ID) string {
 func redisArchIDsToCompTypesKey() string {
 	return "ECB:ARCHETYPE-ID-TO-COMPONENT-TYPES"
 }
+
+func redisStartTickKey() string {
+	return "ECB:START-TICK"
+}
+
+func redisEndTickKey() string {
+	return "ECB:END-TICK"
+}
+
+func redisPendingTransactionKey() string {
+	return "ECB:PENDING-TRANSACTIONS"
+}

--- a/cardinal/ecs/ecb/tick.go
+++ b/cardinal/ecs/ecb/tick.go
@@ -1,0 +1,121 @@
+package ecb
+
+import (
+	"context"
+
+	"github.com/redis/go-redis/v9"
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
+	"pkg.world.dev/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
+	"pkg.world.dev/world-engine/sign"
+)
+
+// The world tick must be updated in the same atomic transaction as all the state changes
+// associated with that tick. This means the manager here must also implement the TickStore interface.
+var _ storage.TickStorage = &Manager{}
+
+func (m *Manager) GetTickNumbers() (start, end uint64, err error) {
+	ctx := context.Background()
+	start, err = m.client.Get(ctx, redisStartTickKey()).Uint64()
+	if err == redis.Nil {
+		start = 0
+	} else if err != nil {
+		return 0, 0, err
+	}
+	end, err = m.client.Get(ctx, redisEndTickKey()).Uint64()
+	if err == redis.Nil {
+		end = 0
+	} else if err != nil {
+		return 0, 0, err
+	}
+	return start, end, nil
+}
+
+func (m *Manager) StartNextTick(txs []transaction.ITransaction, queue *transaction.TxQueue) error {
+	ctx := context.Background()
+	pipe := m.client.TxPipeline()
+	if err := addPendingTransactionToPipe(ctx, pipe, txs, queue); err != nil {
+		return err
+	}
+
+	if err := pipe.Incr(ctx, redisStartTickKey()).Err(); err != nil {
+		return err
+	}
+
+	_, err := pipe.Exec(ctx)
+	return err
+}
+
+func (m *Manager) FinalizeTick() error {
+	ctx := context.Background()
+	pipe, err := m.makePipeOfRedisCommands(ctx)
+	if err != nil {
+		return err
+	}
+	if err = pipe.Incr(context.Background(), redisEndTickKey()).Err(); err != nil {
+		return err
+	}
+	_, err = pipe.Exec(ctx)
+	return err
+}
+
+func (m *Manager) Recover(txs []transaction.ITransaction) (*transaction.TxQueue, error) {
+	ctx := context.Background()
+	key := redisPendingTransactionKey()
+	bz, err := m.client.Get(ctx, key).Bytes()
+	if err != nil {
+		return nil, err
+	}
+	pending, err := codec.Decode[[]pendingTransaction](bz)
+	if err != nil {
+		return nil, err
+	}
+	idToTx := map[transaction.TypeID]transaction.ITransaction{}
+	for _, tx := range txs {
+		idToTx[tx.ID()] = tx
+	}
+
+	txQueue := transaction.NewTxQueue()
+	for _, p := range pending {
+		tx := idToTx[p.TypeID]
+		txData, err := tx.Decode(p.Data)
+		if err != nil {
+			return nil, err
+		}
+		txQueue.AddTransaction(tx.ID(), txData, p.Sig)
+	}
+	return txQueue, nil
+}
+
+type pendingTransaction struct {
+	TypeID transaction.TypeID
+	TxHash transaction.TxHash
+	Data   []byte
+	Sig    *sign.SignedPayload
+}
+
+func addPendingTransactionToPipe(ctx context.Context, pipe redis.Pipeliner, txs []transaction.ITransaction, queue *transaction.TxQueue) error {
+	var pending []pendingTransaction
+	for _, tx := range txs {
+		currList := queue.ForID(tx.ID())
+		for _, txData := range currList {
+			buf, err := tx.Encode(txData.Value)
+			if err != nil {
+				return err
+			}
+			currItem := pendingTransaction{
+				TypeID: tx.ID(),
+				TxHash: txData.TxHash,
+				Sig:    txData.Sig,
+				Data:   buf,
+			}
+			pending = append(pending, currItem)
+		}
+	}
+	buf, err := codec.Encode(pending)
+	if err != nil {
+		return err
+	}
+	key := redisPendingTransactionKey()
+	return pipe.Set(ctx, key, buf, 0).Err()
+}

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -360,9 +360,9 @@ func TestVerifyAutomaticCreationOfArchetypesWorks(t *testing.T) {
 	getArchIDForEntityID := func(id entity.ID) archetype.ID {
 		components, err := world.StoreManager().GetComponentTypesForEntity(id)
 		assert.NilError(t, err)
-		archIDBefore, err := world.StoreManager().GetArchIDForComponents(components)
+		archID, err := world.StoreManager().GetArchIDForComponents(components)
 		assert.NilError(t, err)
-		return archIDBefore
+		return archID
 	}
 
 	entity, err := world.Create(a, b)

--- a/cardinal/ecs/internal/testutil/testutil.go
+++ b/cardinal/ecs/internal/testutil/testutil.go
@@ -11,6 +11,7 @@ import (
 	"github.com/redis/go-redis/v9"
 	"gotest.tools/v3/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/ecb"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/sign"
 )
@@ -35,7 +36,9 @@ func InitWorldWithRedis(t *testing.T, s *miniredis.Miniredis) *ecs.World {
 		DB:       0,  // use default DB
 	}, "in-memory-world")
 	worldStorage := storage.NewWorldStorage(&rs)
-	w, err := ecs.NewWorld(worldStorage)
+	sm, err := ecb.NewManager(rs.Client)
+	assert.NilError(t, err)
+	w, err := ecs.NewWorld(worldStorage, sm)
 	assert.NilError(t, err)
 	return w
 }

--- a/cardinal/ecs/log/log.go
+++ b/cardinal/ecs/log/log.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/rs/zerolog"
+	"pkg.world.dev/world-engine/cardinal/ecs/archetype"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/entity"
 )
@@ -46,14 +47,14 @@ func (l *Logger) loadSystemIntoEvent(zeroLoggerEvent *zerolog.Event, target Logg
 	return zeroLoggerEvent.Array("systems", arrayLogger)
 }
 
-func (l *Logger) loadEntityIntoEvent(zeroLoggerEvent *zerolog.Event, entity entity.Entity, components []component.IComponentType) (*zerolog.Event, error) {
+func (l *Logger) loadEntityIntoEvent(zeroLoggerEvent *zerolog.Event, entityID entity.ID, archID archetype.ID, components []component.IComponentType) (*zerolog.Event, error) {
 	arrayLogger := zerolog.Arr()
 	for _, _component := range components {
 		arrayLogger = l.loadComponentIntoArrayLogger(_component, arrayLogger)
 	}
 	zeroLoggerEvent.Array("components", arrayLogger)
-	zeroLoggerEvent.Int("entity_id", int(entity.EntityID()))
-	return zeroLoggerEvent.Int("archetype_id", int(entity.Loc.ArchID)), nil
+	zeroLoggerEvent.Int("entity_id", int(entityID))
+	return zeroLoggerEvent.Int("archetype_id", int(archID)), nil
 }
 
 // LogComponents logs all component info related to the world
@@ -71,12 +72,12 @@ func (l *Logger) LogSystem(target Loggable, level zerolog.Level) {
 }
 
 // LogEntity logs entity info given an entityID
-func (l *Logger) LogEntity(level zerolog.Level, entity entity.Entity, components []component.IComponentType) {
+func (l *Logger) LogEntity(level zerolog.Level, entityID entity.ID, archID archetype.ID, components []component.IComponentType) {
 	zeroLoggerEvent := l.WithLevel(level)
 	var err error = nil
-	zeroLoggerEvent, err = l.loadEntityIntoEvent(zeroLoggerEvent, entity, components)
+	zeroLoggerEvent, err = l.loadEntityIntoEvent(zeroLoggerEvent, entityID, archID, components)
 	if err != nil {
-		l.Err(err).Msg(fmt.Sprintf("Error in Logger when retrieving entity with id %d", entity.EntityID()))
+		l.Err(err).Msg(fmt.Sprintf("Error in Logger when retrieving entity with id %d", entityID))
 	} else {
 		zeroLoggerEvent.Send()
 	}

--- a/cardinal/ecs/log/log_test.go
+++ b/cardinal/ecs/log/log_test.go
@@ -102,25 +102,32 @@ func TestWorldLogger(t *testing.T) {
 	//require.JSONEq compares json strings for equality.
 	require.JSONEq(t, buf.String(), jsonWorldInfoString)
 	buf.Reset()
-	archetypeId, err := w.StoreManager().GetArchIDForComponents([]component.IComponentType{energy})
+	components := []component.IComponentType{energy}
+	entityId, err := w.Create(components...)
 	assert.NilError(t, err)
-	archetype_creations_json_string := buf.String()
+	logStrings := strings.Split(buf.String(), "\n")[:2]
 	require.JSONEq(t, `
 			{
 				"level":"debug",
 				"archetype_id":0,
 				"message":"created"
-			}`, archetype_creations_json_string)
-	components := w.StoreManager().GetComponentTypesForArchID(archetypeId)
-	entityId, err := w.Create(components...)
-	assert.NilError(t, err)
+			}`, logStrings[0])
+	require.JSONEq(t, `
+			{
+				"level":"debug",
+				"components":[{
+					"component_id":2,
+					"component_name":"EnergyComp"
+				}],
+				"entity_id":0,"archetype_id":0
+			}`, logStrings[1])
+
 	buf.Reset()
 
-	entity, err := w.StoreManager().GetEntity(entityId)
-	assert.NilError(t, err)
-
 	// test log entity
-	cardinalLogger.LogEntity(zerolog.DebugLevel, entity, components)
+	archetypeId, err := w.StoreManager().GetArchIDForComponents(components)
+	assert.NilError(t, err)
+	cardinalLogger.LogEntity(zerolog.DebugLevel, entityId, archetypeId, components)
 	jsonEntityInfoString := `
 		{
 			"level":"debug",
@@ -144,8 +151,7 @@ func TestWorldLogger(t *testing.T) {
 	// testing output of logging a tick. Should log the system log and tick start and end strings.
 	err = w.Tick(ctx)
 	assert.NilError(t, err)
-	logString := buf.String()
-	logStrings := strings.Split(logString, "\n")[:4]
+	logStrings = strings.Split(buf.String(), "\n")[:4]
 	// test tick start
 	require.JSONEq(t, `
 			{

--- a/cardinal/ecs/mock_world.go
+++ b/cardinal/ecs/mock_world.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/alicebob/miniredis/v2"
+	"pkg.world.dev/world-engine/cardinal/ecs/ecb"
 
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
@@ -48,6 +49,10 @@ func newMockWorld(s *miniredis.Miniredis, opts ...Option) (*World, error) {
 		DB:       0,  // use default DB
 	}, "in-memory-world")
 	worldStorage := storage.NewWorldStorage(&rs)
+	sm, err := ecb.NewManager(rs.Client)
+	if err != nil {
+		return nil, err
+	}
 
-	return NewWorld(worldStorage, opts...)
+	return NewWorld(worldStorage, sm, opts...)
 }

--- a/cardinal/ecs/store/store.go
+++ b/cardinal/ecs/store/store.go
@@ -157,8 +157,7 @@ func (s *Manager) createEntityFromArchetypeID(archID archetype.ID) (entity.ID, e
 		return storage.BadID, err
 	}
 	archetype.PushEntity(nextEntityID)
-	entity := storage.NewEntity(nextEntityID, entity.NewLocation(archID, componentIndex))
-	s.logger.LogEntity(zerolog.DebugLevel, entity, components)
+	s.logger.LogEntity(zerolog.DebugLevel, nextEntityID, archID, components)
 	return nextEntityID, nil
 }
 

--- a/cardinal/ecs/transaction/transaction_test.go
+++ b/cardinal/ecs/transaction/transaction_test.go
@@ -280,7 +280,8 @@ func TestTransactionsAreExecutedAtNextTick(t *testing.T) {
 	count := <-modScoreCountCh
 	assert.Equal(t, 1, count)
 
-	// Add a transaction mid-tick.
+	// Add two transactions mid-tick.
+	modScoreTx.AddToQueue(world, &ModifyScoreTx{})
 	modScoreTx.AddToQueue(world, &ModifyScoreTx{})
 
 	// The tick is still not over, so we should still only see 1 modify score transaction
@@ -293,10 +294,11 @@ func TestTransactionsAreExecutedAtNextTick(t *testing.T) {
 	// Start the next tick.
 	tickStart <- time.Now()
 
+	// This second tick shold find 2 ModifyScore transactions. They were added in the middle of the previous tick.
 	count = <-modScoreCountCh
-	assert.Equal(t, 1, count)
+	assert.Equal(t, 2, count)
 	count = <-modScoreCountCh
-	assert.Equal(t, 1, count)
+	assert.Equal(t, 2, count)
 
 	// Block until the tick has completed.
 	<-tickDone

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -79,6 +79,13 @@ func (w *World) StoreManager() store.IManager {
 	return w.storeManager
 }
 
+func (w *World) TickStore() storage.TickStorage {
+	if ts, ok := w.StoreManager().(storage.TickStorage); ok {
+		return ts
+	}
+	return w.store.TickStore
+}
+
 func (w *World) GetTxQueueAmount() int {
 	return w.txQueue.GetAmountOfTxs()
 }
@@ -128,10 +135,6 @@ func (w *World) RegisterComponents(components ...component.IComponentType) error
 		} else {
 			return errors.New("cannot register multiple components with the same name")
 		}
-	}
-
-	if err := w.storeManager.RegisterComponents(w.registeredComponents); err != nil {
-		return err
 	}
 
 	return nil
@@ -204,13 +207,14 @@ func (w *World) ListTransactions() ([]transaction.ITransaction, error) {
 }
 
 // NewWorld creates a new world.
-func NewWorld(s storage.WorldStorage, opts ...Option) (*World, error) {
+func NewWorld(s storage.WorldStorage, sm store.IManager, opts ...Option) (*World, error) {
 	logger := &ecslog.Logger{
 		&log.Logger,
 	}
+	sm.InjectLogger(logger)
 	w := &World{
 		store:             s,
-		storeManager:      store.NewStoreManager(s, logger),
+		storeManager:      sm,
 		namespace:         "world",
 		tick:              0,
 		systems:           make([]System, 0),
@@ -301,7 +305,7 @@ func (w *World) Tick(ctx context.Context) error {
 	}
 	txQueue := w.txQueue.CopyTransaction()
 
-	if err := w.store.TickStore.StartNextTick(w.registeredTransactions, txQueue); err != nil {
+	if err := w.TickStore().StartNextTick(w.registeredTransactions, txQueue); err != nil {
 		return err
 	}
 
@@ -313,13 +317,11 @@ func (w *World) Tick(ctx context.Context) error {
 			return err
 		}
 	}
-	if err := w.saveArchetypeData(); err != nil {
+
+	if err := w.TickStore().FinalizeTick(); err != nil {
 		return err
 	}
 
-	if err := w.store.TickStore.FinalizeTick(); err != nil {
-		return err
-	}
 	w.tick++
 	w.receiptHistory.NextTick()
 	elapsedTime := time.Since(startTime)
@@ -407,30 +409,12 @@ const (
 	storeArchetypeAccessorKey = "arch_accessor"
 )
 
-func (w *World) saveArchetypeData() error {
-	if err := w.saveToKey(storeArchetypeAccessorKey, w.store.ArchAccessor); err != nil {
-		return err
-	}
-	if err := w.saveToKey(storeArchetypeCompIdxKey, w.store.ArchCompIdxStore); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (w *World) saveToKey(key string, cm storage.ComponentMarshaler) error {
-	buf, err := cm.Marshal()
-	if err != nil {
-		return err
-	}
-	return w.store.StateStore.Save(key, buf)
-}
-
 // recoverGameState checks the status of the last game tick. If the tick was incomplete (indicating
 // a problem when running one of the Systems), the snapshotted state is recovered and the pending
 // transactions for the incomplete tick are returned. A nil recoveredTxs indicates there are no pending
 // transactions that need to be processed because the last tick was successful.
 func (w *World) recoverGameState() (recoveredTxs *transaction.TxQueue, err error) {
-	start, end, err := w.store.TickStore.GetTickNumbers()
+	start, end, err := w.TickStore().GetTickNumbers()
 	if err != nil {
 		return nil, err
 	}
@@ -439,7 +423,7 @@ func (w *World) recoverGameState() (recoveredTxs *transaction.TxQueue, err error
 	if start == end {
 		return nil, nil
 	}
-	return w.store.TickStore.Recover(w.registeredTransactions)
+	return w.TickStore().Recover(w.registeredTransactions)
 }
 
 func (w *World) LoadGameState() error {
@@ -456,6 +440,11 @@ func (w *World) LoadGameState() error {
 			return err
 		}
 	}
+
+	if err := w.storeManager.RegisterComponents(w.registeredComponents); err != nil {
+		return err
+	}
+
 	w.stateIsLoaded = true
 	recoveredTxs, err := w.recoverGameState()
 	if err != nil {

--- a/cardinal/log.go
+++ b/cardinal/log.go
@@ -22,18 +22,18 @@ func (l *Logger) LogSystem(world *World, level zerolog.Level) {
 
 // LogEntity logs entity info given an entityID
 func (l *Logger) LogEntity(world *World, level zerolog.Level, entityID EntityID) {
-	entity, err := world.implWorld.StoreManager().GetEntity(entityID)
-	if err != nil {
-		l.impl.Warn().Err(fmt.Errorf("failed to get entity %d: %w", entityID, err))
-		return
-	}
 	components, err := world.implWorld.StoreManager().GetComponentTypesForEntity(entityID)
 	if err != nil {
 		l.impl.Warn().Err(fmt.Errorf("failed to get components for entity %d: %w", entityID, err))
 		return
 	}
+	archID, err := world.implWorld.StoreManager().GetArchIDForComponents(components)
+	if err != nil {
+		l.impl.Warn().Err(fmt.Errorf("failed to get archID for %d: %w", entityID, err))
+		return
+	}
 
-	l.impl.LogEntity(level, entity, components)
+	l.impl.LogEntity(level, entityID, archID, components)
 }
 
 // LogWorld Logs everything about the world (components and Systems)

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/ecb"
 	"pkg.world.dev/world-engine/cardinal/ecs/entity"
 	ecslog "pkg.world.dev/world-engine/cardinal/ecs/log"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
@@ -54,7 +55,11 @@ func NewWorld(addr, password string, opts ...WorldOption) (*World, error) {
 		DB:       0,        // use default DB
 	}, "world")
 	worldStorage := storage.NewWorldStorage(&rs)
-	ecsWorld, err := ecs.NewWorld(worldStorage, ecsOptions...)
+	storeManager, err := ecb.NewManager(rs.Client)
+	if err != nil {
+		return nil, err
+	}
+	ecsWorld, err := ecs.NewWorld(worldStorage, storeManager, ecsOptions...)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes: #WORLD-384, WORLD-385

## What is the purpose of the change

- Update all tests to use the ecb version of the storage manager.
- Update the log code to not depend on component indices (component indices are not used for ecb).
- Add tick management to the ecb (this is required because the tick increment must happen atomically with all other state changes)
- Update the World.Tick code to use ecb for tick starting, tick finalizing, and tick recovery.
- Add some benchmarks for track how long it takes to perform a world tick.


## Testing and Verifying

Existing unit tests verify that there are no functional changes by changing to this new data storage model.

To run the new benchmarks, go to world-engine/cardinal/ecs/ecb and run:

```
go test -bench=.
```
