### PR TITLE
DO NOT SUBMIT - sample code for combining system parameters into a si…

### DIFF
--- a/cardinal/ecs/climate/climate.go
+++ b/cardinal/ecs/climate/climate.go
@@ -1,0 +1,24 @@
+package climate
+
+type Climate interface {
+	Set(key string, value any)
+	Get(key string) any
+}
+
+func NewClimate() Climate {
+	return &climateImpl{
+		m: map[string]any{},
+	}
+}
+
+type climateImpl struct {
+	m map[string]any
+}
+
+func (c *climateImpl) Set(key string, value any) {
+	c.m[key] = value
+}
+
+func (c *climateImpl) Get(key string) any {
+	return c.m[key]
+}

--- a/cardinal/ecs/climate_control.go
+++ b/cardinal/ecs/climate_control.go
@@ -1,0 +1,75 @@
+package ecs
+
+import (
+	"fmt"
+
+	"pkg.world.dev/world-engine/cardinal/ecs/climate"
+	"pkg.world.dev/world-engine/cardinal/ecs/store"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
+)
+
+const (
+	climateKeyTxQueue  = "tx_queue_climate_key"
+	climateKeyWorld    = "world_climate_key"
+	climateKeyReadOnly = "read_only_climate_key"
+	climateKeyLogger   = "logger_climate_key"
+)
+
+func climateGetAs[T any](clim climate.Climate, key string) (value T, err error) {
+	iface := clim.Get(key)
+	if iface == nil {
+		return value, fmt.Errorf("cannot find value for %q", key)
+	}
+	value, ok := iface.(T)
+	if !ok {
+		return value, fmt.Errorf("cannot value at %q to type %T", key, value)
+	}
+	return value, nil
+}
+
+func climateGetTxQueue(clim climate.Climate) (*transaction.TxQueue, error) {
+	return climateGetAs[*transaction.TxQueue](clim, climateKeyTxQueue)
+}
+
+func climateGetWorld(clim climate.Climate) (*World, error) {
+	return climateGetAs[*World](clim, climateKeyWorld)
+}
+
+func climateIsReadOnly(clim climate.Climate) bool {
+	ro, err := climateGetAs[bool](clim, climateKeyReadOnly)
+	// There was an error, but just to be safe let's disallow state changes
+	if err != nil {
+		return true
+	}
+	return ro
+}
+
+func NewClimate(world *World, tq *transaction.TxQueue) climate.Climate {
+	clim := climate.NewClimate()
+	clim.Set(climateKeyWorld, world)
+	clim.Set(climateKeyTxQueue, tq)
+	clim.Set(climateKeyLogger, world.Logger)
+	clim.Set(climateKeyReadOnly, false)
+	return clim
+}
+
+func NewReadOnlyClimate(world *World) climate.Climate {
+	clim := climate.NewClimate()
+	clim.Set(climateKeyWorld, world)
+	clim.Set(climateKeyTxQueue, nil)
+	clim.Set(climateKeyLogger, world.Logger)
+	clim.Set(climateKeyReadOnly, true)
+	return clim
+}
+
+func climateGetStoreReader(clim climate.Climate) (store.Reader, error) {
+	world, err := climateGetWorld(clim)
+	if err != nil {
+		return nil, err
+	}
+	readOnly := climateIsReadOnly(clim)
+	if readOnly {
+		return world.StoreManager().ToReadOnly(), nil
+	}
+	return world.StoreManager(), nil
+}

--- a/cardinal/ecs/ecb/read_only.go
+++ b/cardinal/ecs/ecb/read_only.go
@@ -28,7 +28,7 @@ type readOnlyManager struct {
 	archIDToComps   map[archetype.ID][]component.IComponentType
 }
 
