### PR TITLE
feat(cardinal): event queueing and events package. 

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -8,35 +8,15 @@ import (
 
 	"pkg.world.dev/world-engine/cardinal"
 	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
 )
-
-// TODO this function needs to be moved to a utils package above cardinal to prevent circulars.
-func setTestTimeout(t *testing.T, timeout time.Duration) {
-	if _, ok := t.Deadline(); ok {
-		// A deadline has already been set. Don't add an additional deadline.
-		return
-	}
-	success := make(chan bool)
-	t.Cleanup(func() {
-		success <- true
-	})
-	go func() {
-		select {
-		case <-success:
-			// test was successful. Do nothing
-		case <-time.After(timeout):
-			//assert.Check(t, false, "test timed out")
-			panic("test timed out")
-		}
-	}()
-}
 
 type Foo struct{}
 
 func (Foo) Name() string { return "foo" }
 
 func TestCanQueryInsideSystem(t *testing.T) {
-	setTestTimeout(t, 10*time.Second)
+	test_utils.SetTestTimeout(t, 10*time.Second)
 
 	nextTickCh := make(chan time.Time)
 	tickDoneCh := make(chan uint64)

--- a/cardinal/events/events.go
+++ b/cardinal/events/events.go
@@ -36,7 +36,7 @@ type EventHub struct {
 	eventQueue           []*Event
 }
 
-func (eh *EventHub) BroadcastEvent(event *Event) {
+func (eh *EventHub) EmitEvent(event *Event) {
 	eh.Broadcast <- event
 }
 

--- a/cardinal/events/events.go
+++ b/cardinal/events/events.go
@@ -1,4 +1,4 @@
-package server
+package events
 
 import (
 	"net/http"
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/go-openapi/runtime/middleware"
-
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog/log"
 )

--- a/cardinal/events/events_test.go
+++ b/cardinal/events/events_test.go
@@ -56,5 +56,6 @@ func TestEvents(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	txh.EventHub.shutdown <- true
+	err := txh.Shutdown()
+	assert.NilError(t, err)
 }

--- a/cardinal/events/events_test.go
+++ b/cardinal/events/events_test.go
@@ -34,7 +34,7 @@ func TestEvents(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			//txh.eventHub.Broadcast <- []byte(fmt.Sprintf("test%d", i))
-			txh.EventHub.BroadcastEvent(&events.Event{Message: fmt.Sprintf("test%d", i)})
+			txh.EventHub.EmitEvent(&events.Event{Message: fmt.Sprintf("test%d", i)})
 		}()
 	}
 	wg.Wait()

--- a/cardinal/events/events_test.go
+++ b/cardinal/events/events_test.go
@@ -1,0 +1,60 @@
+package events_test
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+
+	"gotest.tools/v3/assert"
+
+	"github.com/gorilla/websocket"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/events"
+	"pkg.world.dev/world-engine/cardinal/server"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+func TestEvents(t *testing.T) {
+	//broadcast 5 messages to 5 clients means 25 messages received.
+	numberToTest := 5
+	w := ecs.NewTestWorld(t)
+	assert.NilError(t, w.LoadGameState())
+	txh := test_utils.MakeTestTransactionHandler(t, w, server.DisableSignatureVerification())
+	url := txh.MakeWebSocketURL("events")
+	dialers := make([]*websocket.Conn, numberToTest, numberToTest)
+	for i, _ := range dialers {
+		dial, _, err := websocket.DefaultDialer.Dial(url, nil)
+		assert.NilError(t, err)
+		dialers[i] = dial
+	}
+	var wg sync.WaitGroup
+	for i := 0; i < numberToTest; i++ {
+		i := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			//txh.eventHub.Broadcast <- []byte(fmt.Sprintf("test%d", i))
+			txh.EventHub.BroadcastEvent(&events.Event{Message: fmt.Sprintf("test%d", i)})
+		}()
+	}
+	wg.Wait()
+	go func() {
+		txh.EventHub.FlushEvents()
+	}()
+	for _, dialer := range dialers {
+		wg.Add(1)
+		dialer := dialer
+		go func() {
+			defer wg.Done()
+			for j := 0; j < numberToTest; j++ {
+				mode, message, err := dialer.ReadMessage()
+				assert.NilError(t, err)
+				assert.Equal(t, mode, websocket.TextMessage)
+				assert.Equal(t, string(message)[:4], "test")
+				//fmt.Println(string(message))
+			}
+		}()
+	}
+	wg.Wait()
+	txh.EventHub.Shutdown <- true
+}

