### PR TITLE
chore(cardinal): expose ForEach on cardinal.TransactionType

### DIFF
--- a/cardinal/transaction.go
+++ b/cardinal/transaction.go
@@ -63,7 +63,11 @@ func (t *TransactionType[Msg, Result]) GetReceipt(wCtx WorldContext, hash TxHash
 }
 
 func (t *TransactionType[Msg, Result]) ForEach(wCtx WorldContext, fn func(TxData[Msg]) (Result, error)) {
-	t.impl.ForEach(wCtx.getECSWorldContext(), fn)
+	adapterFn := func(ecsTxData ecs.TxData[Msg]) (Result, error) {
+		adaptedTx := TxData[Msg]{impl: ecsTxData}
+		return fn(adaptedTx)
+	}
+	t.impl.ForEach(wCtx.getECSWorldContext(), adapterFn)
 }
 
 // In returns the transactions in the given transaction queue that match this transaction's type.

--- a/cardinal/transaction.go
+++ b/cardinal/transaction.go
@@ -62,6 +62,10 @@ func (t *TransactionType[Msg, Result]) GetReceipt(wCtx WorldContext, hash TxHash
 	return t.impl.GetReceipt(wCtx.getECSWorldContext(), hash)
 }
 
+func (t *TransactionType[Msg, Result]) ForEach(wCtx WorldContext, fn func(TxData[Msg]) (Result, error)) {
+	t.impl.ForEach(wCtx.getECSWorldContext(), fn)
+}
+
 // In returns the transactions in the given transaction queue that match this transaction's type.
 func (t *TransactionType[Msg, Result]) In(wCtx WorldContext) []TxData[Msg] {
 	ecsTxData := t.impl.In(wCtx.getECSWorldContext())


### PR DESCRIPTION
Closes: WORLD-441

## What is the purpose of the change

- We need to expose ForEach on cardinal.TransactionType so users can use the Tx Iterator functionality via Cardinal and without ecs.

## Testing and Verifying

We are ignoring tests related to `cardinal.World` for the time being. [redacted] is the test.

