### PR TITLE
feat(cardinal): Add WorldContext to group storage managers and transient data

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -48,13 +48,15 @@ func TestCanQueryInsideSystem(t *testing.T) {
 	assert.NilError(t, cardinal.RegisterComponent[Foo](world))
 
 	wantNumOfEntities := 10
-	_, err = cardinal.CreateMany(world, wantNumOfEntities, Foo{})
-	assert.NilError(t, err)
-	gotNumOfEntities := 0
-	cardinal.RegisterSystems(world, func(world *cardinal.World, queue *cardinal.TransactionQueue, logger *cardinal.Logger) error {
-		q, err := world.NewSearch(ecs.Exact(Foo{}))
+	world.Init(func(wCtx cardinal.WorldContext) {
+		_, err = cardinal.CreateMany(wCtx, wantNumOfEntities, Foo{})
 		assert.NilError(t, err)
-		q.Each(world, func(cardinal.EntityID) bool {
+	})
+	gotNumOfEntities := 0
+	cardinal.RegisterSystems(world, func(wCtx cardinal.WorldContext) error {
+		q, err := wCtx.NewSearch(ecs.Exact(Foo{}))
+		assert.NilError(t, err)
+		q.Each(wCtx, func(cardinal.EntityID) bool {
 			gotNumOfEntities++
 			return true
 		})

--- a/cardinal/ecs/chain_recover_test.go
+++ b/cardinal/ecs/chain_recover_test.go
@@ -11,8 +11,6 @@ import (
 	"google.golang.org/protobuf/proto"
 	"gotest.tools/v3/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/log"
-	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 	"pkg.world.dev/world-engine/cardinal/shard"
 	"pkg.world.dev/world-engine/chain/x/shard/types"
 	"pkg.world.dev/world-engine/sign"
@@ -98,9 +96,9 @@ func TestWorld_RecoverFromChain(t *testing.T) {
 	sysRuns := uint64(0)
 	timesSendEnergyRan := 0
 	// send energy system
-	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
+	w.AddSystem(func(wCtx ecs.WorldContext) error {
 		sysRuns++
-		txs := SendEnergyTx.In(queue)
+		txs := SendEnergyTx.In(wCtx)
 		if len(txs) > 0 {
 			timesSendEnergyRan++
 		}

--- a/cardinal/ecs/component.go
+++ b/cardinal/ecs/component.go
@@ -1,1 +1,0 @@
-package ecs

--- a/cardinal/ecs/component_metadata/component_metadata_test.go
+++ b/cardinal/ecs/component_metadata/component_metadata_test.go
@@ -120,10 +120,10 @@ func TestErrorWhenAccessingComponentNotOnEntity(t *testing.T) {
 	ecs.MustRegisterComponent[foundComp](world)
 	ecs.MustRegisterComponent[notFoundComp](world)
 
-	id, err := component.Create(world, foundComp{})
+	wCtx := ecs.NewWorldContext(world)
+	id, err := component.Create(wCtx, foundComp{})
 	assert.NilError(t, err)
-	_, err = component.GetComponent[notFoundComp](world, id)
-	//_, err = notFound.Get(world, id)
+	_, err = component.GetComponent[notFoundComp](wCtx, id)
 	assert.ErrorIs(t, err, storage.ErrorComponentNotOnEntity)
 }
 
@@ -140,19 +140,19 @@ func TestMultipleCallsToCreateSupported(t *testing.T) {
 	world := ecs.NewTestWorld(t)
 	assert.NilError(t, ecs.RegisterComponent[ValueComponent](world))
 
-	id, err := component.Create(world, ValueComponent{})
+	wCtx := ecs.NewWorldContext(world)
+	id, err := component.Create(wCtx, ValueComponent{})
 	assert.NilError(t, err)
 
-	assert.NilError(t, component.SetComponent[ValueComponent](world, id, &ValueComponent{99}))
+	assert.NilError(t, component.SetComponent[ValueComponent](wCtx, id, &ValueComponent{99}))
 
-	val, err := component.GetComponent[ValueComponent](world, id)
+	val, err := component.GetComponent[ValueComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 99, val.Val)
 
-	_, err = component.Create(world, ValueComponent{})
+	_, err = component.Create(wCtx, ValueComponent{})
 
-	val, err = component.GetComponent[ValueComponent](world, id)
-	//val, err = valComp.Get(world, id)
+	val, err = component.GetComponent[ValueComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 99, val.Val)
 }

--- a/cardinal/ecs/ecb/ecb_test.go
+++ b/cardinal/ecs/ecb/ecb_test.go
@@ -294,11 +294,12 @@ func TestStorageCanBeUsedInQueries(t *testing.T) {
 	assert.NilError(t, ecs.RegisterComponent[Power](world))
 	assert.NilError(t, world.LoadGameState())
 
-	justHealthIDs, err := component.CreateMany(world, 8, Health{})
+	wCtx := ecs.NewWorldContext(world)
+	justHealthIDs, err := component.CreateMany(wCtx, 8, Health{})
 	assert.NilError(t, err)
-	justPowerIDs, err := component.CreateMany(world, 9, Power{})
+	justPowerIDs, err := component.CreateMany(wCtx, 9, Power{})
 	assert.NilError(t, err)
-	healthAndPowerIDs, err := component.CreateMany(world, 10, Health{}, Power{})
+	healthAndPowerIDs, err := component.CreateMany(wCtx, 10, Health{}, Power{})
 	assert.NilError(t, err)
 
 	testCases := []struct {
@@ -331,7 +332,7 @@ func TestStorageCanBeUsedInQueries(t *testing.T) {
 		found := map[entity.ID]bool{}
 		q, err := world.NewSearch(tc.filter)
 		assert.NilError(t, err)
-		q.Each(world, func(id entity.ID) bool {
+		q.Each(wCtx, func(id entity.ID) bool {
 			found[id] = true
 			return true
 		})

--- a/cardinal/ecs/ecb/read_only_test.go
+++ b/cardinal/ecs/ecb/read_only_test.go
@@ -17,7 +17,7 @@ func TestReadOnly_CanGetComponent(t *testing.T) {
 	_, err = manager.GetComponentForEntity(fooComp, id)
 	assert.NilError(t, err)
 
-	roStore := manager.NewReadOnlyStore()
+	roStore := manager.ToReadOnly()
 
 	// A read-only operation here should NOT find the entity (because it hasn't been commited yet)
 	_, err = roStore.GetComponentForEntity(fooComp, id)
@@ -55,7 +55,7 @@ func TestReadOnly_CanGetComponentTypesForEntityAndArchID(t *testing.T) {
 		assert.NilError(t, err)
 		assert.NilError(t, manager.CommitPending())
 
-		roStore := manager.NewReadOnlyStore()
+		roStore := manager.ToReadOnly()
 
 		gotComps, err := roStore.GetComponentTypesForEntity(id)
 		assert.NilError(t, err)
@@ -99,7 +99,7 @@ func TestReadOnly_GetEntitiesForArchID(t *testing.T) {
 		},
 	}
 
-	roManager := manager.NewReadOnlyStore()
+	roManager := manager.ToReadOnly()
 	for _, tc := range testCases {
 		ids, err := manager.CreateManyEntities(tc.idsToCreate, tc.comps...)
 		assert.NilError(t, err)
@@ -123,7 +123,7 @@ func TestReadOnly_CanFindEntityIDAfterChangingArchetypes(t *testing.T) {
 	fooArchID, err := manager.GetArchIDForComponents([]component_metadata.IComponentMetaData{fooComp})
 	assert.NilError(t, err)
 
-	roManager := manager.NewReadOnlyStore()
+	roManager := manager.ToReadOnly()
 
 	gotIDs, err := roManager.GetEntitiesForArchID(fooArchID)
 	assert.NilError(t, err)
@@ -149,7 +149,7 @@ func TestReadOnly_CanFindEntityIDAfterChangingArchetypes(t *testing.T) {
 
 func TestReadOnly_ArchetypeCount(t *testing.T) {
 	manager := newCmdBufferForTest(t)
-	roManager := manager.NewReadOnlyStore()
+	roManager := manager.ToReadOnly()
 
 	// No archetypes have been created yet
 	assert.Equal(t, 0, roManager.ArchetypeCount())

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -7,9 +7,6 @@ import (
 
 	"pkg.world.dev/world-engine/cardinal/ecs/component_metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/entity"
-	"pkg.world.dev/world-engine/cardinal/ecs/filter"
-	"pkg.world.dev/world-engine/cardinal/ecs/log"
-	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
 // CreatePersonaTransaction allows for the associating of a persona tag with a signer address.
@@ -44,12 +41,12 @@ var AuthorizePersonaAddressTx = NewTransactionType[AuthorizePersonaAddress, Auth
 // AuthorizePersonaAddressSystem enables users to authorize an address to a persona tag. This is mostly used so that
 // users who want to interact with the game via smart contract can link their EVM address to their persona tag, enabling
 // them to mutate their owned state from the context of the EVM.
-func AuthorizePersonaAddressSystem(world *World, queue *transaction.TxQueue, _ *log.Logger) error {
-	personaTagToAddress, err := buildPersonaTagMapping(world)
+func AuthorizePersonaAddressSystem(wCtx WorldContext) error {
+	personaTagToAddress, err := buildPersonaTagMapping(wCtx)
 	if err != nil {
 		return err
 	}
-	AuthorizePersonaAddressTx.ForEach(world, queue, func(tx TxData[AuthorizePersonaAddress]) (AuthorizePersonaAddressResult, error) {
+	AuthorizePersonaAddressTx.ForEach(wCtx, func(tx TxData[AuthorizePersonaAddress]) (AuthorizePersonaAddressResult, error) {
 		val, sig := tx.Value, tx.Sig
 		result := AuthorizePersonaAddressResult{Success: false}
 		if sig.PersonaTag != val.PersonaTag {
@@ -59,7 +56,7 @@ func AuthorizePersonaAddressSystem(world *World, queue *transaction.TxQueue, _ *
 		if !ok {
 			return result, fmt.Errorf("persona does not exist")
 		}
-		err = updateComponent[SignerComponent](world, data.EntityID, func(s *SignerComponent) *SignerComponent {
+		err = updateComponent[SignerComponent](wCtx, data.EntityID, func(s *SignerComponent) *SignerComponent {
 			for _, addr := range s.AuthorizedAddresses {
 				if addr == val.Address {
 					return s
@@ -92,20 +89,15 @@ type personaTagComponentData struct {
 	EntityID      entity.ID
 }
 
-func buildPersonaTagMapping(world *World) (map[string]personaTagComponentData, error) {
+func buildPersonaTagMapping(wCtx WorldContext) (map[string]personaTagComponentData, error) {
 	personaTagToAddress := map[string]personaTagComponentData{}
 	var errs []error
-	q, err := world.NewSearch(Exact(SignerComponent{}))
-	c, err := world.GetComponentByName(SignerComponent{}.Name())
+	q, err := wCtx.NewSearch(Exact(SignerComponent{}))
 	if err != nil {
 		return nil, err
 	}
-	filter.Exact(c)
-	if err != nil {
-		return nil, err
-	}
-	q.Each(world, func(id entity.ID) bool {
-		sc, err := getComponent[SignerComponent](world, id)
+	q.Each(wCtx, func(id entity.ID) bool {
+		sc, err := getComponent[SignerComponent](wCtx, id)
 		if err != nil {
 			errs = append(errs, err)
 			return true
@@ -124,12 +116,12 @@ func buildPersonaTagMapping(world *World) (map[string]personaTagComponentData, e
 
 // RegisterPersonaSystem is an ecs.System that will associate persona tags with signature addresses. Each persona tag
 // may have at most 1 signer, so additional attempts to register a signer with a persona tag will be ignored.
-func RegisterPersonaSystem(world *World, queue *transaction.TxQueue, _ *log.Logger) error {
-	createTxs := CreatePersonaTx.In(queue)
+func RegisterPersonaSystem(wCtx WorldContext) error {
+	createTxs := CreatePersonaTx.In(wCtx)
 	if len(createTxs) == 0 {
 		return nil
 	}
-	personaTagToAddress, err := buildPersonaTagMapping(world)
+	personaTagToAddress, err := buildPersonaTagMapping(wCtx)
 	if err != nil {
 		return err
 	}
@@ -139,23 +131,23 @@ func RegisterPersonaSystem(world *World, queue *transaction.TxQueue, _ *log.Logg
 			// This PersonaTag has already been registered. Don't do anything
 			continue
 		}
-		id, err := create(world, SignerComponent{})
+		id, err := create(wCtx, SignerComponent{})
 		if err != nil {
-			CreatePersonaTx.AddError(world, txData.TxHash, err)
+			CreatePersonaTx.AddError(wCtx, txData.TxHash, err)
 			continue
 		}
-		if err := setComponent[SignerComponent](world, id, &SignerComponent{
+		if err := setComponent[SignerComponent](wCtx, id, &SignerComponent{
 			PersonaTag:    tx.PersonaTag,
 			SignerAddress: tx.SignerAddress,
 		}); err != nil {
-			CreatePersonaTx.AddError(world, txData.TxHash, err)
+			CreatePersonaTx.AddError(wCtx, txData.TxHash, err)
 			continue
 		}
 		personaTagToAddress[tx.PersonaTag] = personaTagComponentData{
 			SignerAddress: tx.SignerAddress,
 			EntityID:      id,
 		}
-		CreatePersonaTx.SetResult(world, txData.TxHash, CreatePersonaTransactionResult{
+		CreatePersonaTx.SetResult(wCtx, txData.TxHash, CreatePersonaTransactionResult{
 			Success: true,
 		})
 	}
@@ -180,8 +172,9 @@ func (w *World) GetSignerForPersonaTag(personaTag string, tick uint64) (addr str
 	if err != nil {
 		return "", err
 	}
-	q.Each(w, func(id entity.ID) bool {
-		sc, err := getComponent[SignerComponent](w, id)
+	wCtx := NewReadOnlyWorldContext(w)
+	err = q.Each(wCtx, func(id entity.ID) bool {
+		sc, err := getComponent[SignerComponent](wCtx, id)
 		//sc, err := SignerComp.Get(w, id)
 		if err != nil {
 			errs = append(errs, err)
@@ -192,31 +185,29 @@ func (w *World) GetSignerForPersonaTag(personaTag string, tick uint64) (addr str
 		}
 		return true
 	})
-	if len(errs) > 0 {
-		return "", errors.Join(errs...)
-	}
-
+	errs = append(errs, err)
 	if addr == "" {
 		return "", ErrorPersonaTagHasNoSigner
 	}
-	return addr, nil
+	return addr, errors.Join(errs...)
 }
 
 // TODO private component function used to temporarily remove circular dependency until we replace components.
 // TODO this function is intended only for use with persona.go and is to be removed with persona when we replace with plugins.
 // Get returns component data from the entity.
-func getComponent[T component_metadata.Component](w *World, id entity.ID) (comp *T, err error) {
+// GetComponent returns component data from the entity.
+func getComponent[T component_metadata.Component](wCtx WorldContext, id entity.ID) (comp *T, err error) {
 	var t T
 	name := t.Name()
-	c, ok := w.nameToComponent[name]
-	if !ok {
+	c, err := wCtx.GetWorld().GetComponentByName(name)
+	if err != nil {
 		return nil, errors.New("Must register component")
 	}
-	value, err := w.StoreManager().GetComponentForEntity(c, id)
+	value, err := wCtx.StoreReader().GetComponentForEntity(c, id)
 	if err != nil {
 		return nil, err
 	}
-	t, ok = value.(T)
+	t, ok := value.(T)
 	if !ok {
 		comp, ok = value.(*T)
 		if !ok {
@@ -232,18 +223,21 @@ func getComponent[T component_metadata.Component](w *World, id entity.ID) (comp 
 // TODO private component function used to temporarily remove circular dependency until we replace components.
 // TODO this function is intended only for use with persona.go and is to be removed with persona when we replace with plugins.
 // Set sets component data to the entity.
-func setComponent[T component_metadata.Component](w *World, id entity.ID, component *T) error {
+func setComponent[T component_metadata.Component](wCtx WorldContext, id entity.ID, component *T) error {
+	if wCtx.IsReadOnly() {
+		return ErrorCannotModifyStateWithReadOnlyContext
+	}
 	var t T
 	name := t.Name()
-	c, ok := w.nameToComponent[name]
-	if !ok {
+	c, err := wCtx.GetWorld().GetComponentByName(name)
+	if err != nil {
 		return fmt.Errorf("%s is not registered, please register it before updating", t.Name())
 	}
-	err := w.StoreManager().SetComponentForEntity(c, id, component)
+	err = wCtx.StoreManager().SetComponentForEntity(c, id, component)
 	if err != nil {
 		return err
 	}
-	w.Logger.Debug().
+	wCtx.Logger().Debug().
 		Str("entity_id", strconv.FormatUint(uint64(id), 10)).
 		Str("component_name", c.Name()).
 		Int("component_id", int(c.ID())).
@@ -254,28 +248,26 @@ func setComponent[T component_metadata.Component](w *World, id entity.ID, compon
 // TODO private component function used to temporarily remove circular dependency until we replace components.
 // TODO this function is intended only for use with persona.go and is to be removed with persona when we replace with plugins.
 // https://linear.app/arguslabs/issue/WORLD-423/ecs-plugin-feature
-func updateComponent[T component_metadata.Component](w *World, id entity.ID, fn func(*T) *T) error {
-	var t T
-	name := t.Name()
-	c, ok := w.nameToComponent[name]
-	if !ok {
-		return fmt.Errorf("%s is not registered, please register it before updating", t.Name())
+func updateComponent[T component_metadata.Component](wCtx WorldContext, id entity.ID, fn func(*T) *T) error {
+	if wCtx.IsReadOnly() {
+		return ErrorCannotModifyStateWithReadOnlyContext
 	}
-	if _, ok := w.nameToComponent[c.Name()]; !ok {
-		return fmt.Errorf("%s is not registered, please register it before updating", c.Name())
-	}
-	val, err := getComponent[T](w, id)
+	val, err := getComponent[T](wCtx, id)
 	if err != nil {
 		return err
 	}
 	updatedVal := fn(val)
-	return setComponent[T](w, id, updatedVal)
+	return setComponent[T](wCtx, id, updatedVal)
 }
 
 // TODO private component function used to temporarily remove circular dependency until we replace components.
 // TODO this function is intended only for use with persona.go and is to be removed with persona when we replace with plugins.
 // https://linear.app/arguslabs/issue/WORLD-423/ecs-plugin-feature
-func createMany(world *World, num int, components ...component_metadata.Component) ([]entity.ID, error) {
+func createMany(wCtx WorldContext, num int, components ...component_metadata.Component) ([]entity.ID, error) {
+	if wCtx.IsReadOnly() {
+		return nil, ErrorCannotModifyStateWithReadOnlyContext
+	}
+	world := wCtx.GetWorld()
 	acc := make([]component_metadata.IComponentMetaData, 0, len(components))
 	for _, comp := range components {
 		c, err := world.GetComponentByName(comp.Name())
@@ -306,8 +298,8 @@ func createMany(world *World, num int, components ...component_metadata.Componen
 // TODO private component function used to temporarily remove circular dependency until we replace components.
 // TODO this function is intended only for use with persona.go and is to be removed with persona when we replace with plugins.
 // https://linear.app/arguslabs/issue/WORLD-423/ecs-plugin-feature
-func create(world *World, components ...component_metadata.Component) (entity.ID, error) {
-	entities, err := createMany(world, 1, components...)
+func create(wCtx WorldContext, components ...component_metadata.Component) (entity.ID, error) {
+	entities, err := createMany(wCtx, 1, components...)
 	if err != nil {
 		return 0, err
 	}

--- a/cardinal/ecs/persona_test.go
+++ b/cardinal/ecs/persona_test.go
@@ -37,11 +37,12 @@ func TestCreatePersonaTransactionAutomaticallyCreated(t *testing.T) {
 	assert.NilError(t, world.Tick(context.Background()))
 
 	count := 0
-	q, err := world.NewSearch(ecs.Exact(ecs.SignerComponent{}))
+	wCtx := ecs.NewWorldContext(world)
+	q, err := wCtx.NewSearch(ecs.Exact(ecs.SignerComponent{}))
 	assert.NilError(t, err)
-	q.Each(world, func(id entity.ID) bool {
+	q.Each(wCtx, func(id entity.ID) bool {
 		count++
-		sc, err := component.GetComponent[ecs.SignerComponent](world, id)
+		sc, err := component.GetComponent[ecs.SignerComponent](wCtx, id)
 		assert.NilError(t, err)
 		assert.Equal(t, sc.PersonaTag, wantTag)
 		assert.Equal(t, sc.SignerAddress, wantAddress)
@@ -143,9 +144,10 @@ func TestCanAuthorizeAddress(t *testing.T) {
 	count := 0
 	q, err := world.NewSearch(ecs.Exact(ecs.SignerComponent{}))
 	assert.NilError(t, err)
-	q.Each(world, func(id entity.ID) bool {
+	wCtx := ecs.NewWorldContext(world)
+	q.Each(wCtx, func(id entity.ID) bool {
 		count++
-		sc, err := component.GetComponent[ecs.SignerComponent](world, id)
+		sc, err := component.GetComponent[ecs.SignerComponent](wCtx, id)
 		assert.NilError(t, err)
 		assert.Equal(t, sc.PersonaTag, wantTag)
 		assert.Equal(t, sc.SignerAddress, wantSigner)

--- a/cardinal/ecs/query_test.go
+++ b/cardinal/ecs/query_test.go
@@ -30,7 +30,7 @@ func TestQueryTypeNotStructs(t *testing.T) {
 		// test should trigger a panic.
 		panicValue := recover()
 		assert.Assert(t, panicValue != nil)
-		ecs.NewQueryType[FooRequest, FooReply]("foo", func(world *ecs.World, req FooRequest) (FooReply, error) {
+		ecs.NewQueryType[FooRequest, FooReply]("foo", func(wCtx ecs.WorldContext, req FooRequest) (FooReply, error) {
 			return expectedReply, nil
 		})
 		defer func() {
@@ -40,7 +40,7 @@ func TestQueryTypeNotStructs(t *testing.T) {
 		}()
 	}()
 
-	ecs.NewQueryType[string, string]("foo", func(world *ecs.World, req string) (string, error) {
+	ecs.NewQueryType[string, string]("foo", func(wCtx ecs.WorldContext, req string) (string, error) {
 		return "blah", nil
 	})
 }
@@ -59,7 +59,7 @@ func TestQueryEVM(t *testing.T) {
 		Name: "Chad",
 		Age:  22,
 	}
-	fooQuery := ecs.NewQueryType[FooRequest, FooReply]("foo", func(world *ecs.World, req FooRequest) (FooReply, error) {
+	fooQuery := ecs.NewQueryType[FooRequest, FooReply]("foo", func(wCtx ecs.WorldContext, req FooRequest) (FooReply, error) {
 		return expectedReply, nil
 	}, ecs.WithQueryEVMSupport[FooRequest, FooReply])
 

--- a/cardinal/ecs/search_test.go
+++ b/cardinal/ecs/search_test.go
@@ -26,25 +26,26 @@ func TestSearchEarlyTermination(t *testing.T) {
 	total := 10
 	count := 0
 	stop := 5
-	_, err := component.CreateMany(world, total, FooComponent{})
+	wCtx := ecs.NewWorldContext(world)
+	_, err := component.CreateMany(wCtx, total, FooComponent{})
 	assert.NilError(t, err)
 	q, err := world.NewSearch(ecs.Exact(FooComponent{}))
 	assert.NilError(t, err)
-	q.Each(world, func(id entity.ID) bool {
+	assert.NilError(t, q.Each(wCtx, func(id entity.ID) bool {
 		count++
 		if count == stop {
 			return false
 		}
 		return true
-	})
+	}))
 	assert.Equal(t, count, stop)
 
 	count = 0
 	q, err = world.NewSearch(ecs.Exact(FooComponent{}))
 	assert.NilError(t, err)
-	q.Each(world, func(id entity.ID) bool {
+	assert.NilError(t, q.Each(wCtx, func(id entity.ID) bool {
 		count++
 		return true
-	})
+	}))
 	assert.Equal(t, count, total)
 }

--- a/cardinal/ecs/store/iface.go
+++ b/cardinal/ecs/store/iface.go
@@ -55,4 +55,5 @@ type Writer interface {
 type IManager interface {
 	Reader
 	Writer
+	ToReadOnly() Reader
 }

--- a/cardinal/ecs/store/store.go
+++ b/cardinal/ecs/store/store.go
@@ -31,6 +31,10 @@ func NewStoreManager(store storage.WorldStorage, logger *log.Logger) *Manager {
 	}
 }
 
+func (s *Manager) ToReadOnly() Reader {
+	return s
+}
+
 func (s *Manager) GetEntitiesForArchID(archID archetype.ID) ([]entity.ID, error) {
 	return s.store.ArchAccessor.Archetype(archID).Entities(), nil
 }

--- a/cardinal/ecs/system.go
+++ b/cardinal/ecs/system.go
@@ -1,8 +1,3 @@
 package ecs
 
-import (
-	"pkg.world.dev/world-engine/cardinal/ecs/log"
-	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
-)
-
-type System func(*World, *transaction.TxQueue, *log.Logger) error
+type System func(WorldContext) error

--- a/cardinal/ecs/transaction/transaction_test.go
+++ b/cardinal/ecs/transaction/transaction_test.go
@@ -6,13 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"gotest.tools/v3/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/entity"
-	"pkg.world.dev/world-engine/cardinal/ecs/log"
-	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
-
-	"gotest.tools/v3/assert"
 )
 
 type ScoreComponent struct {
@@ -59,15 +56,16 @@ func TestCanQueueTransactions(t *testing.T) {
 	modifyScoreTx := ecs.NewTransactionType[*ModifyScoreTx, *EmptyTxResult]("modify_score")
 	assert.NilError(t, world.RegisterTransactions(modifyScoreTx))
 
-	id, err := component.Create(world, ScoreComponent{})
+	wCtx := ecs.NewWorldContext(world)
+	id, err := component.Create(wCtx, ScoreComponent{})
 	assert.NilError(t, err)
 
 	// Set up a system that allows for the modification of a player's score
-	world.AddSystem(func(w *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		modifyScore := modifyScoreTx.In(queue)
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
+		modifyScore := modifyScoreTx.In(wCtx)
 		for _, txData := range modifyScore {
 			ms := txData.Value
-			err := component.UpdateComponent[ScoreComponent](w, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
+			err := component.UpdateComponent[ScoreComponent](wCtx, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
 				s.Score += ms.Amount
 				return s
 			})
@@ -81,11 +79,10 @@ func TestCanQueueTransactions(t *testing.T) {
 
 	modifyScoreTx.AddToQueue(world, &ModifyScoreTx{id, 100})
 
-	assert.NilError(t, component.SetComponent[ScoreComponent](world, id, &ScoreComponent{}))
+	assert.NilError(t, component.SetComponent[ScoreComponent](wCtx, id, &ScoreComponent{}))
 
 	// Verify the score is 0
-	s, err := component.GetComponent[ScoreComponent](world, id)
-	//s, err := score.Get(world, id)
+	s, err := component.GetComponent[ScoreComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 0, s.Score)
 
@@ -93,8 +90,7 @@ func TestCanQueueTransactions(t *testing.T) {
 	assert.NilError(t, world.Tick(context.Background()))
 
 	// Verify the score was updated
-	s, err = component.GetComponent[ScoreComponent](world, id)
-	//s, err = score.Get(world, id)
+	s, err = component.GetComponent[ScoreComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 100, s.Score)
 
@@ -102,8 +98,7 @@ func TestCanQueueTransactions(t *testing.T) {
 	assert.NilError(t, world.Tick(context.Background()))
 
 	// Verify the score hasn't changed
-	s, err = component.GetComponent[ScoreComponent](world, id)
-	//s, err = score.Get(world, id)
+	s, err = component.GetComponent[ScoreComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 100, s.Score)
 }
@@ -121,10 +116,11 @@ func TestSystemsAreExecutedDuringGameTick(t *testing.T) {
 
 	assert.NilError(t, ecs.RegisterComponent[CounterComponent](world))
 
-	id, err := component.Create(world, CounterComponent{})
+	wCtx := ecs.NewWorldContext(world)
+	id, err := component.Create(wCtx, CounterComponent{})
 	assert.NilError(t, err)
-	world.AddSystem(func(w *ecs.World, _ *transaction.TxQueue, _ *log.Logger) error {
-		return component.UpdateComponent[CounterComponent](w, id, func(c *CounterComponent) *CounterComponent {
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
+		return component.UpdateComponent[CounterComponent](wCtx, id, func(c *CounterComponent) *CounterComponent {
 			c.Count++
 			return c
 		})
@@ -135,8 +131,7 @@ func TestSystemsAreExecutedDuringGameTick(t *testing.T) {
 		assert.NilError(t, world.Tick(context.Background()))
 	}
 
-	c, err := component.GetComponent[CounterComponent](world, id)
-	//c, err := count.Get(world, id)
+	c, err := component.GetComponent[CounterComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 10, c.Count)
 }
@@ -148,11 +143,11 @@ func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 	modifyScoreTx := ecs.NewTransactionType[*ModifyScoreTx, *EmptyTxResult]("modify_score")
 	assert.NilError(t, world.RegisterTransactions(modifyScoreTx))
 
-	world.AddSystem(func(w *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		modifyScores := modifyScoreTx.In(queue)
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
+		modifyScores := modifyScoreTx.In(wCtx)
 		for _, msData := range modifyScores {
 			ms := msData.Value
-			err := component.UpdateComponent[ScoreComponent](w, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
+			err := component.UpdateComponent[ScoreComponent](wCtx, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
 				s.Score += ms.Amount
 				return s
 			})
@@ -162,7 +157,8 @@ func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 	})
 	assert.NilError(t, world.LoadGameState())
 
-	ids, err := component.CreateMany(world, 100, ScoreComponent{})
+	wCtx := ecs.NewWorldContext(world)
+	ids, err := component.CreateMany(wCtx, 100, ScoreComponent{})
 	assert.NilError(t, err)
 	// Entities at index 5, 10 and 50 will be updated with some values
 	modifyScoreTx.AddToQueue(world, &ModifyScoreTx{
@@ -189,8 +185,7 @@ func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 		} else if i == 50 {
 			wantScore = 150
 		}
-		s, err := component.GetComponent[ScoreComponent](world, id)
-		//s, err := score.Get(world, id)
+		s, err := component.GetComponent[ScoreComponent](wCtx, id)
 		assert.NilError(t, err)
 		assert.Equal(t, wantScore, s.Score)
 	}
@@ -207,7 +202,7 @@ func TestAddToQueueDuringTickDoesNotTimeout(t *testing.T) {
 	inSystemCh := make(chan struct{})
 	// This system will block forever. This will give us a never-ending game tick that we can use
 	// to verify that the addition of more transactions doesn't block.
-	world.AddSystem(func(*ecs.World, *transaction.TxQueue, *log.Logger) error {
+	world.AddSystem(func(ecs.WorldContext) error {
 		<-inSystemCh
 		select {}
 		return nil
@@ -256,14 +251,14 @@ func TestTransactionsAreExecutedAtNextTick(t *testing.T) {
 	// transaction queue. These counts should be the same for each tick. modScoreCountCh is an unbuffered channel
 	// so these systems will block while writing to modScoreCountCh. This allows the test to ensure that we can run
 	// commands mid-tick.
-	world.AddSystem(func(_ *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		modScores := modScoreTx.In(queue)
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
+		modScores := modScoreTx.In(wCtx)
 		modScoreCountCh <- len(modScores)
 		return nil
 	})
 
-	world.AddSystem(func(_ *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		modScores := modScoreTx.In(queue)
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
+		modScores := modScoreTx.In(wCtx)
 		modScoreCountCh <- len(modScores)
 		return nil
 	})
@@ -325,12 +320,12 @@ func TestIdenticallyTypedTransactionCanBeDistinguished(t *testing.T) {
 	alpha.AddToQueue(world, NewOwner{"alpha"})
 	beta.AddToQueue(world, NewOwner{"beta"})
 
-	world.AddSystem(func(_ *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		newNames := alpha.In(queue)
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
+		newNames := alpha.In(wCtx)
 		assert.Check(t, 1 == len(newNames), "expected 1 transaction, not %d", len(newNames))
 		assert.Check(t, "alpha" == newNames[0].Value.Name)
 
-		newNames = beta.In(queue)
+		newNames = beta.In(wCtx)
 		assert.Check(t, 1 == len(newNames), "expected 1 transaction, not %d", len(newNames))
 		assert.Check(t, "beta" == newNames[0].Value.Name)
 		return nil
@@ -413,13 +408,13 @@ func TestCanGetTransactionErrorsAndResults(t *testing.T) {
 	wantSecondError := errors.New("another transaction error")
 	wantDeltaX, wantDeltaY := 99, 100
 
-	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
 		// This new TxsIn function returns a triplet of information:
 		// 1) The transaction input
 		// 2) An ID that uniquely identifies this specific transaction
 		// 3) The signature
 		// This function would replace both "In" and "TxsAndSigsIn"
-		txs := moveTx.In(queue)
+		txs := moveTx.In(wCtx)
 		assert.Equal(t, 1, len(txs), "expected 1 move transaction")
 		tx := txs[0]
 		// The input for the transaction is found at tx.Val
@@ -428,12 +423,12 @@ func TestCanGetTransactionErrorsAndResults(t *testing.T) {
 
 		// AddError will associate an error with the tx.TxHash. Multiple errors can be
 		// associated with a transaction.
-		moveTx.AddError(world, tx.TxHash, wantFirstError)
-		moveTx.AddError(world, tx.TxHash, wantSecondError)
+		moveTx.AddError(wCtx, tx.TxHash, wantFirstError)
+		moveTx.AddError(wCtx, tx.TxHash, wantSecondError)
 
 		// SetResult sets the output for the transaction. Only one output can be set
 		// for a tx.TxHash (the last assigned result will clobber other results)
-		moveTx.SetResult(world, tx.TxHash, MoveTxResult{42, 42})
+		moveTx.SetResult(wCtx, tx.TxHash, MoveTxResult{42, 42})
 		return nil
 	})
 	assert.NilError(t, world.LoadGameState())
@@ -467,23 +462,23 @@ func TestSystemCanFindErrorsFromEarlierSystem(t *testing.T) {
 	assert.NilError(t, world.RegisterTransactions(numTx))
 	wantErr := errors.New("some transaction error")
 	systemCalls := 0
-	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
 		systemCalls++
-		txs := numTx.In(queue)
+		txs := numTx.In(wCtx)
 		assert.Equal(t, 1, len(txs))
 		hash := txs[0].TxHash
-		_, _, ok := numTx.GetReceipt(world, hash)
+		_, _, ok := numTx.GetReceipt(wCtx, hash)
 		assert.Check(t, !ok)
-		numTx.AddError(world, hash, wantErr)
+		numTx.AddError(wCtx, hash, wantErr)
 		return nil
 	})
 
-	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
 		systemCalls++
-		txs := numTx.In(queue)
+		txs := numTx.In(wCtx)
 		assert.Equal(t, 1, len(txs))
 		hash := txs[0].TxHash
-		_, errs, ok := numTx.GetReceipt(world, hash)
+		_, errs, ok := numTx.GetReceipt(wCtx, hash)
 		assert.Check(t, ok)
 		assert.Equal(t, 1, len(errs))
 		assert.ErrorIs(t, wantErr, errs[0])
@@ -511,27 +506,27 @@ func TestSystemCanClobberTransactionResult(t *testing.T) {
 
 	firstResult := TxOut{1234}
 	secondResult := TxOut{5678}
-	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
 		systemCalls++
-		txs := numTx.In(queue)
+		txs := numTx.In(wCtx)
 		assert.Equal(t, 1, len(txs))
 		hash := txs[0].TxHash
-		_, _, ok := numTx.GetReceipt(world, hash)
+		_, _, ok := numTx.GetReceipt(wCtx, hash)
 		assert.Check(t, !ok)
-		numTx.SetResult(world, hash, firstResult)
+		numTx.SetResult(wCtx, hash, firstResult)
 		return nil
 	})
 
-	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
 		systemCalls++
-		txs := numTx.In(queue)
+		txs := numTx.In(wCtx)
 		assert.Equal(t, 1, len(txs))
 		hash := txs[0].TxHash
-		out, errs, ok := numTx.GetReceipt(world, hash)
+		out, errs, ok := numTx.GetReceipt(wCtx, hash)
 		assert.Check(t, ok)
 		assert.Equal(t, 0, len(errs))
 		assert.Equal(t, TxOut{1234}, out)
-		numTx.SetResult(world, hash, secondResult)
+		numTx.SetResult(wCtx, hash, secondResult)
 		return nil
 	})
 	assert.NilError(t, world.LoadGameState())

--- a/cardinal/ecs/transaction_test.go
+++ b/cardinal/ecs/transaction_test.go
@@ -8,7 +8,6 @@ import (
 	"gotest.tools/v3/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
-	"pkg.world.dev/world-engine/cardinal/ecs/log"
 	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 )
 
@@ -24,8 +23,8 @@ func TestForEachTransaction(t *testing.T) {
 	someTx := ecs.NewTransactionType[SomeTxRequest, SomeTxResponse]("some_tx")
 	assert.NilError(t, world.RegisterTransactions(someTx))
 
-	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, logger *log.Logger) error {
-		someTx.ForEach(world, queue, func(t ecs.TxData[SomeTxRequest]) (result SomeTxResponse, err error) {
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
+		someTx.ForEach(wCtx, func(t ecs.TxData[SomeTxRequest]) (result SomeTxResponse, err error) {
 			if t.Value.GenerateError {
 				return result, errors.New("some error")
 			}

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -309,7 +309,8 @@ func (w *World) Tick(ctx context.Context) error {
 
 	for i, sys := range w.systems {
 		nameOfCurrentRunningSystem = w.systemNames[i]
-		err := sys(w, txQueue, w.systemLoggers[i])
+		wCtx := NewWorldContextForTick(w, txQueue, w.systemLoggers[i])
+		err := sys(wCtx)
 		nameOfCurrentRunningSystem = nullSystemName
 		if err != nil {
 			return err

--- a/cardinal/ecs/world_context.go
+++ b/cardinal/ecs/world_context.go
@@ -1,0 +1,97 @@
+package ecs
+
+import (
+	"errors"
+
+	"github.com/rs/zerolog"
+	ecslog "pkg.world.dev/world-engine/cardinal/ecs/log"
+	"pkg.world.dev/world-engine/cardinal/ecs/store"
+	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
+)
+
+type WorldContext interface {
+	CurrentTick() uint64
+	Logger() *zerolog.Logger
+	NewSearch(filter Filterable) (*Search, error)
+
+	// Meant for internal ECS access only
+	GetWorld() *World
+	GetTxQueue() *transaction.TxQueue
+	IsReadOnly() bool
+	StoreReader() store.Reader
+	StoreManager() store.IManager
+}
+
+var (
+	ErrorCannotModifyStateWithReadOnlyContext = errors.New("cannot modify state with read only context")
+)
+
+type worldContext struct {
+	world    *World
+	txQueue  *transaction.TxQueue
+	logger   *ecslog.Logger
+	readOnly bool
+}
+
+func NewWorldContextForTick(world *World, queue *transaction.TxQueue, logger *ecslog.Logger) WorldContext {
+	return &worldContext{
+		world:    world,
+		txQueue:  queue,
+		logger:   logger,
+		readOnly: false,
+	}
+}
+
+func NewWorldContext(world *World) WorldContext {
+	return &worldContext{
+		world:    world,
+		readOnly: false,
+	}
+}
+
+func NewReadOnlyWorldContext(world *World) WorldContext {
+	return &worldContext{
+		world:    world,
+		txQueue:  nil,
+		readOnly: true,
+	}
+}
+
+func (w *worldContext) CurrentTick() uint64 {
+	return w.world.CurrentTick()
+}
+
+func (w *worldContext) Logger() *zerolog.Logger {
+	if w.logger != nil {
+		return w.logger.Logger
+	}
+	return w.world.Logger.Logger
+}
+
+func (w *worldContext) GetWorld() *World {
+	return w.world
+}
+
+func (w *worldContext) GetTxQueue() *transaction.TxQueue {
+	return w.txQueue
+}
+
+func (w *worldContext) IsReadOnly() bool {
+	return w.readOnly
+}
+
+func (w *worldContext) StoreManager() store.IManager {
+	return w.world.StoreManager()
+}
+
+func (w *worldContext) StoreReader() store.Reader {
+	sm := w.StoreManager()
+	if w.IsReadOnly() {
+		return sm.ToReadOnly()
+	}
+	return sm
+}
+
+func (w *worldContext) NewSearch(filter Filterable) (*Search, error) {
+	return w.world.NewSearch(filter)
+}

--- a/cardinal/evm/server.go
+++ b/cardinal/evm/server.go
@@ -158,13 +158,14 @@ func (s *msgServerImpl) SendMessage(ctx context.Context, msg *routerv1.SendMessa
 func (s *msgServerImpl) getSignerComponentForAuthorizedAddr(addr string) (*ecs.SignerComponent, error) {
 	var sc *ecs.SignerComponent
 	var err error
-	q, err := s.world.NewSearch(ecs.Exact(ecs.SignerComponent{}))
+	wCtx := ecs.NewReadOnlyWorldContext(s.world)
+	q, err := wCtx.NewSearch(ecs.Exact(ecs.SignerComponent{}))
 	if err != nil {
 		return nil, err
 	}
-	q.Each(s.world, func(id entity.ID) bool {
+	q.Each(wCtx, func(id entity.ID) bool {
 		var signerComp *ecs.SignerComponent
-		signerComp, err = component.GetComponent[ecs.SignerComponent](s.world, id)
+		signerComp, err = component.GetComponent[ecs.SignerComponent](wCtx, id)
 		if err != nil {
 			return false
 		}

--- a/cardinal/evm/server.go
+++ b/cardinal/evm/server.go
@@ -195,7 +195,7 @@ func (s *msgServerImpl) QueryShard(ctx context.Context, req *routerv1.QueryShard
 	if err != nil {
 		return nil, err
 	}
-	reply, err := query.HandleQuery(s.world, ecsRequest)
+	reply, err := query.HandleQuery(ecs.NewReadOnlyWorldContext(s.world), ecsRequest)
 	if err != nil {
 		return nil, err
 	}

--- a/cardinal/evm/server_test.go
+++ b/cardinal/evm/server_test.go
@@ -126,7 +126,7 @@ func TestServer_Query(t *testing.T) {
 		Y uint64
 	}
 	// set up a query that simply returns the FooReq.X
-	query := ecs.NewQueryType[FooReq, FooReply]("foo", func(world *ecs.World, req FooReq) (FooReply, error) {
+	query := ecs.NewQueryType[FooReq, FooReply]("foo", func(wCtx ecs.WorldContext, req FooReq) (FooReply, error) {
 		return FooReply{Y: req.X}, nil
 	}, ecs.WithQueryEVMSupport[FooReq, FooReply])
 	w := ecs.NewTestWorld(t)

--- a/cardinal/evm/server_test.go
+++ b/cardinal/evm/server_test.go
@@ -7,8 +7,6 @@ import (
 
 	"gotest.tools/v3/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/log"
-	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 	routerv1 "pkg.world.dev/world-engine/rift/router/v1"
 	"pkg.world.dev/world-engine/sign"
 )
@@ -54,12 +52,12 @@ func TestServer_SendMessage(t *testing.T) {
 	enabled := false
 
 	// add a system that checks that they are submitted properly to the world.
-	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
+	w.AddSystem(func(wCtx ecs.WorldContext) error {
 		if !enabled {
 			return nil
 		}
-		inFooTxs := FooTx.In(queue)
-		inBarTxs := BarTx.In(queue)
+		inFooTxs := FooTx.In(wCtx)
+		inBarTxs := BarTx.In(wCtx)
 		assert.Equal(t, len(inFooTxs), len(fooTxs))
 		assert.Equal(t, len(inBarTxs), len(barTxs))
 		for i, tx := range inFooTxs {

--- a/cardinal/example_transactiontype_test.go
+++ b/cardinal/example_transactiontype_test.go
@@ -29,8 +29,8 @@ func ExampleTransactionType() {
 		panic(err)
 	}
 
-	cardinal.RegisterSystems(world, func(world *cardinal.World, queue *cardinal.TransactionQueue, logger *cardinal.Logger) error {
-		for _, tx := range MoveTx.In(queue) {
+	cardinal.RegisterSystems(world, func(wCtx cardinal.WorldContext) error {
+		for _, tx := range MoveTx.In(wCtx) {
 			msg := tx.Value()
 			// handle the transaction
 			// ...

--- a/cardinal/read.go
+++ b/cardinal/read.go
@@ -18,23 +18,21 @@ type QueryType[Request, Reply any] struct {
 // in the given handler function.
 func NewQueryType[Request any, Reply any](
 	name string,
-	handler func(*World, Request) (Reply, error),
+	handler func(WorldContext, Request) (Reply, error),
 ) *QueryType[Request, Reply] {
 	return &QueryType[Request, Reply]{
-		impl: ecs.NewQueryType[Request, Reply](name, func(world *ecs.World, req Request) (Reply, error) {
-			outerWorld := &World{implWorld: world}
-			return handler(outerWorld, req)
+		impl: ecs.NewQueryType[Request, Reply](name, func(wCtx ecs.WorldContext, req Request) (Reply, error) {
+			return handler(wCtx, req)
 		}),
 	}
 }
 
 // NewQueryTypeWithEVMSupport creates a new instance of a QueryType with EVM support, allowing this query to be called from
 // the EVM base shard. The World state must not be changed in the given handler function.
-func NewQueryTypeWithEVMSupport[Request, Reply any](name string, handler func(*World, Request) (Reply, error)) *QueryType[Request, Reply] {
+func NewQueryTypeWithEVMSupport[Request, Reply any](name string, handler func(WorldContext, Request) (Reply, error)) *QueryType[Request, Reply] {
 	return &QueryType[Request, Reply]{
-		impl: ecs.NewQueryType[Request, Reply](name, func(world *ecs.World, req Request) (Reply, error) {
-			outerWorld := &World{implWorld: world}
-			return handler(outerWorld, req)
+		impl: ecs.NewQueryType[Request, Reply](name, func(wCtx ecs.WorldContext, req Request) (Reply, error) {
+			return handler(wCtx, req)
 		}, ecs.WithQueryEVMSupport[Request, Reply]),
 	}
 }

--- a/cardinal/search.go
+++ b/cardinal/search.go
@@ -25,18 +25,18 @@ type SearchCallBackFn func(EntityID) bool
 
 // Each executes the given callback function on every EntityID that matches this search. If any call to callback returns
 // falls, no more entities will be processed.
-func (q *Search) Each(w *World, callback SearchCallBackFn) {
-	q.impl.Each(w.implWorld, func(eid entity.ID) bool {
+func (q *Search) Each(wCtx WorldContext, callback SearchCallBackFn) {
+	q.impl.Each(wCtx, func(eid entity.ID) bool {
 		return callback(eid)
 	})
 }
 
 // Count returns the number of entities that match this search.
-func (q *Search) Count(w *World) (int, error) {
-	return q.impl.Count(w.implWorld)
+func (q *Search) Count(wCtx WorldContext) (int, error) {
+	return q.impl.Count(wCtx)
 }
 
 // First returns the first entity that matches this search.
-func (q *Search) First(w *World) (id EntityID, err error) {
-	return q.impl.First(w.implWorld)
+func (q *Search) First(wCtx WorldContext) (id EntityID, err error) {
+	return q.impl.First(wCtx)
 }

--- a/cardinal/server/query.go
+++ b/cardinal/server/query.go
@@ -60,7 +60,8 @@ func (handler *Handler) registerQueryHandlerSwagger(api *untyped.API) error {
 		if err != nil {
 			return nil, err
 		}
-		rawJsonReply, err := outputType.HandleQueryRaw(handler.w, rawJsonBody)
+		wCtx := ecs.NewReadOnlyWorldContext(handler.w)
+		rawJsonReply, err := outputType.HandleQueryRaw(wCtx, rawJsonBody)
 		if err != nil {
 			return nil, err
 		}

--- a/cardinal/server/query.go
+++ b/cardinal/server/query.go
@@ -112,7 +112,8 @@ func (handler *Handler) registerQueryHandlerSwagger(api *untyped.API) error {
 
 		result := make([]cql.QueryResponse, 0)
 
-		ecs.NewSearch(resultFilter).Each(handler.w, func(id entity.ID) bool {
+		wCtx := ecs.NewReadOnlyWorldContext(handler.w)
+		ecs.NewSearch(resultFilter).Each(wCtx, func(id entity.ID) bool {
 			components, err := handler.w.StoreManager().GetComponentTypesForEntity(id)
 			if err != nil {
 				return false

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -26,8 +26,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/cql"
-	"pkg.world.dev/world-engine/cardinal/ecs/log"
-	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 	"pkg.world.dev/world-engine/cardinal/server"
 	"pkg.world.dev/world-engine/sign"
 )
@@ -192,7 +190,7 @@ func TestShutDownViaSignal(t *testing.T) {
 	w := ecs.NewTestWorld(t)
 	sendTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult]("sendTx")
 	assert.NilError(t, w.RegisterTransactions(sendTx))
-	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
+	w.AddSystem(func(ecs.WorldContext) error {
 		return nil
 	})
 	assert.NilError(t, w.LoadGameState())
@@ -291,8 +289,8 @@ func TestHandleTransactionWithNoSignatureVerification(t *testing.T) {
 	sendTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult](endpoint)
 	assert.NilError(t, w.RegisterTransactions(sendTx))
 	count := 0
-	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		txs := sendTx.In(queue)
+	w.AddSystem(func(wCtx ecs.WorldContext) error {
+		txs := sendTx.In(wCtx)
 		assert.Equal(t, 1, len(txs))
 		tx := txs[0]
 		assert.Equal(t, tx.Value.From, "me")
@@ -348,17 +346,18 @@ func TestHandleSwaggerServer(t *testing.T) {
 	w := ecs.NewTestWorld(t)
 	sendTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult]("send-energy")
 	assert.NilError(t, w.RegisterTransactions(sendTx))
-	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
+	w.AddSystem(func(ecs.WorldContext) error {
 		return nil
 	})
 
 	assert.NilError(t, ecs.RegisterComponent[garbageStructAlpha](w))
 	assert.NilError(t, ecs.RegisterComponent[garbageStructBeta](w))
 	alphaCount := 75
-	_, err := component.CreateMany(w, alphaCount, garbageStructAlpha{})
+	wCtx := ecs.NewWorldContext(w)
+	_, err := component.CreateMany(wCtx, alphaCount, garbageStructAlpha{})
 	assert.NilError(t, err)
 	bothCount := 100
-	_, err = component.CreateMany(w, bothCount, garbageStructAlpha{}, garbageStructBeta{})
+	_, err = component.CreateMany(wCtx, bothCount, garbageStructAlpha{}, garbageStructBeta{})
 	assert.NilError(t, err)
 
 	// Queue up a CreatePersonaTx
@@ -544,8 +543,8 @@ func TestHandleWrappedTransactionWithNoSignatureVerification(t *testing.T) {
 	w := ecs.NewTestWorld(t)
 	sendTx := ecs.NewTransactionType[SendEnergyTx, SendEnergyTxResult](endpoint)
 	assert.NilError(t, w.RegisterTransactions(sendTx))
-	w.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		txs := sendTx.In(queue)
+	w.AddSystem(func(wCtx ecs.WorldContext) error {
+		txs := sendTx.In(wCtx)
 		assert.Equal(t, 1, len(txs))
 		tx := txs[0]
 		assert.Equal(t, tx.Value.From, "me")
@@ -950,18 +949,18 @@ func TestCanGetTransactionReceiptsSwagger(t *testing.T) {
 	world := ecs.NewTestWorld(t)
 	assert.NilError(t, world.RegisterTransactions(incTx, dupeTx, errTx))
 	// System to handle incrementing numbers
-	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		for _, tx := range incTx.In(queue) {
-			incTx.SetResult(world, tx.TxHash, IncReply{
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
+		for _, tx := range incTx.In(wCtx) {
+			incTx.SetResult(wCtx, tx.TxHash, IncReply{
 				Number: tx.Value.Number + 1,
 			})
 		}
 		return nil
 	})
 	// System to handle duplicating strings
-	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		for _, tx := range dupeTx.In(queue) {
-			dupeTx.SetResult(world, tx.TxHash, DupeReply{
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
+		for _, tx := range dupeTx.In(wCtx) {
+			dupeTx.SetResult(wCtx, tx.TxHash, DupeReply{
 				Str: tx.Value.Str + tx.Value.Str,
 			})
 		}
@@ -969,10 +968,10 @@ func TestCanGetTransactionReceiptsSwagger(t *testing.T) {
 	})
 	wantError := errors.New("some error")
 	// System to handle error production
-	world.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, _ *log.Logger) error {
-		for _, tx := range errTx.In(queue) {
-			errTx.AddError(world, tx.TxHash, wantError)
-			errTx.AddError(world, tx.TxHash, wantError)
+	world.AddSystem(func(wCtx ecs.WorldContext) error {
+		for _, tx := range errTx.In(wCtx) {
+			errTx.AddError(wCtx, tx.TxHash, wantError)
+			errTx.AddError(wCtx, tx.TxHash, wantError)
 		}
 		return nil
 	})

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -387,7 +387,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 		Name: "Chad",
 		Age:  22,
 	}
-	fooQuery := ecs.NewQueryType[FooRequest, FooReply]("foo", func(world *ecs.World, req FooRequest) (FooReply, error) {
+	fooQuery := ecs.NewQueryType[FooRequest, FooReply]("foo", func(wCtx ecs.WorldContext, req FooRequest) (FooReply, error) {
 		return expectedReply, nil
 	})
 	assert.NilError(t, w.RegisterQueries(fooQuery))
@@ -753,14 +753,14 @@ func TestCanListQueries(t *testing.T) {
 		Meow string `json:"meow,omitempty"`
 	}
 
-	fooQuery := ecs.NewQueryType[FooRequest, FooResponse]("foo", func(world *ecs.World, req FooRequest) (FooResponse, error) {
+	fooQuery := ecs.NewQueryType[FooRequest, FooResponse]("foo", func(wCtx ecs.WorldContext, req FooRequest) (FooResponse, error) {
 		return FooResponse{Meow: req.Meow}, nil
 	})
-	barQuery := ecs.NewQueryType[FooRequest, FooResponse]("bar", func(world *ecs.World, req FooRequest) (FooResponse, error) {
+	barQuery := ecs.NewQueryType[FooRequest, FooResponse]("bar", func(wCtx ecs.WorldContext, req FooRequest) (FooResponse, error) {
 
 		return FooResponse{Meow: req.Meow}, nil
 	})
-	bazQuery := ecs.NewQueryType[FooRequest, FooResponse]("baz", func(world *ecs.World, req FooRequest) (FooResponse, error) {
+	bazQuery := ecs.NewQueryType[FooRequest, FooResponse]("baz", func(wCtx ecs.WorldContext, req FooRequest) (FooResponse, error) {
 		return FooResponse{Meow: req.Meow}, nil
 	})
 
@@ -804,7 +804,7 @@ func TestQueryEncodeDecode(t *testing.T) {
 	type FooResponse struct {
 		Meow string `json:"meow,omitempty"`
 	}
-	fq := ecs.NewQueryType[FooRequest, FooResponse](endpoint, func(world *ecs.World, req FooRequest) (FooResponse, error) {
+	fq := ecs.NewQueryType[FooRequest, FooResponse](endpoint, func(wCtx ecs.WorldContext, req FooRequest) (FooResponse, error) {
 		return FooResponse{Meow: req.Meow}, nil
 	})
 

--- a/cardinal/transaction.go
+++ b/cardinal/transaction.go
@@ -58,13 +58,13 @@ func (t *TransactionType[Msg, Result]) SetResult(world *World, hash TxHash, resu
 
 // GetReceipt returns the result (if any) and errors (if any) associated with the given hash. If false is returned,
 // the hash is not recognized, so the returned result and errors will be empty.
-func (t *TransactionType[Msg, Result]) GetReceipt(world *World, hash TxHash) (r Result, errs []error, ok bool) {
-	return t.impl.GetReceipt(world.implWorld, hash)
+func (t *TransactionType[Msg, Result]) GetReceipt(wCtx WorldContext, hash TxHash) (r Result, errs []error, ok bool) {
+	return t.impl.GetReceipt(wCtx, hash)
 }
 
 // In returns the transactions in the given transaction queue that match this transaction's type.
-func (t *TransactionType[Msg, Result]) In(tq *TransactionQueue) []TxData[Msg] {
-	ecsTxData := t.impl.In(tq.impl)
+func (t *TransactionType[Msg, Result]) In(wCtx WorldContext) []TxData[Msg] {
+	ecsTxData := t.impl.In(wCtx)
 	out := make([]TxData[Msg], 0, len(ecsTxData))
 	for _, tx := range ecsTxData {
 		out = append(out, TxData[Msg]{

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -12,7 +12,6 @@ import (
 	"pkg.world.dev/world-engine/cardinal/ecs/component_metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/ecb"
 	"pkg.world.dev/world-engine/cardinal/ecs/entity"
-	ecslog "pkg.world.dev/world-engine/cardinal/ecs/log"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/cardinal/ecs/transaction"
 	"pkg.world.dev/world-engine/cardinal/server"
@@ -31,13 +30,14 @@ type World struct {
 type (
 	// EntityID represents a single entity in the World. An EntityID is tied to
 	// one or more components.
-	EntityID = entity.ID
-	TxHash   = transaction.TxHash
+	EntityID     = entity.ID
+	TxHash       = transaction.TxHash
+	WorldContext = ecs.WorldContext
 
 	// System is a function that process the transaction in the given transaction queue.
 	// Systems are automatically called during a world tick, and they must be registered
 	// with a world using AddSystem or AddSystems.
-	System func(*World, *TransactionQueue, *Logger) error
+	System func(WorldContext) error
 )
 
 // NewWorld creates a new World object using Redis as the storage layer.
@@ -99,39 +99,39 @@ func NewMockWorld(opts ...WorldOption) (*World, error) {
 
 // CreateMany creates multiple entities in the world, and returns the slice of ids for the newly created
 // entities. At least 1 component must be provided.
-func CreateMany(w *World, num int, components ...component_metadata.Component) ([]EntityID, error) {
-	return component.CreateMany(w.implWorld, num, components...)
+func CreateMany(wCtx WorldContext, num int, components ...component_metadata.Component) ([]EntityID, error) {
+	return component.CreateMany(wCtx, num, components...)
 }
 
 // Create creates a single entity in the world, and returns the id of the newly created entity.
 // At least 1 component must be provided.
-func Create(w *World, components ...component_metadata.Component) (EntityID, error) {
-	return component.Create(w.implWorld, components...)
+func Create(wCtx WorldContext, components ...component_metadata.Component) (EntityID, error) {
+	return component.Create(wCtx, components...)
 }
 
 // SetComponent Set sets component data to the entity.
-func SetComponent[T component_metadata.Component](w *World, id entity.ID, comp *T) error {
-	return component.SetComponent[T](w.implWorld, id, comp)
+func SetComponent[T component_metadata.Component](wCtx WorldContext, id entity.ID, comp *T) error {
+	return component.SetComponent[T](wCtx, id, comp)
 }
 
 // GetComponent Get returns component data from the entity.
-func GetComponent[T component_metadata.Component](w *World, id entity.ID) (comp *T, err error) {
-	return component.GetComponent[T](w.implWorld, id)
+func GetComponent[T component_metadata.Component](wCtx WorldContext, id entity.ID) (comp *T, err error) {
+	return component.GetComponent[T](wCtx, id)
 }
 
 // UpdateComponent Updates a component on an entity
-func UpdateComponent[T component_metadata.Component](w *World, id entity.ID, fn func(*T) *T) error {
-	return component.UpdateComponent[T](w.implWorld, id, fn)
+func UpdateComponent[T component_metadata.Component](wCtx WorldContext, id entity.ID, fn func(*T) *T) error {
+	return component.UpdateComponent[T](wCtx, id, fn)
 }
 
 // AddComponentTo Adds a component on an entity
-func AddComponentTo[T component_metadata.Component](w *World, id entity.ID) error {
-	return component.AddComponentTo[T](w.implWorld, id)
+func AddComponentTo[T component_metadata.Component](wCtx WorldContext, id entity.ID) error {
+	return component.AddComponentTo[T](wCtx, id)
 }
 
 // RemoveComponentFrom Removes a component from an entity
-func RemoveComponentFrom[T component_metadata.Component](w *World, id entity.ID) error {
-	return component.RemoveComponentFrom[T](w.implWorld, id)
+func RemoveComponentFrom[T component_metadata.Component](wCtx WorldContext, id entity.ID) error {
+	return component.RemoveComponentFrom[T](wCtx, id)
 }
 
 // Remove removes the given entity id from the world.
@@ -189,8 +189,8 @@ func (w *World) ShutDown() error {
 
 func RegisterSystems(w *World, systems ...System) {
 	for _, system := range systems {
-		w.implWorld.AddSystem(func(world *ecs.World, queue *transaction.TxQueue, logger *ecslog.Logger) error {
-			return system(&World{implWorld: world}, &TransactionQueue{queue}, &Logger{logger})
+		w.implWorld.AddSystem(func(wCtx WorldContext) error {
+			return system(wCtx)
 		})
 	}
 }
@@ -217,4 +217,9 @@ func (w *World) CurrentTick() uint64 {
 
 func (w *World) Tick(ctx context.Context) error {
 	return w.implWorld.Tick(ctx)
+}
+
+func (w *World) Init(fn func(WorldContext)) {
+	ecsWorldCtx := ecs.NewWorldContext(w.implWorld)
+	fn(ecsWorldCtx)
 }


### PR DESCRIPTION
Closes: #WORLD-408

## What is the purpose of the change

Adds a "WorldContext" object that wraps a reference to *World, a transaction queue, a logger, and whether we're in a "read-only" context (e.g. User defined queries should user a read only WorldContext). This will 1) make it impossible to modify the state inside of a user's query implementation and 2) data from the previously completed tick will be returned instead of the mid-tick state.

The middle commit: "Fix tests for WorldContext" contains a large number of _test changes to accommodate the WorldContext; I suggesting focusing on the first and last commit.

## Brief Changelog

[Implement WorldContext non test files](https://github.com/Argus-Labs/world-engine/pull/330/commits/5229be7ab57901ec8d3293af3c72b53451cd33b8): Add the world_context.go source file that wraps a handful of ecs objects.

[Fix tests for WorldContext](https://github.com/Argus-Labs/world-engine/pull/330/commits/3f38d8b33a6ec27fce45d8f7dba45902e57f82cf): A large number of test file updates. No feature implementation is contained in this commit.

[Have queries use WorldContext](https://github.com/Argus-Labs/world-engine/pull/330/commits/ca20500f25b4f020deb99d1ae649531f6e41b361): Update query handlers to also use WorldContext. 

## Testing and Verifying

Existing unit and integration tests verify these changes.