-func (m *Manager) NewReadOnlyStore() store.Reader {
+func (m *Manager) ToReadOnly() store.Reader {
 	return &readOnlyManager{
 		client:          m.client,
 		typeToComponent: m.typeToComponent,

--- a/cardinal/ecs/read_test.go
+++ b/cardinal/ecs/read_test.go
@@ -2,8 +2,10 @@ package ecs_test
 
 import (
 	"context"
-	"pkg.world.dev/world-engine/cardinal/evm"
 	"testing"
+
+	"pkg.world.dev/world-engine/cardinal/ecs/climate"
+	"pkg.world.dev/world-engine/cardinal/evm"
 
 	routerv1 "buf.build/gen/go/argus-labs/world-engine/protocolbuffers/go/router/v1"
 	"gotest.tools/v3/assert"
@@ -29,7 +31,7 @@ func TestReadTypeNotStructs(t *testing.T) {
 		// test should trigger a panic.
 		panicValue := recover()
 		assert.Assert(t, panicValue != nil)
-		ecs.NewReadType[FooRequest, FooReply]("foo", func(world *ecs.World, req FooRequest) (FooReply, error) {
+		ecs.NewReadType[FooRequest, FooReply]("foo", func(clim climate.Climate, req FooRequest) (FooReply, error) {
 			return expectedReply, nil
 		})
 		defer func() {
@@ -39,7 +41,7 @@ func TestReadTypeNotStructs(t *testing.T) {
 		}()
 	}()
 
-	ecs.NewReadType[string, string]("foo", func(world *ecs.World, req string) (string, error) {
+	ecs.NewReadType[string, string]("foo", func(clim climate.Climate, req string) (string, error) {
 		return "blah", nil
 	})
 }
@@ -58,7 +60,7 @@ func TestReadEVM(t *testing.T) {
 		Name: "Chad",
 		Age:  22,
 	}
-	fooRead := ecs.NewReadType[FooRequest, FooReply]("foo", func(world *ecs.World, req FooRequest) (FooReply, error) {
+	fooRead := ecs.NewReadType[FooRequest, FooReply]("foo", func(clim climate.Climate, req FooRequest) (FooReply, error) {
 		return expectedReply, nil
 	}, ecs.WithReadEVMSupport[FooRequest, FooReply])
 

--- a/cardinal/ecs/store/iface.go
+++ b/cardinal/ecs/store/iface.go
@@ -58,4 +58,5 @@ type Writer interface {
 type IManager interface {
 	Reader
 	Writer
+	ToReadOnly() Reader
 }

--- a/cardinal/ecs/system.go
+++ b/cardinal/ecs/system.go
@@ -1,8 +1,7 @@
 package ecs
 
 import (
-	"pkg.world.dev/world-engine/cardinal/ecs/log"
-	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
+	"pkg.world.dev/world-engine/cardinal/ecs/climate"
 )
 
-type System func(*World, *transaction.TxQueue, *log.Logger) error
+type System func(climate.Climate) error

--- a/cardinal/ecs/transaction/transaction_test.go
+++ b/cardinal/ecs/transaction/transaction_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/climate"
 	"pkg.world.dev/world-engine/cardinal/ecs/entity"
 	"pkg.world.dev/world-engine/cardinal/ecs/log"
 	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
@@ -63,11 +64,11 @@ func TestCanQueueTransactions(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Set up a system that allows for the modification of a player's score
-	world.AddSystem(func(w *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		modifyScore := modifyScoreTx.In(queue)
+	world.AddSystem(func(clim climate.Climate) error {
+		modifyScore := modifyScoreTx.In(clim)
 		for _, txData := range modifyScore {
 			ms := txData.Value
-			err := ecs.UpdateComponent[ScoreComponent](w, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
+			err := ecs.UpdateComponent[ScoreComponent](clim, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
 				s.Score += ms.Amount
 				return s
 			})
@@ -150,11 +151,11 @@ func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 	modifyScoreTx := ecs.NewTransactionType[*ModifyScoreTx, *EmptyTxResult]("modify_score")
 	assert.NilError(t, world.RegisterTransactions(modifyScoreTx))
 
-	world.AddSystem(func(w *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		modifyScores := modifyScoreTx.In(queue)
+	world.AddSystem(func(clim climate.Climate) error {
+		modifyScores := modifyScoreTx.In(clim)
 		for _, msData := range modifyScores {
 			ms := msData.Value
-			err := ecs.UpdateComponent[ScoreComponent](w, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
+			err := ecs.UpdateComponent[ScoreComponent](clim, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
 				s.Score += ms.Amount
 				return s
 			})

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"pkg.world.dev/world-engine/cardinal/ecs/climate"
 	"pkg.world.dev/world-engine/cardinal/shard"
 	"pkg.world.dev/world-engine/chain/x/shard/types"
 
@@ -175,7 +176,7 @@ func TestShutDownViaSignal(t *testing.T) {
 	w := ecs.NewTestWorld(t)
 	sendTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult]("sendTx")
 	assert.NilError(t, w.RegisterTransactions(sendTx))
-	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
+	w.AddSystem(func(clim climate.Climate) error {
 		return nil
 	})
 	assert.NilError(t, w.LoadGameState())
@@ -274,8 +275,8 @@ func TestHandleTransactionWithNoSignatureVerification(t *testing.T) {
 	sendTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult](endpoint)
 	assert.NilError(t, w.RegisterTransactions(sendTx))
 	count := 0
-	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		txs := sendTx.In(queue)
+	w.AddSystem(func(clim climate.Climate) error {
+		txs := sendTx.In(clim)
 		assert.Equal(t, 1, len(txs))
 		tx := txs[0]
 		assert.Equal(t, tx.Value.From, "me")
@@ -331,7 +332,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 	w := ecs.NewTestWorld(t)
 	sendTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult]("send-energy")
 	assert.NilError(t, w.RegisterTransactions(sendTx))
-	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
+	w.AddSystem(func(climate.Climate) error {
 		return nil
 	})
 
@@ -372,7 +373,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 		Name: "Chad",
 		Age:  22,
 	}
-	fooRead := ecs.NewReadType[FooRequest, FooReply]("foo", func(world *ecs.World, req FooRequest) (FooReply, error) {
+	fooRead := ecs.NewReadType[FooRequest, FooReply]("foo", func(clim climate.Climate, req FooRequest) (FooReply, error) {
 		return expectedReply, nil
 	})
 	assert.NilError(t, w.RegisterReads(fooRead))


### PR DESCRIPTION
Here is some sample code that show how a "Context" or "Climate" object will be implemented across ecs.

"Climate" was chosen here to ensure the name doesn't collide with the commonly-used [contex.Context](https://pkg.go.dev/context#Context). 

See the [Sys/Read Refactor](https://www.notion.so/arguslabs/World-Engine-V1-2fe15adfaa1a40e9ad0936558afda6f5?p=2586dc3392984100ac08557ad4d3e9d8&pm=s) doc in notions for more details. 