### PR TITLE
refactor(cardinal): move abi.go and abi_test.go out of ecs and into an abi package. 

### DIFF
--- a/cardinal/ecs/abi/abi.go
+++ b/cardinal/ecs/abi/abi.go
@@ -1,13 +1,14 @@
-package ecs
+package abi
 
 import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/ethereum/go-ethereum/accounts/abi"
 	"reflect"
 	"regexp"
 	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi"
 )
 
 const (

--- a/cardinal/ecs/abi/abi_test.go
+++ b/cardinal/ecs/abi/abi_test.go
@@ -1,11 +1,13 @@
-package ecs
+package abi_test
 
 import (
-	"github.com/ethereum/go-ethereum/accounts/abi"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"testing"
+
+	ethereumAbi "github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs/abi"
 )
 
 // TestNoTagPanics tests that it panics when a struct field is of type *big.Int and does not have a `solidity` struct
@@ -14,14 +16,14 @@ func TestNoTagPanics(t *testing.T) {
 	type FooReadBroken struct {
 		Large *big.Int
 	}
-	_, err := GenerateABIType(FooReadBroken{})
+	_, err := abi.GenerateABIType(FooReadBroken{})
 	assert.Error(t, err)
 
 	type FooReadBrokenSlice struct {
 		SliceBig []*big.Int
 	}
 
-	_, err = GenerateABIType(FooReadBrokenSlice{})
+	_, err = abi.GenerateABIType(FooReadBrokenSlice{})
 	assert.Error(t, err)
 }
 
@@ -60,9 +62,9 @@ func TestGenerateABIType_AllValidTypes(t *testing.T) {
 
 		SliceOfSomeOtherStruct []SomeOtherType
 	}
-	at, err := GenerateABIType(BigType{})
+	at, err := abi.GenerateABIType(BigType{})
 	assert.Nil(t, err)
-	args := abi.Arguments{{Type: *at}}
+	args := ethereumAbi.Arguments{{Type: *at}}
 
 	b := BigType{
 		Uint8:        30,
@@ -103,7 +105,7 @@ func TestGenerateABIType_AllValidTypes(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, unpacked, 1)
 
-	got, err := SerdeInto[BigType](unpacked[0])
+	got, err := abi.SerdeInto[BigType](unpacked[0])
 	assert.Nil(t, err)
 	assert.Equal(t, got, b)
 }
@@ -112,7 +114,7 @@ func TestGenerateABIType_PanicOnImportedTypes(t *testing.T) {
 	type InvalidType struct {
 		X common.Decimal
 	}
-	_, err := GenerateABIType(InvalidType{})
+	_, err := abi.GenerateABIType(InvalidType{})
 	assert.Error(t, err)
 }
 
@@ -125,10 +127,10 @@ func TestGenerateABIType_NoSizeOnInt(t *testing.T) {
 		Int int
 	}
 
-	_, err := GenerateABIType(InvalidUint{})
+	_, err := abi.GenerateABIType(InvalidUint{})
 	assert.Error(t, err)
 
-	_, err = GenerateABIType(InvalidInt{})
+	_, err = abi.GenerateABIType(InvalidInt{})
 	assert.Error(t, err)
 }
 
@@ -142,9 +144,9 @@ func TestGenerateABIType_StructInStruct(t *testing.T) {
 		B Bar
 	}
 	foo := Foo{32, Bar{42}}
-	a, err := GenerateABIType(foo)
+	a, err := abi.GenerateABIType(foo)
 	assert.Nil(t, err)
-	args := abi.Arguments{{Type: *a}}
+	args := ethereumAbi.Arguments{{Type: *a}}
 	bz, err := args.Pack(foo)
 	assert.Nil(t, err)
 
@@ -152,7 +154,7 @@ func TestGenerateABIType_StructInStruct(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, unpacked, 1)
 
-	got, err := SerdeInto[Foo](unpacked[0])
+	got, err := abi.SerdeInto[Foo](unpacked[0])
 	assert.Nil(t, err)
 
 	assert.Equal(t, got, foo)