--- a/cardinal/events/events_test.go
+++ b/cardinal/events/events_test.go
@@ -33,7 +33,7 @@ func TestEvents(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			//txh.eventHub.Broadcast <- []byte(fmt.Sprintf("test%d", i))
+			//txh.eventHub.broadcast <- []byte(fmt.Sprintf("test%d", i))
 			txh.EventHub.EmitEvent(&events.Event{Message: fmt.Sprintf("test%d", i)})
 		}()
 	}
@@ -56,5 +56,5 @@ func TestEvents(t *testing.T) {
 		}()
 	}
 	wg.Wait()
-	txh.EventHub.Shutdown <- true
+	txh.EventHub.shutdown <- true
 }

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -12,13 +12,13 @@ import (
 	"os/exec"
 	"reflect"
 	"strconv"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/gorilla/websocket"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/shard"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
 	"pkg.world.dev/world-engine/chain/x/shard/types"
 
 	"gotest.tools/v3/assert"
@@ -40,111 +40,11 @@ type SendEnergyTx struct {
 
 type SendEnergyTxResult struct{}
 
-// testTransactionHandler is a helper struct that can start an HTTP server on port 4040 with the given world.
-type testTransactionHandler struct {
-	*server.Handler
-	t        *testing.T
-	host     string
-	eventHub *server.EventHub
-}
-
-func (t *testTransactionHandler) makeHttpURL(path string) string {
-	return "http://" + t.host + "/" + path
-}
-
-func (t *testTransactionHandler) makeWebSocketURL(path string) string {
-	return "ws://" + t.host + "/" + path
-}
-
-func (t *testTransactionHandler) post(path string, payload any) *http.Response {
-	bz, err := json.Marshal(payload)
-	assert.NilError(t.t, err)
-
-	res, err := http.Post(t.makeHttpURL(path), "application/json", bytes.NewReader(bz))
-	assert.NilError(t.t, err)
-	return res
-}
-
-func makeTestTransactionHandler(t *testing.T, world *ecs.World, opts ...server.Option) *testTransactionHandler {
-	port := "4040"
-	opts = append(opts, server.WithPort(port))
-	eventHub := server.CreateEventHub()
-	go func() {
-		eventHub.Run()
-	}()
-	eventBuilder := server.CreateNewWebSocketBuilder("/events", server.CreateWebSocketEventHandler(eventHub))
-	txh, err := server.NewHandler(world, eventBuilder, opts...)
-	assert.NilError(t, err)
-
-	//add test websocket handler.
-	txh.Mux.HandleFunc("/echo", server.Echo)
-
-	healthPath := "/health"
-	t.Cleanup(func() {
-		assert.NilError(t, txh.Close())
-	})
-
-	go func() {
-		err = txh.Serve()
-		// ErrServerClosed is returned from txh.Serve after txh.Close is called. This is
-		// normal.
-		if err != http.ErrServerClosed {
-			assert.NilError(t, err)
-		}
-	}()
-	gameObject := server.NewGameManager(world, txh)
-	t.Cleanup(func() {
-		_ = gameObject.Shutdown()
-	})
-
-	host := "localhost:" + port
-	healthURL := host + healthPath
-	start := time.Now()
-	for {
-		assert.Check(t, time.Since(start) < time.Second, "timeout while waiting for a healthy server")
-
-		resp, err := http.Get("http://" + healthURL)
-		if err == nil && resp.StatusCode == 200 {
-			// the health check endpoint was successfully queried.
-			break
-		}
-	}
-
-	return &testTransactionHandler{
-		Handler:  txh,
-		t:        t,
-		host:     host,
-		eventHub: eventHub,
-	}
-}
-
-// TODO this function is duplicated in cardinal_test.go. Please eventually move both of these functions
-// into a utils package that lives outside of cardinal.
-func setTestTimeout(t *testing.T, timeout time.Duration) {
-	if _, ok := t.Deadline(); ok {
-		// A deadline has already been set. Don't add an additional deadline.
-		return
-	}
-	success := make(chan bool)
-	t.Cleanup(func() {
-		success <- true
-	})
-	go func() {
-		select {
-		case <-success:
-			// test was successful. Do nothing
-		case <-time.After(timeout):
-			//assert.Check(t, false, "test timed out")
-			panic("test timed out")
-		}
-	}()
-}
-
 func TestHealthEndpoint(t *testing.T) {
-	setTestTimeout(t, 10*time.Second)
+	test_utils.SetTestTimeout(t, 10*time.Second)
 	w := ecs.NewTestWorld(t)
 	assert.NilError(t, w.LoadGameState())
-	makeTestTransactionHandler(t, w, server.DisableSignatureVerification())
+	test_utils.MakeTestTransactionHandler(t, w, server.DisableSignatureVerification())
 	resp, err := http.Get("http://localhost:4040/health")
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
@@ -168,10 +68,10 @@ func TestHealthEndpoint(t *testing.T) {
 }
 
 func TestShutDownViaMethod(t *testing.T) {
-	setTestTimeout(t, 10*time.Second) // If this test is frozen then it failed to shut down, create failure with panic.
+	test_utils.SetTestTimeout(t, 10*time.Second) // If this test is frozen then it failed to shut down, create failure with panic.
 	w := ecs.NewTestWorld(t)
 	assert.NilError(t, w.LoadGameState())
-	txh := makeTestTransactionHandler(t, w, server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, w, server.DisableSignatureVerification())
 	resp, err := http.Get("http://localhost:4040/health")
 	assert.Equal(t, resp.StatusCode, 200)
 	ctx := context.Background()
@@ -189,7 +89,7 @@ func TestShutDownViaMethod(t *testing.T) {
 }
 
 func TestShutDownViaSignal(t *testing.T) {
-	setTestTimeout(t, 10*time.Second) // If this test is frozen then it failed to shut down, create a failure with panic.
+	test_utils.SetTestTimeout(t, 10*time.Second) // If this test is frozen then it failed to shut down, create a failure with panic.
 	w := ecs.NewTestWorld(t)
 	sendTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult]("sendTx")
 	assert.NilError(t, w.RegisterTransactions(sendTx))
@@ -197,7 +97,7 @@ func TestShutDownViaSignal(t *testing.T) {
 		return nil
 	})
 	assert.NilError(t, w.LoadGameState())
-	txh := makeTestTransactionHandler(t, w, server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, w, server.DisableSignatureVerification())
 	resp, err := http.Get("http://localhost:4040/health")
 	assert.Equal(t, resp.StatusCode, 200)
 	ctx := context.Background()
@@ -253,9 +153,9 @@ func TestCanListTransactionEndpoints(t *testing.T) {
 	betaTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult]("beta")
 	gammaTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult]("gamma")
 	assert.NilError(t, w.RegisterTransactions(alphaTx, betaTx, gammaTx))
-	txh := makeTestTransactionHandler(t, w, server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, w, server.DisableSignatureVerification())
 
-	resp, err := http.Post(txh.makeHttpURL("query/http/endpoints"), "application/json", nil)
+	resp, err := http.Post(txh.MakeHttpURL("query/http/endpoints"), "application/json", nil)
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 	var gotEndpoints map[string][]string
@@ -321,9 +221,9 @@ func TestHandleTransactionWithNoSignatureVerification(t *testing.T) {
 	bogusSignatureBz, err := json.Marshal(payload)
 	assert.NilError(t, err)
 
-	txh := makeTestTransactionHandler(t, w, server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, w, server.DisableSignatureVerification())
 
-	resp, err := http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bogusSignatureBz))
+	resp, err := http.Post(txh.MakeHttpURL(url), "application/json", bytes.NewReader(bogusSignatureBz))
 	assert.NilError(t, err)
 	assert.Equal(t, 200, resp.StatusCode, "request failed with body: %v", mustReadBody(t, resp))
 
@@ -394,7 +294,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 	})
 	assert.NilError(t, w.RegisterQueries(fooQuery))
 
