### PR TITLE
refactor(cardinal): remove the deprecated GetEntity and return an error…

### DIFF
--- a/cardinal/ecs/ecb/ecb.go
+++ b/cardinal/ecs/ecb/ecb.go
@@ -123,13 +123,6 @@ func (m *Manager) DiscardPending() {
 	m.pendingArchIDs = m.pendingArchIDs[:0]
 }
 
-// GetEntity converts an entity ID into an entity.Entity.
-// TODO: This is only used in tests, so it should be removed from the StoreManager interface.
-// See: https://linear.app/arguslabs/issue/WORLD-394/remove-getentity-method-from-storemanager
-func (m *Manager) GetEntity(id entity.ID) (entity.Entity, error) {
-	panic("implement me")
-}
-
 // RemoveEntity removes the given entity from the ECS data model.
 func (m *Manager) RemoveEntity(idToRemove entity.ID) error {
 	archID, err := m.getArchetypeForEntity(idToRemove)
@@ -346,14 +339,12 @@ func (m *Manager) GetArchIDForComponents(components []component.IComponentType) 
 }
 
 // GetEntitiesForArchID returns all the entities that currently belong to the given archetype ID.
-func (m *Manager) GetEntitiesForArchID(archID archetype.ID) []entity.ID {
+func (m *Manager) GetEntitiesForArchID(archID archetype.ID) ([]entity.ID, error) {
 	active, err := m.getActiveEntities(archID)
 	if err != nil {
-		// TODO: This should either return an error or never panic.
-		// See https://linear.app/arguslabs/issue/WORLD-395/update-ecbgetentitiesforarchid-to-return-error-or-to-never-panicp
-		panic(err)
+		return nil, err
 	}
-	return active.ids
+	return active.ids, nil
 }
 
 // SearchFrom returns an ArchetypeIterator based on a component filter. The iterator will iterate over all archetypes

--- a/cardinal/ecs/ecb/ecb_test.go
+++ b/cardinal/ecs/ecb/ecb_test.go
@@ -352,7 +352,8 @@ func TestEntityCanBeRemoved(t *testing.T) {
 	archID, err := manager.GetArchIDForComponents(comps)
 	assert.NilError(t, err)
 
-	gotIDs := manager.GetEntitiesForArchID(archID)
+	gotIDs, err := manager.GetEntitiesForArchID(archID)
+	assert.NilError(t, err)
 	assert.Equal(t, 5, len(gotIDs))
 
 	// Only the ids at odd indices should be findable
@@ -382,16 +383,20 @@ func TestMovedEntitiesCanBeFoundInNewArchetype(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Make sure there are the correct number of ids in each archetype to start
-	ids := manager.GetEntitiesForArchID(fooArchID)
+	ids, err := manager.GetEntitiesForArchID(fooArchID)
+	assert.NilError(t, err)
 	assert.Equal(t, 1, len(ids))
-	ids = manager.GetEntitiesForArchID(bothArchID)
+	ids, err = manager.GetEntitiesForArchID(bothArchID)
+	assert.NilError(t, err)
 	assert.Equal(t, startEntityCount, len(ids))
 
 	assert.NilError(t, manager.AddComponentToEntity(barComp, id))
 
-	ids = manager.GetEntitiesForArchID(fooArchID)
+	ids, err = manager.GetEntitiesForArchID(fooArchID)
+	assert.NilError(t, err)
 	assert.Equal(t, 0, len(ids))
-	ids = manager.GetEntitiesForArchID(bothArchID)
+	ids, err = manager.GetEntitiesForArchID(bothArchID)
+	assert.NilError(t, err)
 	assert.Equal(t, startEntityCount+1, len(ids))
 
 	// make sure the target id is in the new list of ids.
@@ -406,9 +411,11 @@ func TestMovedEntitiesCanBeFoundInNewArchetype(t *testing.T) {
 
 	// Also make sure we can remove the archetype
 	assert.NilError(t, manager.RemoveComponentFromEntity(barComp, id))
-	ids = manager.GetEntitiesForArchID(fooArchID)
+	ids, err = manager.GetEntitiesForArchID(fooArchID)
+	assert.NilError(t, err)
 	assert.Equal(t, 1, len(ids))
-	ids = manager.GetEntitiesForArchID(bothArchID)
+	ids, err = manager.GetEntitiesForArchID(bothArchID)
+	assert.NilError(t, err)
 	assert.Equal(t, startEntityCount, len(ids))
 
 	// Make sure the target id is NOT in the 'both' group

--- a/cardinal/ecs/ecb/read_only.go
+++ b/cardinal/ecs/ecb/read_only.go
@@ -49,13 +49,6 @@ func (r *readOnlyManager) refreshArchIDToCompTypes() error {
 	return nil
 }
 
-// GetEntity converts an entity ID into an entity.Entity.
-// TODO: This is only used in tests, so it should be removed from the StoreManager interface.
-// See: https://linear.app/arguslabs/issue/WORLD-394/remove-getentity-method-from-storemanager
-func (r *readOnlyManager) GetEntity(id entity.ID) (entity.Entity, error) {
-	panic("implement me")
-}
-
 func (r *readOnlyManager) GetComponentForEntity(cType component.IComponentType, id entity.ID) (any, error) {
 	bz, err := r.GetComponentForEntityInRawJson(cType, id)
 	if err != nil {
@@ -128,21 +121,19 @@ func (r *readOnlyManager) GetArchIDForComponents(components []component.ICompone
 	return 0, errors.New("arch ID for components not found")
 }
 
-func (r *readOnlyManager) GetEntitiesForArchID(archID archetype.ID) []entity.ID {
+func (r *readOnlyManager) GetEntitiesForArchID(archID archetype.ID) ([]entity.ID, error) {
 	ctx := context.Background()
 	key := redisActiveEntityIDKey(archID)
 	bz, err := r.client.Get(ctx, key).Bytes()
 	if err != nil {
 		// No entities were found for this archetype ID
-		return nil
+		return nil, nil
 	}
 	ids, err := codec.Decode[[]entity.ID](bz)
 	if err != nil {
-		// TODO: This should either return an error or never panic.
-		// See https://linear.app/arguslabs/issue/WORLD-395/update-ecbgetentitiesforarchid-to-return-error-or-to-never-panicp
-		panic(err)
+		return nil, err
 	}
-	return ids
+	return ids, nil
 }
 
 func (r *readOnlyManager) SearchFrom(filter filter.ComponentFilter, start int) *storage.ArchetypeIterator {

--- a/cardinal/ecs/ecb/read_only_test.go
+++ b/cardinal/ecs/ecb/read_only_test.go
@@ -107,7 +107,8 @@ func TestReadOnly_GetEntitiesForArchID(t *testing.T) {
 		archID, err := roManager.GetArchIDForComponents(tc.comps)
 		assert.NilError(t, err)
 
-		gotIDs := roManager.GetEntitiesForArchID(archID)
+		gotIDs, err := roManager.GetEntitiesForArchID(archID)
+		assert.NilError(t, err)
 		assert.DeepEqual(t, ids, gotIDs)
 	}
 }
@@ -123,7 +124,8 @@ func TestReadOnly_CanFindEntityIDAfterChangingArchetypes(t *testing.T) {
 
 	roManager := manager.NewReadOnlyStore()
 
-	gotIDs := roManager.GetEntitiesForArchID(fooArchID)
+	gotIDs, err := roManager.GetEntitiesForArchID(fooArchID)
+	assert.NilError(t, err)
 	assert.Equal(t, 1, len(gotIDs))
 	assert.Equal(t, gotIDs[0], id)
 
@@ -131,13 +133,15 @@ func TestReadOnly_CanFindEntityIDAfterChangingArchetypes(t *testing.T) {
 	assert.NilError(t, manager.CommitPending())
 
 	// There should be no more entities with JUST the foo componnet
-	gotIDs = roManager.GetEntitiesForArchID(fooArchID)
+	gotIDs, err = roManager.GetEntitiesForArchID(fooArchID)
+	assert.NilError(t, err)
 	assert.Equal(t, 0, len(gotIDs))
 
 	bothArchID, err := roManager.GetArchIDForComponents([]component.IComponentType{fooComp, barComp})
 	assert.NilError(t, err)
 
-	gotIDs = roManager.GetEntitiesForArchID(bothArchID)
+	gotIDs, err = roManager.GetEntitiesForArchID(bothArchID)
+	assert.NilError(t, err)
 	assert.Equal(t, 1, len(gotIDs))
 	assert.Equal(t, gotIDs[0], id)
 }

--- a/cardinal/ecs/ecb/recovery_test.go
+++ b/cardinal/ecs/ecb/recovery_test.go
@@ -153,14 +153,16 @@ func TestEntitiesCanBeFetchedAfterReload(t *testing.T) {
 	comps, err := manager.GetComponentTypesForEntity(ids[0])
 	archID, err := manager.GetArchIDForComponents(comps)
 
-	ids = manager.GetEntitiesForArchID(archID)
+	ids, err = manager.GetEntitiesForArchID(archID)
+	assert.NilError(t, err)
 	assert.Equal(t, 10, len(ids))
 
 	assert.NilError(t, manager.CommitPending())
 
 	// Create a new Manager instances and make sure the previously created entities can be found
 	manager, _ = newCmdBufferAndRedisClientForTest(t, client)
-	ids = manager.GetEntitiesForArchID(archID)
+	ids, err = manager.GetEntitiesForArchID(archID)
+	assert.NilError(t, err)
 	assert.Equal(t, 10, len(ids))
 }
 
@@ -174,7 +176,8 @@ func TestTheRemovalOfEntitiesCanBeDiscarded(t *testing.T) {
 	archID, err := manager.GetArchIDForComponents(comps)
 	assert.NilError(t, err)
 
-	gotIDs := manager.GetEntitiesForArchID(archID)
+	gotIDs, err := manager.GetEntitiesForArchID(archID)
+	assert.NilError(t, err)
 	assert.Equal(t, 10, len(gotIDs))
 	assert.NilError(t, manager.CommitPending())
 
@@ -183,13 +186,15 @@ func TestTheRemovalOfEntitiesCanBeDiscarded(t *testing.T) {
 	assert.NilError(t, manager.RemoveEntity(ids[4]))
 	assert.NilError(t, manager.RemoveEntity(ids[7]))
 
-	gotIDs = manager.GetEntitiesForArchID(archID)
+	gotIDs, err = manager.GetEntitiesForArchID(archID)
+	assert.NilError(t, err)
 	assert.Equal(t, 7, len(gotIDs))
 
 	// Discard these changes (this should bring the entities back)
 	manager.DiscardPending()
 
-	gotIDs = manager.GetEntitiesForArchID(archID)
+	gotIDs, err = manager.GetEntitiesForArchID(archID)
+	assert.NilError(t, err)
 	assert.Equal(t, 10, len(gotIDs))
 }
 

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -526,7 +526,9 @@ func TestQueriesAndFiltersWorks(t *testing.T) {
 	})
 	q, err = world.NewQuery(abFilter)
 	assert.NilError(t, err)
-	assert.Equal(t, q.Count(world), 1)
+	num, err := q.Count(world)
+	assert.NilError(t, err)
+	assert.Equal(t, num, 1)
 
 	cdFilter := ecs.Contains(C{}, D{})
 	q, err = world.NewQuery(cdFilter)
@@ -537,11 +539,14 @@ func TestQueriesAndFiltersWorks(t *testing.T) {
 	})
 	q, err = world.NewQuery(abFilter)
 	assert.NilError(t, err)
-	assert.Equal(t, q.Count(world), 1)
+	num, err = q.Count(world)
+	assert.NilError(t, err)
+	assert.Equal(t, num, 1)
 
 	q, err = world.NewQuery(ecs.Or(ecs.Contains(A{}), ecs.Contains(D{})))
 	assert.NilError(t, err)
-	allCount := q.Count(world)
+	allCount, err := q.Count(world)
+	assert.NilError(t, err)
 	assert.Equal(t, allCount, 3)
 }
 

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -92,7 +92,8 @@ func TestECS(t *testing.T) {
 
 	q, err := world.NewQuery(ecs.Or(ecs.Contains(EnergyComponent{}), ecs.Contains(OwnableComponent{})))
 	assert.NilError(t, err)
-	amt := q.Count(world)
+	amt, err := q.Count(world)
+	assert.NilError(t, err)
 	assert.Equal(t, numPlanets+numEnergyOnly, amt)
 	comp, err := world.GetComponentByName("EnergyComponent")
 	assert.NilError(t, err)
@@ -524,16 +525,21 @@ func TestQueriesAndFiltersWorks(t *testing.T) {
 		assert.Equal(t, id, ab)
 		return true
 	})
-	assert.Equal(t, ecs.NewQuery(abFilter).Count(world), 1)
+	count, err := ecs.NewQuery(abFilter).Count(world)
+	assert.NilError(t, err)
+	assert.Equal(t, count, 1)
 
 	cdFilter := filter.Contains(c, d)
 	ecs.NewQuery(cdFilter).Each(world, func(id entity.ID) bool {
 		assert.Equal(t, id, cd)
 		return true
 	})
-	assert.Equal(t, ecs.NewQuery(abFilter).Count(world), 1)
+	count, err = ecs.NewQuery(abFilter).Count(world)
+	assert.NilError(t, err)
+	assert.Equal(t, count, 1)
 
-	allCount := ecs.NewQuery(filter.Or(filter.Contains(a), filter.Contains(d))).Count(world)
+	allCount, err := ecs.NewQuery(filter.Or(filter.Contains(a), filter.Contains(d))).Count(world)
+	assert.NilError(t, err)
 	assert.Equal(t, allCount, 3)
 }
 

--- a/cardinal/ecs/query.go
+++ b/cardinal/ecs/query.go
@@ -39,30 +39,37 @@ type QueryCallBackFn func(entity.ID) bool
 
 // Each iterates over all entities that match the query.
 // If you would like to stop the iteration, return false to the callback. To continue iterating, return true.
-func (q *Query) Each(w *World, callback QueryCallBackFn) {
+func (q *Query) Each(w *World, callback QueryCallBackFn) error {
 	result := q.evaluateQuery(w.namespace, w.StoreManager())
 	iter := storage.NewEntityIterator(0, w.StoreManager(), result)
 	for iter.HasNext() {
-		entities := iter.Next()
+		entities, err := iter.Next()
+		if err != nil {
+			return err
+		}
 		for _, id := range entities {
 			cont := callback(id)
 			if !cont {
-				return
+				return nil
 			}
 		}
 	}
+	return nil
 }
 
 // Count returns the number of entities that match the query.
-func (q *Query) Count(w *World) int {
+func (q *Query) Count(w *World) (int, error) {
 	result := q.evaluateQuery(w.namespace, w.StoreManager())
 	iter := storage.NewEntityIterator(0, w.StoreManager(), result)
 	ret := 0
 	for iter.HasNext() {
-		entities := iter.Next()
+		entities, err := iter.Next()
+		if err != nil {
+			return 0, err
+		}
 		ret += len(entities)
 	}
-	return ret
+	return ret, nil
 }
 
 // First returns the first entity that matches the query.
@@ -73,7 +80,10 @@ func (q *Query) First(w *World) (id entity.ID, err error) {
 		return storage.BadID, err
 	}
 	for iter.HasNext() {
-		entities := iter.Next()
+		entities, err := iter.Next()
+		if err != nil {
+			return 0, err
+		}
 		if len(entities) > 0 {
 			return entities[0], nil
 		}

--- a/cardinal/ecs/storage/iterator.go
+++ b/cardinal/ecs/storage/iterator.go
@@ -6,7 +6,7 @@ import (
 )
 
 type HasEntitiesForArchetype interface {
-	GetEntitiesForArchID(archID archetype.ID) []entity.ID
+	GetEntitiesForArchID(archID archetype.ID) ([]entity.ID, error)
 }
 
 // EntityIterator is an iterator for Ent lists in archetypes.
@@ -31,7 +31,7 @@ func (it *EntityIterator) HasNext() bool {
 }
 
 // Next returns the next Ent list.
-func (it *EntityIterator) Next() []entity.ID {
+func (it *EntityIterator) Next() ([]entity.ID, error) {
 	archetypeID := it.indices[it.current]
 	it.current++
 	return it.archAccessor.GetEntitiesForArchID(archetypeID)

--- a/cardinal/ecs/store/iface.go
+++ b/cardinal/ecs/store/iface.go
@@ -12,9 +12,6 @@ import (
 )
 
 type Reader interface {
-	// One Entity
-	GetEntity(id entity.ID) (entity.Entity, error)
-
 	// One Component One Entity
 	GetComponentForEntity(cType component.IComponentType, id entity.ID) (any, error)
 	GetComponentForEntityInRawJson(cType component.IComponentType, id entity.ID) (json.RawMessage, error)
@@ -27,7 +24,7 @@ type Reader interface {
 	GetArchIDForComponents(components []component.IComponentType) (archetype.ID, error)
 
 	// One Archetype Many Entities
-	GetEntitiesForArchID(archID archetype.ID) []entity.ID
+	GetEntitiesForArchID(archID archetype.ID) ([]entity.ID, error)
 
 	// Misc
 	SearchFrom(filter filter.ComponentFilter, start int) *storage.ArchetypeIterator

--- a/cardinal/ecs/store/store.go
+++ b/cardinal/ecs/store/store.go
@@ -31,8 +31,8 @@ func NewStoreManager(store storage.WorldStorage, logger *log.Logger) *Manager {
 	}
 }
 
-func (s *Manager) GetEntitiesForArchID(archID archetype.ID) []entity.ID {
-	return s.store.ArchAccessor.Archetype(archID).Entities()
+func (s *Manager) GetEntitiesForArchID(archID archetype.ID) ([]entity.ID, error) {
+	return s.store.ArchAccessor.Archetype(archID).Entities(), nil
 }
 
 func (s *Manager) SearchFrom(filter filter.ComponentFilter, seen int) *storage.ArchetypeIterator {
@@ -49,14 +49,6 @@ func (s *Manager) Close() error {
 
 func (s *Manager) InjectLogger(logger *log.Logger) {
 	s.logger = logger
-}
-
-func (s *Manager) GetEntity(id entity.ID) (entity.Entity, error) {
-	loc, err := s.getEntityLocation(id)
-	if err != nil {
-		return storage.BadEntity, err
-	}
-	return storage.NewEntity(id, loc), nil
 }
 
 func (s *Manager) isValid(id entity.ID) (bool, error) {

--- a/cardinal/query.go
+++ b/cardinal/query.go
@@ -29,7 +29,7 @@ func (q *Query) Each(w *World, callback QueryCallBackFn) {
 }
 
 // Count returns the number of entities that match this query.
-func (q *Query) Count(w *World) int {
+func (q *Query) Count(w *World) (int, error) {
 	return q.impl.Count(w.implWorld)
 }
 


### PR DESCRIPTION
… for GetEntitiesForArchID

Closes: #WORLD-394, WORLD-395

## What is the purpose of the change

Remove GetEntity method - GetEntity returns an "entity" which is a combination of an ID and a Location. Location contains information about a "Component Index" which was a concept used in the old snapshotting version of the storage layer, but isn't used with the entity command buffer. 

Update GetEntitiesForArchID to return an error. Previously, the mapping of ArchetypeID to entities was handles completely in memory so this method didn't need to return an error. With ECB, this information is sometimes fetched from redis, so it's possible for this request to fail. This change ends up changing our query/filter code to also allow for the returning of errors.

