### PR TITLE
Add ability to send notifications to connected clients

### DIFF
--- a/relay/nakama/notifications.go
+++ b/relay/nakama/notifications.go
@@ -1,0 +1,119 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+)
+
+// targetInfo contains information about who should receive a notification. It contains a user ID as well as
+// when this record of notification was created.
+type targetInfo struct {
+	createdAt time.Time
+	userID    string
+}
+
+// txHashAndUser is a tuple of a transaction hash and a userID.
+type txHashAndUser struct {
+	txHash string
+	userID string
+}
+
+// receiptNotifier is a struct that sends out notifications to users based on transaction receipts.
+type receiptNotifier struct {
+	// txHashToTargetInto maps a specific transaction hash to a user ID. A timestamp is also tracked so "stale" transaction
+	// can be cleaned up.
+	txHashToTargetInfo map[string]targetInfo
+	// newTxHash is a channel that takes in txHash/userID tuples. An item on this channel signalts to the receiptNotifier
+	// that the given user ID must be informed about the given transaction.
+	newTxHash chan txHashAndUser
+	// staleDuration is how much time has to pass before an undelivered notification is treated as stale.
+	staleDuration time.Duration
+
+	// Nakama specific strucst to log information and send transactions.
+	nk     runtime.NakamaModule
+	logger runtime.Logger
+}
+
+func newReceiptNotifier(logger runtime.Logger, nk runtime.NakamaModule) (*receiptNotifier, error) {
+	rd := globalReceiptsDispatcher
+	ch := make(chan *Receipt)
+	rd.subscribe("notifications", ch)
+	notifier := &receiptNotifier{
+		txHashToTargetInfo: map[string]targetInfo{},
+		nk:                 nk,
+		logger:             logger,
+		staleDuration:      time.Minute,
+		newTxHash:          make(chan txHashAndUser),
+	}
+
+	go notifier.sendNotifications(ch)
+
+	return notifier, nil
+}
+
+// AddTxHashToPendingNotifications adds the given user ID and tx hash to pending notifications. When this system
+// becomes aware of a transaction receipt with the given tx hash, the given user will be sent a notification with any
+// results and errors.
+// This method is safe for concurrent access.
+func (r *receiptNotifier) AddTxHashToPendingNotifications(txHash string, userID string) {
+	r.newTxHash <- txHashAndUser{
+		txHash: txHash,
+		userID: userID,
+	}
+}
+
+// sendNotifications loops forever, consuming Receipts from the given channel and sending them to the relevant user.
+func (r *receiptNotifier) sendNotifications(ch chan *Receipt) {
+	ticker := time.Tick(r.staleDuration)
+
+	for {
+		select {
+		case receipt := <-ch:
+			r.logger.Debug("i want to send a tx: %v", receipt)
+			if err := r.handleReceipt(receipt); err != nil {
+				r.logger.Warn("failed to handle receipt: %v", err)
+			}
+		case <-ticker:
+			r.cleanupStaleTransactions()
+		case tx := <-r.newTxHash:
+			r.txHashToTargetInfo[tx.txHash] = targetInfo{
+				createdAt: time.Now(),
+				userID:    tx.userID,
+			}
+		}
+	}
+}
+
+// handleReceipt identifies the relevant user for this receipt and sends them a notification.
+func (r *receiptNotifier) handleReceipt(receipt *Receipt) error {
+	ctx := context.Background()
+	target, ok := r.txHashToTargetInfo[receipt.TxHash]
+	if !ok {
+		return fmt.Errorf("unable to find user for tx hash %q", receipt.TxHash)
+	}
+	delete(r.txHashToTargetInfo, receipt.TxHash)
+
+	data := map[string]any{
+		"tx_hash": receipt.TxHash,
+		"result":  receipt.Result,
+		"errors":  receipt.Errors,
+	}
+
+	if err := r.nk.NotificationSend(ctx, target.userID, "subject", data, 1, "", false); err != nil {
+		return fmt.Errorf("unable to send tx hash %q to user %q: %w", receipt.TxHash, target.userID, err)
+	}
+	return nil
+}
+
+// cleanupStaleTransactions identifies any transactions that have been pending for too long see receiptNotifier.staleDuration)
+// and deletes them.
+func (r *receiptNotifier) cleanupStaleTransactions() {
+	for txHash, info := range r.txHashToTargetInfo {
+		if time.Since(info.createdAt) > r.staleDuration {
+			delete(r.txHashToTargetInfo, txHash)
+		}
+	}
+}


### PR DESCRIPTION
Closes: #WORLD-379

## What is the purpose of the change

Add a feature that will send the results of transactions to users via the Nakama notifications system.

Notifications are not saved, so they will only be delivered if the relevant client is actively connected and waiting for notifications. See [this PR](https://github.com/Argus-Labs/starter-game-template/pull/14) for the starter-game-template for some sample code of how to connect and view the notifications.

Note: The old and busted mechanism for sending tx results via match data has been left in place. Both can work side by side. Eventually the match data path will be removed.

## Testing and Verifying

Manual testing can be done by syncing to the above mentioned starter-game-templte branch, and using the `mage nakamaAt` target to run this world-engine/relay version of nakama.

Once Cardinal and Nakama are running, run the jsclient in the starget-game-template code base with:

```
node main.mjs
```
Once running, visit the Nakama UI console at localhost:7351 and go to the API Explorer.

issue a `nakama/claim-persona` transaction using the session user_id that was printed to the console.

The payload should be something like:

````
{"persona_tag": "my-awesome-name"}
```

After hitting `Send Request` you should automatically see the transaction receipt printed to the screen via the js client. It should look something like:

```
Notification content {                                                                                         
  errors: [ [length]: 0 ],                                                                                     
  result: { Success: true },                                                                                                                                                                                                  
  tx_hash: '0x65adf6b10e91edcac391155b39505df02ede221ff07f0db9ec923067d25611fc'
}
```

\