-	txh := makeTestTransactionHandler(t, w, server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, w, server.DisableSignatureVerification())
 
 	tx := SendEnergyTx{
 		From:   "me",
@@ -420,7 +320,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 		TxEndpoints:    []string{"/tx/persona/create-persona", "/tx/persona/authorize-persona-address", "/tx/game/send-energy"},
 		QueryEndpoints: []string{"/query/game/foo", "/query/http/endpoints", "/query/persona/signer", "/query/receipt/list", "/query/game/cql"},
 	}
-	resp1, err := http.Post(txh.makeHttpURL("query/http/endpoints"), "application/json", nil)
+	resp1, err := http.Post(txh.MakeHttpURL("query/http/endpoints"), "application/json", nil)
 	assert.NilError(t, err)
 	defer resp1.Body.Close()
 	var endpointResult server.EndpointsResult
@@ -437,7 +337,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 	}
 	queryPersonaRequestData, err := json.Marshal(queryPersonaRequest)
 	assert.NilError(t, err)
-	req, err := http.NewRequest("POST", txh.makeHttpURL("query/persona/signer"), bytes.NewBuffer(queryPersonaRequestData))
+	req, err := http.NewRequest("POST", txh.MakeHttpURL("query/persona/signer"), bytes.NewBuffer(queryPersonaRequestData))
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Content-Length", strconv.Itoa(len(queryPersonaRequestData)))
 	req.Header.Set("Accept", "application/json")
