### PR TITLE
feat(cardinal): logger event hub

### DIFF
--- a/cardinal/ecs/options.go
+++ b/cardinal/ecs/options.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+	ecslog "pkg.world.dev/world-engine/cardinal/ecs/log"
 	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
 	"pkg.world.dev/world-engine/cardinal/ecs/store"
 	"pkg.world.dev/world-engine/cardinal/events"
@@ -44,8 +45,18 @@ func WithStoreManager(s store.IManager) Option {
 	}
 }
 
-func WithEventHub(eventHub *events.EventHub) Option {
+func WithWebSocketEventHub(eventHub *events.WebSocketEventHub) Option {
 	return func(w *World) {
 		w.eventHub = eventHub
+	}
+}
+
+func WithLoggingEventHub(logger *ecslog.Logger) Option {
+	return func(w *World) {
+		//because the logging event hub is for testing purposes it will only register itself if there isn't
+		//already another eventhub used by world.
+		if w.eventHub == nil {
+			w.eventHub = events.CreateLoggingEventHub(logger)
+		}
 	}
 }

--- a/cardinal/ecs/options.go
+++ b/cardinal/ecs/options.go
@@ -45,7 +45,7 @@ func WithStoreManager(s store.IManager) Option {
 	}
 }
 
-func WithWebSocketEventHub(eventHub *events.WebSocketEventHub) Option {
+func WithEventHub(eventHub events.EventHub) Option {
 	return func(w *World) {
 		w.eventHub = eventHub
 	}

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -90,6 +90,10 @@ func (w *World) EmitEvent(event *events.Event) {
 	w.eventHub.EmitEvent(event)
 }
 
+func (w *World) FlushEvents() {
+	w.eventHub.FlushEvents()
+}
+
 func (w *World) IsRecovering() bool {
 	return w.isRecovering
 }

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -82,7 +82,7 @@ var (
 	ErrorDuplicateQueryName                    = errors.New("query names must be unique")
 )
 
-func (w *World) SetEventHub(eventHub *events.WebSocketEventHub) {
+func (w *World) SetEventHub(eventHub events.EventHub) {
 	w.eventHub = eventHub
 }
 

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -72,7 +72,7 @@ type World struct {
 
 	nextComponentID component_metadata.TypeID
 
-	eventHub *events.EventHub
+	eventHub events.EventHub
 }
 
 var (
@@ -82,7 +82,7 @@ var (
 	ErrorDuplicateQueryName                    = errors.New("query names must be unique")
 )
 
-func (w *World) SetEventHub(eventHub *events.EventHub) {
+func (w *World) SetEventHub(eventHub *events.WebSocketEventHub) {
 	w.eventHub = eventHub
 }
 

--- a/cardinal/events/events.go
+++ b/cardinal/events/events.go
@@ -20,7 +20,7 @@ type EventHub interface {
 	Run()
 }
 
-type LoggingEventHub struct {
+type loggingEventHub struct {
 	logger     *ecslog.Logger
 	eventQueue []*Event
 	running    atomic.Bool
@@ -29,15 +29,15 @@ type LoggingEventHub struct {
 	flush      chan bool
 }
 
-func (eh *LoggingEventHub) EmitEvent(event *Event) {
+func (eh *loggingEventHub) EmitEvent(event *Event) {
 	eh.broadcast <- event
 }
 
-func (eh *LoggingEventHub) FlushEvents() {
+func (eh *loggingEventHub) FlushEvents() {
 	eh.flush <- true
 }
 
-func (eh *LoggingEventHub) Run() {
+func (eh *loggingEventHub) Run() {
 	if eh.running.Load() {
 		return
 	}
@@ -66,12 +66,12 @@ func (eh *LoggingEventHub) Run() {
 	}
 }
 
-func (eh *LoggingEventHub) ShutdownEventHub() {
+func (eh *loggingEventHub) ShutdownEventHub() {
 	eh.shutdown <- true
 }
 
-func CreateLoggingEventHub(logger *ecslog.Logger) *LoggingEventHub {
-	res := LoggingEventHub{
+func CreateLoggingEventHub(logger *ecslog.Logger) *loggingEventHub {
+	res := loggingEventHub{
 		eventQueue: make([]*Event, 0),
 		running:    atomic.Bool{},
 		broadcast:  make(chan *Event),

--- a/cardinal/events/events.go
+++ b/cardinal/events/events.go
@@ -1,6 +1,7 @@
 package events
 
 import (
+	"fmt"
 	"net/http"
 	"sync"
 	"sync/atomic"
@@ -29,15 +30,15 @@ type LoggingEventHub struct {
 }
 
 func (eh *LoggingEventHub) EmitEvent(event *Event) {
-	go func() {
-		eh.broadcast <- event
-	}()
+	//go func() {
+	eh.broadcast <- event
+	//}()
 }
 
 func (eh *LoggingEventHub) FlushEvents() {
-	go func() {
-		eh.flush <- true
-	}()
+	//go func() {
+	eh.flush <- true
+	//}()
 }
 
 func (eh *LoggingEventHub) Run() {
@@ -54,12 +55,15 @@ func (eh *LoggingEventHub) Run() {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
+				acc := 0
 				for _, event := range eh.eventQueue {
-					event := event
 					eh.logger.Info().Msg(event.Message)
+					acc += 1
 				}
+				fmt.Printf("called %d times\n", acc)
 			}() //a goroutine is not technically necessary here but this imitates the websocket eventhub as much as possible.
 			wg.Wait()
+			eh.eventQueue = eh.eventQueue[:0]
 		case <-eh.shutdown:
 			eh.running.Store(false)
 		}
@@ -119,15 +123,15 @@ type WebSocketEventHub struct {
 }
 
 func (eh *WebSocketEventHub) EmitEvent(event *Event) {
-	go func() {
-		eh.broadcast <- event
-	}()
+	//go func() {
+	eh.broadcast <- event
+	//}()
 }
 
 func (eh *WebSocketEventHub) FlushEvents() {
-	go func() {
-		eh.flush <- true
-	}()
+	//go func() {
+	eh.flush <- true
+	//}()
 }
 
 func (eh *WebSocketEventHub) RegisterConnection(ws *websocket.Conn) {

--- a/cardinal/events/events.go
+++ b/cardinal/events/events.go
@@ -30,15 +30,11 @@ type LoggingEventHub struct {
 }
 
 func (eh *LoggingEventHub) EmitEvent(event *Event) {
-	//go func() {
 	eh.broadcast <- event
-	//}()
 }
 
 func (eh *LoggingEventHub) FlushEvents() {
-	//go func() {
 	eh.flush <- true
-	//}()
 }
 
 func (eh *LoggingEventHub) Run() {
@@ -123,15 +119,11 @@ type WebSocketEventHub struct {
 }
 
 func (eh *WebSocketEventHub) EmitEvent(event *Event) {
-	//go func() {
 	eh.broadcast <- event
-	//}()
 }
 
 func (eh *WebSocketEventHub) FlushEvents() {
-	//go func() {
 	eh.flush <- true
-	//}()
 }
 
 func (eh *WebSocketEventHub) RegisterConnection(ws *websocket.Conn) {

--- a/cardinal/events/events_test.go
+++ b/cardinal/events/events_test.go
@@ -159,7 +159,6 @@ func TestEventHubLogger(t *testing.T) {
 	w := ecs.NewTestWorld(t, ecs.WithLoggingEventHub(&cardinalLogger))
 	numberToTest := 5
 	for i := 0; i < numberToTest; i++ {
-		//i := i
 		w.AddSystem(func(wCtx ecs.WorldContext) error {
 			wCtx.GetWorld().EmitEvent(&events.Event{Message: fmt.Sprintf("test")})
 			return nil

--- a/cardinal/events/events_test.go
+++ b/cardinal/events/events_test.go
@@ -166,16 +166,10 @@ func TestEventHubLogger(t *testing.T) {
 	}
 	assert.NilError(t, w.LoadGameState())
 	ctx := context.Background()
-	waitForTicks := sync.WaitGroup{}
-	waitForTicks.Add(1)
-	go func() {
-		defer waitForTicks.Done()
-		for i := 0; i < numberToTest; i++ {
-			err := w.Tick(ctx)
-			assert.NilError(t, err)
-		}
-	}()
-	waitForTicks.Wait()
+	for i := 0; i < numberToTest; i++ {
+		err := w.Tick(ctx)
+		assert.NilError(t, err)
+	}
 	testString := "{\"level\":\"info\",\"message\":\"test\"}\n"
 	eventsLogs := buf.String()
 	splitLogs := strings.Split(eventsLogs, "\n")

--- a/cardinal/events/events_test.go
+++ b/cardinal/events/events_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/gorilla/websocket"
 	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/require"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	ecslog "pkg.world.dev/world-engine/cardinal/ecs/log"
 	"pkg.world.dev/world-engine/cardinal/events"
@@ -157,8 +159,9 @@ func TestEventHubLogger(t *testing.T) {
 	w := ecs.NewTestWorld(t, ecs.WithLoggingEventHub(&cardinalLogger))
 	numberToTest := 5
 	for i := 0; i < numberToTest; i++ {
+		//i := i
 		w.AddSystem(func(wCtx ecs.WorldContext) error {
-			wCtx.GetWorld().EmitEvent(&events.Event{Message: "test"})
+			wCtx.GetWorld().EmitEvent(&events.Event{Message: fmt.Sprintf("test")})
 			return nil
 		})
 	}
@@ -175,8 +178,11 @@ func TestEventHubLogger(t *testing.T) {
 	}()
 	waitForTicks.Wait()
 	testString := "{\"level\":\"info\",\"message\":\"test\"}\n"
-	acc := ""
-	for i := 0; i < numberToTest*numberToTest; i++ {
-		acc += testString
+	eventsLogs := buf.String()
+	splitLogs := strings.Split(eventsLogs, "\n")
+	splitLogs = splitLogs[:len(splitLogs)-1]
+	assert.Equal(t, 25, len(splitLogs))
+	for _, logEntry := range splitLogs {
+		require.JSONEq(t, testString, logEntry)
 	}
 }

--- a/cardinal/events/events_test.go
+++ b/cardinal/events/events_test.go
@@ -170,7 +170,7 @@ func TestEventHubLogger(t *testing.T) {
 		err := w.Tick(ctx)
 		assert.NilError(t, err)
 	}
-	testString := "{\"level\":\"info\",\"message\":\"test\"}\n"
+	testString := "{\"level\":\"info\",\"message\":\"EVENT: test\"}\n"
 	eventsLogs := buf.String()
 	splitLogs := strings.Split(eventsLogs, "\n")
 	splitLogs = splitLogs[:len(splitLogs)-1]

--- a/cardinal/test_utils/test_utils.go
+++ b/cardinal/test_utils/test_utils.go
@@ -70,7 +70,7 @@ type TestTransactionHandler struct {
 	*server.Handler
 	T        *testing.T
 	Host     string
-	EventHub *events.WebSocketEventHub
+	EventHub events.EventHub
 }
 
 func (t *TestTransactionHandler) MakeHttpURL(path string) string {

--- a/cardinal/test_utils/test_utils.go
+++ b/cardinal/test_utils/test_utils.go
@@ -17,7 +17,7 @@ import (
 func MakeTestTransactionHandler(t *testing.T, world *ecs.World, opts ...server.Option) *TestTransactionHandler {
 	port := "4040"
 	opts = append(opts, server.WithPort(port))
-	eventHub := events.CreateEventHub()
+	eventHub := events.CreateWebSocketEventHub()
 	world.SetEventHub(eventHub)
 	eventBuilder := events.CreateNewWebSocketBuilder("/events", events.CreateWebSocketEventHandler(eventHub))
 	txh, err := server.NewHandler(world, eventBuilder, opts...)
@@ -70,7 +70,7 @@ type TestTransactionHandler struct {
 	*server.Handler
 	T        *testing.T
 	Host     string
-	EventHub *events.EventHub
+	EventHub *events.WebSocketEventHub
 }
 
 func (t *TestTransactionHandler) MakeHttpURL(path string) string {

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -67,7 +67,7 @@ func NewWorld(addr, password string, opts ...WorldOption) (*World, error) {
 	}
 
 	eventHub := events.CreateWebSocketEventHub()
-	ecsOptions = append(ecsOptions, ecs.WithWebSocketEventHub(eventHub))
+	ecsOptions = append(ecsOptions, ecs.WithEventHub(eventHub))
 
 	ecsWorld, err := ecs.NewWorld(worldStorage, storeManager, ecsOptions...)
 	if err != nil {
@@ -96,7 +96,7 @@ func NewWorld(addr, password string, opts ...WorldOption) (*World, error) {
 func NewMockWorld(opts ...WorldOption) (*World, error) {
 	ecsOptions, serverOptions, cardinalOptions := separateOptions(opts)
 	eventHub := events.CreateWebSocketEventHub()
-	ecsOptions = append(ecsOptions, ecs.WithWebSocketEventHub(eventHub))
+	ecsOptions = append(ecsOptions, ecs.WithEventHub(eventHub))
 	world := &World{
 		implWorld:     ecs.NewMockWorld(ecsOptions...),
 		serverOptions: serverOptions,

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -3,9 +3,10 @@ package cardinal
 import (
 	"context"
 	"errors"
-	"pkg.world.dev/world-engine/cardinal/evm"
 	"sync/atomic"
 	"time"
+
+	"pkg.world.dev/world-engine/cardinal/evm"
 
 	"github.com/rs/zerolog/log"
 	"pkg.world.dev/world-engine/cardinal/ecs"
@@ -65,8 +66,8 @@ func NewWorld(addr, password string, opts ...WorldOption) (*World, error) {
 		return nil, err
 	}
 
-	eventHub := events.CreateEventHub()
-	ecsOptions = append(ecsOptions, ecs.WithEventHub(eventHub))
+	eventHub := events.CreateWebSocketEventHub()
+	ecsOptions = append(ecsOptions, ecs.WithWebSocketEventHub(eventHub))
 
 	ecsWorld, err := ecs.NewWorld(worldStorage, storeManager, ecsOptions...)
 	if err != nil {
@@ -94,8 +95,8 @@ func NewWorld(addr, password string, opts ...WorldOption) (*World, error) {
 // This is only suitable for local development.
 func NewMockWorld(opts ...WorldOption) (*World, error) {
 	ecsOptions, serverOptions, cardinalOptions := separateOptions(opts)
-	eventHub := events.CreateEventHub()
-	ecsOptions = append(ecsOptions, ecs.WithEventHub(eventHub))
+	eventHub := events.CreateWebSocketEventHub()
+	ecsOptions = append(ecsOptions, ecs.WithWebSocketEventHub(eventHub))
 	world := &World{
 		implWorld:     ecs.NewMockWorld(ecsOptions...),
 		serverOptions: serverOptions,


### PR DESCRIPTION
Closes: #439

## What is the purpose of the change

Adds a new EventHub to the engine. 

EventHub has been changed to WebSocketEventHub and now an Interface called EventHub has replaced its existence in ecs.world. 

Fixed a subtle race condition bug involving OOM. See EmitEvent and FlushEvents. removed go routines. 

## Brief Changelog

Created new option called WithLoggingEventHub allowing us to inject in a EventHubLogger
Changed EventHub to WebSocketEventHub
Created New interface called EventHub
Created New LoggingEventHub

Event broadcasting and event flushing were sent to go routines This could actually cause a memory leak where the game loop spun faster than the EventHub loop. If this occured the go routines would pile up as the game loop would emit events faster than the EventHub loop could handle it, thus blocked go routines will slowly accumulate until OOM. 

removed go routines but this means EventHub slows down the main game loop. Additionally if the client doesn't read the socket now, it can block the entire loop for a little bit. 

## Testing and Verifying

Created new test that shows how it works. 
