### PR TITLE
chore(cardinal): make these methods use wCtx.

### DIFF
--- a/cardinal/example_transactiontype_test.go
+++ b/cardinal/example_transactiontype_test.go
@@ -36,13 +36,13 @@ func ExampleTransactionType() {
 			// ...
 
 			// save the result
-			MoveTx.SetResult(world, tx.Hash(), MovePlayerResult{
+			MoveTx.SetResult(wCtx, tx.Hash(), MovePlayerResult{
 				FinalX: msg.DeltaX,
 				FinalY: msg.DeltaY,
 			})
 
 			// optionally, add an error to the transaction
-			MoveTx.AddError(world, tx.Hash(), errors.New("some error"))
+			MoveTx.AddError(wCtx, tx.Hash(), errors.New("some error"))
 		}
 		return nil
 	})

--- a/cardinal/transaction.go
+++ b/cardinal/transaction.go
@@ -51,14 +51,14 @@ func (t *TransactionType[Msg, Result]) AddToQueue(world *World, data Msg, sigs .
 
 // AddError adds the given error to the transaction identified by the given hash. Multiple errors can be
 // added to the same transaction hash.
-func (t *TransactionType[Msg, Result]) AddError(world *World, hash TxHash, err error) {
-	world.implWorld.AddTransactionError(hash, err)
+func (t *TransactionType[Msg, Result]) AddError(wCtx WorldContext, hash TxHash, err error) {
+	t.AddError(wCtx, hash, err)
 }
 
 // SetResult sets the result of the transaction identified by the given hash. Only one result may be associated
 // with a transaction hash, so calling this multiple times will clobber previously set results.
-func (t *TransactionType[Msg, Result]) SetResult(world *World, hash TxHash, result Result) {
-	world.implWorld.SetTransactionResult(hash, result)
+func (t *TransactionType[Msg, Result]) SetResult(wCtx WorldContext, hash TxHash, result Result) {
+	t.SetResult(wCtx, hash, result)
 }
 
 // GetReceipt returns the result (if any) and errors (if any) associated with the given hash. If false is returned,


### PR DESCRIPTION
Doesn't close any tickets. We missed a couple of methods for worldContext. 