@@ -460,7 +360,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 	if err != nil {
 		assert.NilError(t, err)
 	}
-	resp3, err := http.Post(txh.makeHttpURL("query/game/foo"), "application/json", bytes.NewBuffer(fooData))
+	resp3, err := http.Post(txh.MakeHttpURL("query/game/foo"), "application/json", bytes.NewBuffer(fooData))
 	if err != nil {
 		assert.NilError(t, err)
 	}
@@ -492,16 +392,16 @@ func TestHandleSwaggerServer(t *testing.T) {
 		Tick:   1,
 	}
 	gotTxReply := server.TransactionReply{}
-	resp4, err := http.Post(txh.makeHttpURL("tx/persona/authorize-persona-address"), "application/json", bytes.NewBuffer(signedTxJson))
+	resp4, err := http.Post(txh.MakeHttpURL("tx/persona/authorize-persona-address"), "application/json", bytes.NewBuffer(signedTxJson))
 	assert.NilError(t, err)
 	err = json.NewDecoder(resp4.Body).Decode(&gotTxReply)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, gotTxReply, expectedTxReply)
 
-	resp5, err := http.Post(txh.makeHttpURL("tx/game/dsakjsdlfksdj"), "application/json", bytes.NewBuffer(signedTxJson))
+	resp5, err := http.Post(txh.MakeHttpURL("tx/game/dsakjsdlfksdj"), "application/json", bytes.NewBuffer(signedTxJson))
 	assert.NilError(t, err)
 	assert.Equal(t, resp5.StatusCode, 404)
-	resp6, err := http.Post(txh.makeHttpURL("query/game/sdsdfsdfsdf"), "application/json", bytes.NewBuffer(signedTxJson))
+	resp6, err := http.Post(txh.MakeHttpURL("query/game/sdsdfsdfsdf"), "application/json", bytes.NewBuffer(signedTxJson))
 	assert.NilError(t, err)
 	assert.Equal(t, resp6.StatusCode, 404)
 
@@ -522,7 +422,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 		jsonQuery := struct{ CQL string }{v.cql}
 		jsonQueryBytes, err := json.Marshal(jsonQuery)
 		assert.NilError(t, err)
-		resp7, err := http.Post(txh.makeHttpURL("query/game/cql"), "application/json", bytes.NewBuffer(jsonQueryBytes))
+		resp7, err := http.Post(txh.MakeHttpURL("query/game/cql"), "application/json", bytes.NewBuffer(jsonQueryBytes))
 		assert.NilError(t, err)
 		assert.Equal(t, resp7.StatusCode, v.expectedStatus)
 		var entities []cql.QueryResponse
@@ -533,7 +433,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 	jsonQuery := struct{ CQL string }{"blah"}
 	jsonQueryBytes, err := json.Marshal(jsonQuery)
 	assert.NilError(t, err)
-	resp8, err := http.Post(txh.makeHttpURL("query/game/cql"), "application/json", bytes.NewBuffer(jsonQueryBytes))
+	resp8, err := http.Post(txh.MakeHttpURL("query/game/cql"), "application/json", bytes.NewBuffer(jsonQueryBytes))
 	assert.NilError(t, err)
 	assert.Equal(t, resp8.StatusCode, 422)
 }
@@ -555,7 +455,7 @@ func TestHandleWrappedTransactionWithNoSignatureVerification(t *testing.T) {
 		count++
 		return nil
 	})