@@ -168,9 +170,9 @@ func TestGenerateABIType_SliceOfStructInStruct(t *testing.T) {
 		B []Bar
 	}
 	foo := Foo{32, []Bar{{899789}}}
-	a, err := GenerateABIType(foo)
+	a, err := abi.GenerateABIType(foo)
 	assert.Nil(t, err)
-	args := abi.Arguments{{Type: *a}}
+	args := ethereumAbi.Arguments{{Type: *a}}
 	bz, err := args.Pack(foo)
 	assert.Nil(t, err)
 
@@ -178,7 +180,7 @@ func TestGenerateABIType_SliceOfStructInStruct(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, unpacked, 1)
 
-	underlyingFoo, err := SerdeInto[Foo](unpacked[0])
+	underlyingFoo, err := abi.SerdeInto[Foo](unpacked[0])
 	assert.Nil(t, err)
 
 	assert.Equal(t, underlyingFoo, foo)

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -5,7 +5,8 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/ethereum/go-ethereum/accounts/abi"
+	ethereumAbi "github.com/ethereum/go-ethereum/accounts/abi"
+	"pkg.world.dev/world-engine/cardinal/ecs/abi"
 	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 	"pkg.world.dev/world-engine/sign"
@@ -23,21 +24,21 @@ type TransactionType[In, Out any] struct {
 	id         transaction.TypeID
 	isIDSet    bool
 	name       string
-	inEVMType  *abi.Type
-	outEVMType *abi.Type
+	inEVMType  *ethereumAbi.Type
+	outEVMType *ethereumAbi.Type
 }
 
 func WithTxEVMSupport[In, Out any]() func(transactionType *TransactionType[In, Out]) {
 	return func(txt *TransactionType[In, Out]) {
 		var in In
-		abiType, err := GenerateABIType(in)
+		abiType, err := abi.GenerateABIType(in)
 		if err != nil {
 			panic(err)
 		}
 		txt.inEVMType = abiType
 
 		var out Out
-		abiType, err = GenerateABIType(out)
+		abiType, err = abi.GenerateABIType(out)
 		if err != nil {
 			panic(err)
 		}
@@ -187,15 +188,15 @@ func (t *TransactionType[In, Out]) ABIEncode(v any) ([]byte, error) {
 		return nil, ErrEVMTypeNotSet
 	}
 
-	var args abi.Arguments
+	var args ethereumAbi.Arguments
 	var input any
 	switch v.(type) {
 	case In:
 		input = v.(In)
-		args = abi.Arguments{{Type: *t.inEVMType}}
+		args = ethereumAbi.Arguments{{Type: *t.inEVMType}}
 	case Out:
 		input = v.(Out)
-		args = abi.Arguments{{Type: *t.outEVMType}}
+		args = ethereumAbi.Arguments{{Type: *t.outEVMType}}
 	default:
 		return nil, fmt.Errorf("expected input to be of type %T or %T, got %T", new(In), new(Out), v)
 	}
@@ -208,7 +209,7 @@ func (t *TransactionType[In, Out]) DecodeEVMBytes(bz []byte) (any, error) {
 	if t.inEVMType == nil {
 		return nil, ErrEVMTypeNotSet
 	}
-	args := abi.Arguments{{Type: *t.inEVMType}}
+	args := ethereumAbi.Arguments{{Type: *t.inEVMType}}
 	unpacked, err := args.Unpack(bz)
 	if err != nil {
 		return nil, err
@@ -216,7 +217,7 @@ func (t *TransactionType[In, Out]) DecodeEVMBytes(bz []byte) (any, error) {
 	if len(unpacked) < 1 {
 		return nil, fmt.Errorf("error decoding EVM bytes: no values could be unpacked into the abi type")
 	}
-	input, err := SerdeInto[In](unpacked[0])
+	input, err := abi.SerdeInto[In](unpacked[0])
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes: #422

## What is the purpose of the change

Move abi.go into it's own  package.
 
## Brief Changelog

abi.go and abi_test.go moved.

## tests

all original tests work. 