### PR TITLE
chore(cardinal): expose AddToQueue in Cardinal 

### DIFF
--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -649,6 +649,10 @@ func (w *World) NewSearch(filter Filterable) (*Search, error) {
 	return NewSearch(componentFilter), nil
 }
 
+func (w *World) AddToQueue(t *TransactionType[In, Out], data any, sigs ...*sign.SignedPayload) {
+	t.AddToQueue(w, data, sigs...)
+}
+
 func GetRawJsonOfComponent(w *World, component component_metadata.IComponentMetaData, id entity.ID) (json.RawMessage, error) {
 	return w.StoreManager().GetComponentForEntityInRawJson(component, id)
 }

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -649,10 +649,6 @@ func (w *World) NewSearch(filter Filterable) (*Search, error) {
 	return NewSearch(componentFilter), nil
 }
 
-func AddToQueue[In, Out any](w *World, t *TransactionType[In, Out], data In, sigs ...*sign.SignedPayload) {
-	t.AddToQueue(w, data, sigs...)
-}
-
 func GetRawJsonOfComponent(w *World, component component_metadata.IComponentMetaData, id entity.ID) (json.RawMessage, error) {
 	return w.StoreManager().GetComponentForEntityInRawJson(component, id)
 }

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -649,7 +649,7 @@ func (w *World) NewSearch(filter Filterable) (*Search, error) {
 	return NewSearch(componentFilter), nil
 }
 
-func (w *World) AddToQueue(t *TransactionType[In, Out], data any, sigs ...*sign.SignedPayload) {
+func AddToQueue[In, Out any](w *World, t *TransactionType[In, Out], data In, sigs ...*sign.SignedPayload) {
 	t.AddToQueue(w, data, sigs...)
 }
 

--- a/cardinal/transaction.go
+++ b/cardinal/transaction.go
@@ -44,8 +44,9 @@ func NewTransactionTypeWithEVMSupport[Msg, Result any](name string) *Transaction
 	}
 }
 
+// AddToQueue is not meant to be used in production whatsoever, it is exposed here for usage in tests.
 func (t *TransactionType[Msg, Result]) AddToQueue(world *World, data Msg, sigs ...*sign.SignedPayload) {
-	ecs.AddToQueue[Msg, Result](world.implWorld, t.impl, data, sigs...)
+	t.impl.AddToQueue(world.implWorld, data, sigs...)
 }
 
 // AddError adds the given error to the transaction identified by the given hash. Multiple errors can be

--- a/cardinal/transaction.go
+++ b/cardinal/transaction.go
@@ -44,6 +44,10 @@ func NewTransactionTypeWithEVMSupport[Msg, Result any](name string) *Transaction
 	}
 }
 
+func (t *TransactionType[Msg, Result]) AddToQueue(world *World, data Msg, sigs ...*sign.SignedPayload) {
+	world.implWorld.AddToQueue(t, data, sigs...)
+}
+
 // AddError adds the given error to the transaction identified by the given hash. Multiple errors can be
 // added to the same transaction hash.
 func (t *TransactionType[Msg, Result]) AddError(world *World, hash TxHash, err error) {

--- a/cardinal/transaction.go
+++ b/cardinal/transaction.go
@@ -45,7 +45,7 @@ func NewTransactionTypeWithEVMSupport[Msg, Result any](name string) *Transaction
 }
 
 func (t *TransactionType[Msg, Result]) AddToQueue(world *World, data Msg, sigs ...*sign.SignedPayload) {
-	world.implWorld.AddToQueue(t, data, sigs...)
+	ecs.AddToQueue[Msg, Result](world.implWorld, t.impl, data, sigs...)
 }
 
 // AddError adds the given error to the transaction identified by the given hash. Multiple errors can be


### PR DESCRIPTION
Closes: WORLD-431

## Brief Changelog

- [x] Expose `ecs/transaction.go`'s `AddToQueue` in `cardinal.World`

## Testing and Verifying

We are ignoring the fact that we don't have great tests for `cardinal.World` for the time being. 