-	txh := makeTestTransactionHandler(t, w, server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, w, server.DisableSignatureVerification())
 	tx := SendEnergyTx{
 		From:   "me",
 		To:     "you",
@@ -574,7 +474,7 @@ func TestHandleWrappedTransactionWithNoSignatureVerification(t *testing.T) {
 
 	bz, err = json.Marshal(&signedTx)
 	assert.NilError(t, err)
-	_, err = http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
+	_, err = http.Post(txh.MakeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 
 	assert.NilError(t, w.LoadGameState())
@@ -592,7 +492,7 @@ func TestCanCreateAndVerifyPersonaSigner(t *testing.T) {
 	assert.NilError(t, world.RegisterTransactions(tx))
 	assert.NilError(t, world.LoadGameState())
 	assert.NilError(t, world.Tick(context.Background()))
-	txh := makeTestTransactionHandler(t, world)
+	txh := test_utils.MakeTestTransactionHandler(t, world)
 
 	personaTag := "CoolMage"
 	privateKey, err := crypto.GenerateKey()
@@ -610,7 +510,7 @@ func TestCanCreateAndVerifyPersonaSigner(t *testing.T) {
 	bz, err := signedPayload.Marshal()
 	assert.NilError(t, err)
 
-	resp, err := http.Post(txh.makeHttpURL(urlSet[0]), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.MakeHttpURL(urlSet[0]), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	body := mustReadBody(t, resp)
 	assert.Equal(t, 200, resp.StatusCode, "request failed with body: %s", body)
@@ -627,7 +527,7 @@ func TestCanCreateAndVerifyPersonaSigner(t *testing.T) {
 			Tick:       tick,
 		})
 		assert.NilError(t, err)
-		resp, err = http.Post(txh.makeHttpURL(urlSet[1]), "application/json", bytes.NewReader(bz))
+		resp, err = http.Post(txh.MakeHttpURL(urlSet[1]), "application/json", bytes.NewReader(bz))
 		assert.NilError(t, err)
 		assert.Equal(t, resp.StatusCode, 200)
 		var queryPersonaSignerResponse server.QueryPersonaSignerResponse
@@ -661,7 +561,7 @@ func TestSigVerificationChecksNamespace(t *testing.T) {
 	privateKey, err := crypto.GenerateKey()
 	assert.NilError(t, err)
 
-	txh := makeTestTransactionHandler(t, world)
+	txh := test_utils.MakeTestTransactionHandler(t, world)
 
 	personaTag := "some_dude"
 	signerAddr := crypto.PubkeyToAddress(privateKey.PublicKey).Hex()
@@ -675,7 +575,7 @@ func TestSigVerificationChecksNamespace(t *testing.T) {
 
 	bz, err := sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err := http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.MakeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	// This should fail because the namespace does not match the world's namespace
 	assert.Equal(t, resp.StatusCode, 401)
@@ -685,7 +585,7 @@ func TestSigVerificationChecksNamespace(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err = http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.MakeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.Equal(t, resp.StatusCode, 200)
 	txh.Close()
 }
@@ -697,7 +597,7 @@ func TestSigVerificationChecksNonce(t *testing.T) {
 	privateKey, err := crypto.GenerateKey()
 	assert.NilError(t, err)
 
-	txh := makeTestTransactionHandler(t, world)
+	txh := test_utils.MakeTestTransactionHandler(t, world)
 
 	personaTag := "some_dude"
 	signerAddr := crypto.PubkeyToAddress(privateKey.PublicKey).Hex()
@@ -713,12 +613,12 @@ func TestSigVerificationChecksNonce(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Register a persona. This should succeed
-	resp, err := http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.MakeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 
 	// Repeat the request. Since the nonce is the same, this should fail
-	resp, err = http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.MakeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 401)
 
@@ -727,7 +627,7 @@ func TestSigVerificationChecksNonce(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err = http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.MakeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 401)
 
@@ -736,7 +636,7 @@ func TestSigVerificationChecksNonce(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err = http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.MakeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 	err = txh.Close()
@@ -769,9 +669,9 @@ func TestCanListQueries(t *testing.T) {
 	assert.NilError(t, world.RegisterQueries(fooQuery, barQuery, bazQuery))
 	assert.NilError(t, world.LoadGameState())
 
-	txh := makeTestTransactionHandler(t, world, server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, world, server.DisableSignatureVerification())
 
-	resp, err := http.Post(txh.makeHttpURL("query/http/endpoints"), "application/json", nil)
+	resp, err := http.Post(txh.MakeHttpURL("query/http/endpoints"), "application/json", nil)
 	assert.NilError(t, err)
 	assert.Equal(t, resp.StatusCode, 200)
 	var gotEndpoints map[string][]string
@@ -817,14 +717,14 @@ func TestQueryEncodeDecode(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	// make our test tx handler
-	txh := makeTestTransactionHandler(t, world, server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, world, server.DisableSignatureVerification())
 
 	// now we set up a request, and marshal it to json to send to the handler
 	req := FooRequest{Foo: 12, Meow: "hello"}
 	bz, err := json.Marshal(req)
 	assert.NilError(t, err)
 
-	res, err := http.Post(txh.makeHttpURL(url), "application/json", bytes.NewReader(bz))
+	res, err := http.Post(txh.MakeHttpURL(url), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 
 	buf, err := io.ReadAll(res.Body)
@@ -843,8 +743,8 @@ func TestMalformedRequestToGetTransactionReceiptsProducesError(t *testing.T) {
 	url := "query/receipts/list"
 	world := ecs.NewTestWorld(t)
 	assert.NilError(t, world.LoadGameState())
-	txh := makeTestTransactionHandler(t, world, server.DisableSignatureVerification())
-	res := txh.post(url, map[string]any{
+	txh := test_utils.MakeTestTransactionHandler(t, world, server.DisableSignatureVerification())
+	res := txh.Post(url, map[string]any{
 		"missing_start_tick": 0,
 	})
 	assert.Check(t, 400 <= res.StatusCode && res.StatusCode <= 499)
@@ -858,11 +758,11 @@ func TestTransactionReceiptReturnCorrectTickWindows(t *testing.T) {
 	historySize := uint64(10)
 	world := ecs.NewTestWorld(t, ecs.WithReceiptHistorySize(int(historySize)))
 	assert.NilError(t, world.LoadGameState())
-	txh := makeTestTransactionHandler(t, world, server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, world, server.DisableSignatureVerification())
 
 	// getReceipts is a helper that hits the txReceiptsEndpoint endpoint.
 	getReceipts := func(start uint64) server.ListTxReceiptsReply {
-		res := txh.post(url, server.ListTxReceiptsRequest{
+		res := txh.Post(url, server.ListTxReceiptsRequest{
 			StartTick: start,
 		})
 		assert.Equal(t, 200, res.StatusCode)
@@ -983,11 +883,11 @@ func TestCanGetTransactionReceiptsSwagger(t *testing.T) {
 	ctx := context.Background()
 	assert.NilError(t, world.Tick(ctx))
 
-	txh := makeTestTransactionHandler(t, world, server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, world, server.DisableSignatureVerification())
 
 	// We're going to be getting the list of receipts a lot, so make a helper to fetch the receipts
 	getReceipts := func(start uint64) server.ListTxReceiptsReply {
-		res := txh.post(receiptEndpoint, server.ListTxReceiptsRequest{
+		res := txh.Post(receiptEndpoint, server.ListTxReceiptsRequest{
 			StartTick: start,
 		})
 		assert.Equal(t, 200, res.StatusCode)
@@ -1076,7 +976,7 @@ func TestTransactionIDIsReturned(t *testing.T) {
 	assert.NilError(t, world.Tick(ctx))
 	privateKey, err := crypto.GenerateKey()
 	assert.NilError(t, err)
-	txh := makeTestTransactionHandler(t, world)
+	txh := test_utils.MakeTestTransactionHandler(t, world)
 
 	personaTag := "clifford_the_big_red_dog"
 	signerAddr := crypto.PubkeyToAddress(privateKey.PublicKey).Hex()
@@ -1093,7 +993,7 @@ func TestTransactionIDIsReturned(t *testing.T) {
 	bz, err := sigPayload.Marshal()
 	assert.NilError(t, err)
 
-	resp, err := http.Post(txh.makeHttpURL(urls[0]), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.MakeHttpURL(urls[0]), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 
@@ -1115,7 +1015,7 @@ func TestTransactionIDIsReturned(t *testing.T) {
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
 
-	resp, err = http.Post(txh.makeHttpURL(urls[1]), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.MakeHttpURL(urls[1]), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.NilError(t, json.NewDecoder(resp.Body).Decode(&txReply))
@@ -1155,7 +1055,7 @@ func TestTransactionsSubmittedToChain(t *testing.T) {
 	world.RegisterTransactions(moveTx)
 	assert.NilError(t, world.LoadGameState())
 	adapter := adapterMock{}
-	txh := makeTestTransactionHandler(t, world, server.WithAdapter(&adapter), server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, world, server.WithAdapter(&adapter), server.DisableSignatureVerification())
 
 	privateKey, err := crypto.GenerateKey()
 	assert.NilError(t, err)
@@ -1169,7 +1069,7 @@ func TestTransactionsSubmittedToChain(t *testing.T) {
 	bz, err := sigPayload.Marshal()
 	assert.NilError(t, err)
 
-	resp, err := http.Post(txh.makeHttpURL(createPersonaEndpoint), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.MakeHttpURL(createPersonaEndpoint), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, adapter.called, 1)
@@ -1178,7 +1078,7 @@ func TestTransactionsSubmittedToChain(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err = sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err = http.Post(txh.makeHttpURL(moveEndpoint), "application/json", bytes.NewReader(bz))
+	resp, err = http.Post(txh.MakeHttpURL(moveEndpoint), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, 200, resp.StatusCode)
 	assert.Equal(t, adapter.called, 2)
@@ -1197,7 +1097,7 @@ func TestTransactionNotSubmittedWhenRecovering(t *testing.T) {
 	moveTx := ecs.NewTransactionType[MoveTx, MoveTx]("move")
 	world.RegisterTransactions(moveTx)
 	assert.NilError(t, world.LoadGameState())
-	txh := makeTestTransactionHandler(t, world, server.WithAdapter(&adapter), server.DisableSignatureVerification())
+	txh := test_utils.MakeTestTransactionHandler(t, world, server.WithAdapter(&adapter), server.DisableSignatureVerification())
 
 	privateKey, err := crypto.GenerateKey()
 	assert.NilError(t, err)
@@ -1207,7 +1107,7 @@ func TestTransactionNotSubmittedWhenRecovering(t *testing.T) {
 	assert.NilError(t, err)
 	bz, err := sigPayload.Marshal()
 	assert.NilError(t, err)
-	resp, err := http.Post(txh.makeHttpURL(moveEndpoint), "application/json", bytes.NewReader(bz))
+	resp, err := http.Post(txh.MakeHttpURL(moveEndpoint), "application/json", bytes.NewReader(bz))
 	assert.NilError(t, err)
 	assert.Equal(t, 500, resp.StatusCode)
 	bz, err = io.ReadAll(resp.Body)
@@ -1218,8 +1118,8 @@ func TestTransactionNotSubmittedWhenRecovering(t *testing.T) {
 func TestWebSocket(t *testing.T) {
 	w := ecs.NewTestWorld(t)
 	assert.NilError(t, w.LoadGameState())
-	txh := makeTestTransactionHandler(t, w, server.DisableSignatureVerification())
-	url := txh.makeWebSocketURL("echo")
+	txh := test_utils.MakeTestTransactionHandler(t, w, server.DisableSignatureVerification())
+	url := txh.MakeWebSocketURL("echo")
 	dial, _, err := websocket.DefaultDialer.Dial(url, nil)
 	assert.NilError(t, err)
 	messageToSend := "test"
@@ -1231,49 +1131,4 @@ func TestWebSocket(t *testing.T) {
 	assert.Equal(t, string(message), messageToSend)
 	err = dial.Close()
 	assert.NilError(t, err)
-}
-
-func TestEvents(t *testing.T) {
-	//broadcast 5 messages to 5 clients means 25 messages received.
-	numberToTest := 5
-	w := ecs.NewTestWorld(t)
-	assert.NilError(t, w.LoadGameState())
-	txh := makeTestTransactionHandler(t, w, server.DisableSignatureVerification())
-	url := txh.makeWebSocketURL("events")
-	dialers := make([]*websocket.Conn, numberToTest, numberToTest)
-	for i, _ := range dialers {
-		dial, _, err := websocket.DefaultDialer.Dial(url, nil)
-		assert.NilError(t, err)
-		dialers[i] = dial
-	}
-	var wg sync.WaitGroup
-	for i := 0; i < numberToTest; i++ {
-		i := i
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
-			//txh.eventHub.Broadcast <- []byte(fmt.Sprintf("test%d", i))
-			txh.eventHub.BroadcastEvent(&server.Event{Message: fmt.Sprintf("test%d", i)})
-		}()
-	}
-	wg.Wait()
-	go func() {
-		txh.eventHub.FlushEvents()
-	}()
-	for _, dialer := range dialers {
-		wg.Add(1)
-		dialer := dialer
-		go func() {
-			defer wg.Done()
-			for j := 0; j < numberToTest; j++ {
-				mode, message, err := dialer.ReadMessage()
-				assert.NilError(t, err)
-				assert.Equal(t, mode, websocket.TextMessage)
-				assert.Equal(t, string(message)[:4], "test")
-				//fmt.Println(string(message))
-			}
-		}()
-	}
-	wg.Wait()
-	txh.eventHub.Shutdown <- true
 }

--- a/cardinal/test_utils/test_utils.go
+++ b/cardinal/test_utils/test_utils.go
@@ -1,0 +1,115 @@
+package test_utils
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"gotest.tools/v3/assert"
+
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/events"
+	"pkg.world.dev/world-engine/cardinal/server"
+)
+
+func MakeTestTransactionHandler(t *testing.T, world *ecs.World, opts ...server.Option) *TestTransactionHandler {
+	port := "4040"
+	opts = append(opts, server.WithPort(port))
+	eventHub := events.CreateEventHub()
+	go func() {
+		eventHub.Run()
+	}()
+	eventBuilder := events.CreateNewWebSocketBuilder("/events", events.CreateWebSocketEventHandler(eventHub))
+	txh, err := server.NewHandler(world, eventBuilder, opts...)
+	assert.NilError(t, err)
+
+	//add test websocket handler.
+	txh.Mux.HandleFunc("/echo", events.Echo)
+
+	healthPath := "/health"
+	t.Cleanup(func() {
+		assert.NilError(t, txh.Close())
+	})
+
+	go func() {
+		err = txh.Serve()
+		// ErrServerClosed is returned from txh.Serve after txh.Close is called. This is
+		// normal.
+		if err != http.ErrServerClosed {
+			assert.NilError(t, err)
+		}
+	}()
+	gameObject := server.NewGameManager(world, txh)
+	t.Cleanup(func() {
+		_ = gameObject.Shutdown()
+	})
+
+	host := "localhost:" + port
+	healthURL := host + healthPath
+	start := time.Now()
+	for {
+		assert.Check(t, time.Since(start) < time.Second, "timeout while waiting for a healthy server")
+
+		resp, err := http.Get("http://" + healthURL)
+		if err == nil && resp.StatusCode == 200 {
+			// the health check endpoint was successfully queried.
+			break
+		}
+	}
+
+	return &TestTransactionHandler{
+		Handler:  txh,
+		T:        t,
+		Host:     host,
+		EventHub: eventHub,
+	}
+}
+
+// TestTransactionHandler is a helper struct that can start an HTTP server on port 4040 with the given world.
+type TestTransactionHandler struct {
+	*server.Handler
+	T        *testing.T
+	Host     string
+	EventHub *events.EventHub
+}
+
+func (t *TestTransactionHandler) MakeHttpURL(path string) string {
+	return "http://" + t.Host + "/" + path
+}
+
+func (t *TestTransactionHandler) MakeWebSocketURL(path string) string {
+	return "ws://" + t.Host + "/" + path
+}
+
+func (t *TestTransactionHandler) Post(path string, payload any) *http.Response {
+	bz, err := json.Marshal(payload)
+	assert.NilError(t.T, err)
+
+	res, err := http.Post(t.MakeHttpURL(path), "application/json", bytes.NewReader(bz))
+	assert.NilError(t.T, err)
+	return res
+}
+
+// TODO this function is duplicated in cardinal_test.go. Please eventually move both of these functions
+// into a utils package that lives outside of cardinal.
+func SetTestTimeout(t *testing.T, timeout time.Duration) {
+	if _, ok := t.Deadline(); ok {
+		// A deadline has already been set. Don't add an additional deadline.
+		return
+	}
+	success := make(chan bool)
+	t.Cleanup(func() {
+		success <- true
+	})
+	go func() {
+		select {
+		case <-success:
+			// test was successful. Do nothing
+		case <-time.After(timeout):
+			//assert.Check(t, false, "test timed out")
+			panic("test timed out")
+		}
+	}()
+}

--- a/cardinal/test_utils/test_utils.go
+++ b/cardinal/test_utils/test_utils.go
@@ -92,8 +92,6 @@ func (t *TestTransactionHandler) Post(path string, payload any) *http.Response {
 	return res
 }
 
-// TODO this function is duplicated in cardinal_test.go. Please eventually move both of these functions
-// into a utils package that lives outside of cardinal.
 func SetTestTimeout(t *testing.T, timeout time.Duration) {
 	if _, ok := t.Deadline(); ok {
 		// A deadline has already been set. Don't add an additional deadline.


### PR DESCRIPTION
Closes: #425
## What is the purpose of the change

Added Event queueing to the hub with events getting broadcasted on calling the Flush method. 

Additionally moved Events.go from Server to an events package. 

Created a test_utils package on the side for shared functionality among tests. 


## Brief Changelog

See above.

events are processed vertically. Meaning one thread per connection operating on the entire event queue during the flush. Each event in the queue is processed serially per connection.  
 

## Testing

moved the events related tests from server_test to events package which necessitated the creation of the test_utils package. 

