### PR TITLE
feat(cardinal): new MustReg function

### DIFF
--- a/cardinal/ecs/component/components_test.go
+++ b/cardinal/ecs/component/components_test.go
@@ -116,8 +116,8 @@ func (_ notFoundComp) Name() string {
 
 func TestErrorWhenAccessingComponentNotOnEntity(t *testing.T) {
 	world := ecs.NewTestWorld(t)
-	assert.NilError(t, ecs.RegisterComponent[foundComp](world))
-	assert.NilError(t, ecs.RegisterComponent[notFoundComp](world))
+	ecs.MustRegisterComponent[foundComp](world)
+	ecs.MustRegisterComponent[notFoundComp](world)
 
 	id, err := ecs.Create(world, foundComp{})
 	assert.NilError(t, err)

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -131,6 +131,13 @@ func RegisterComponent[T component.IAbstractComponent](world *World) error {
 	return nil
 }
 
+func MustRegisterComponent[T component.IAbstractComponent](world *World) {
+	err := RegisterComponent[T](world)
+	if err != nil {
+		panic(err)
+	}
+}
+
 func (w *World) GetComponentByName(name string) (IComponentType, error) {
 	componentType, exists := w.nameToComponent[name]
 	if !exists {


### PR DESCRIPTION
Closes: #411

## What is the purpose of the change

> Add a description of the overall background and high-level changes that this PR introduces

New function partner to `RegisterComponent` called `MustRegisterComponent` that panics. 

## testing

Changed one test to use the new function. 