### PR TITLE
test(cardinal): Add test samples to cardinal package and extend test_utils package

### DIFF
--- a/cardinal/component_test.go
+++ b/cardinal/component_test.go
@@ -1,0 +1,90 @@
+package cardinal_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+type Height struct {
+	Inches int
+}
+
+func (Height) Name() string { return "height" }
+
+type Weight struct {
+	Pounds int
+}
+
+func (Weight) Name() string { return "weight" }
+
+type Age struct {
+	Years int
+}
+
+func (Age) Name() string { return "age" }
+
+func TestComponentExample(t *testing.T) {
+	world, _ := makeWorldAndTicker(t)
+
+	assert.NilError(t, cardinal.RegisterComponent[Height](world))
+	assert.NilError(t, cardinal.RegisterComponent[Weight](world))
+	assert.NilError(t, cardinal.RegisterComponent[Age](world))
+
+	testWorldCtx := test_utils.WorldToWorldContext(world)
+	startHeight := 72
+	startWeight := 200
+	startAge := 30
+
+	peopleIDs, err := cardinal.CreateMany(testWorldCtx, 10, Height{startHeight}, Weight{startWeight}, Age{startAge})
+	assert.NilError(t, err)
+
+	targetID := peopleIDs[4]
+	height, err := cardinal.GetComponent[Height](testWorldCtx, targetID)
+	assert.NilError(t, err)
+	assert.Equal(t, startHeight, height.Inches)
+
+	assert.NilError(t, cardinal.RemoveComponentFrom[Age](testWorldCtx, targetID))
+
+	// Age was removed form exactly 1 entity.
+	search, err := testWorldCtx.NewSearch(cardinal.Exact(Height{}, Weight{}))
+	assert.NilError(t, err)
+	count, err := search.Count(testWorldCtx)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, count)
+
+	// The rest of the entities still have the Age field.
+	search, err = testWorldCtx.NewSearch(cardinal.Contains(Age{}))
+	assert.NilError(t, err)
+	count, err = search.Count(testWorldCtx)
+	assert.NilError(t, err)
+	assert.Equal(t, len(peopleIDs)-1, count)
+
+	// Age does not exist on the target ID, so this should result in an error
+	err = cardinal.UpdateComponent[Age](testWorldCtx, targetID, func(a *Age) *Age {
+		return a
+	})
+	assert.Check(t, err != nil)
+
+	heavyWeight := 999
+	err = cardinal.UpdateComponent[Weight](testWorldCtx, targetID, func(w *Weight) *Weight {
+		w.Pounds = heavyWeight
+		return w
+	})
+	assert.NilError(t, err)
+
+	// Adding the Age component to the targetID should not change the weight component
+	assert.NilError(t, cardinal.AddComponentTo[Age](testWorldCtx, targetID))
+
+	for _, id := range peopleIDs {
+		weight, err := cardinal.GetComponent[Weight](testWorldCtx, id)
+		assert.NilError(t, err)
+		if id == targetID {
+			assert.Equal(t, heavyWeight, weight.Pounds)
+		} else {
+			assert.Equal(t, startWeight, weight.Pounds)
+		}
+	}
+}

--- a/cardinal/ecs/mock_world.go
+++ b/cardinal/ecs/mock_world.go
@@ -16,7 +16,7 @@ import (
 // NewMockWorld creates an ecs.World that uses a mock redis DB as the storage
 // layer. This is only suitable for local development. If you are creating an ecs.World for
 // unit tests, use NewTestWorld.
-func NewMockWorld(opts ...Option) *World {
+func NewMockWorld(opts ...Option) (world *World, cleanup func()) {
 	// We manually set the start address to make the port deterministic
 	s := miniredis.NewMiniRedis()
 	err := s.StartAddr(":12345")
@@ -30,7 +30,9 @@ func NewMockWorld(opts ...Option) *World {
 		panic(fmt.Errorf("unable to initialize world: %w", err))
 	}
 
-	return w
+	return w, func() {
+		s.Close()
+	}
 }
 
 // NewTestWorld creates an ecs.World suitable for running in tests. Relevant resources

--- a/cardinal/evm/server.go
+++ b/cardinal/evm/server.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net"
 	"os"
+
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/entity"
@@ -38,6 +39,7 @@ type Server interface {
 	routerv1.MsgServer
 	// Serve serves the application in a new go routine.
 	Serve() error
+	Shutdown()
 }
 
 // txByID maps transaction type ID's to transaction types.
@@ -57,6 +59,8 @@ type msgServerImpl struct {
 	// opts
 	creds credentials.TransportCredentials
 	port  string
+
+	shutdown func()
 }
 
 // NewServer returns a new EVM connection server. This server is responsible for handling requests originating from
@@ -168,7 +172,14 @@ func (s *msgServerImpl) Serve() error {
 			log.Fatal(err)
 		}
 	}()
+	s.shutdown = server.GracefulStop
 	return nil
+}
+
+func (s *msgServerImpl) Shutdown() {
+	if s.shutdown != nil {
+		s.shutdown()
+	}
 }
 
 const (

--- a/cardinal/query.go
+++ b/cardinal/query.go
@@ -42,3 +42,12 @@ func NewQueryTypeWithEVMSupport[Request, Reply any](name string, handler func(Wo
 func (r *QueryType[Request, Reply]) Convert() ecs.IQuery {
 	return r.impl
 }
+
+func (q *QueryType[Request, Reply]) DoQuery(worldCtx WorldContext, req Request) (reply Reply, err error) {
+	iface, err := q.impl.HandleQuery(worldCtx.getECSWorldContext(), req)
+	if err != nil {
+		return reply, err
+	}
+	reply = iface.(Reply)
+	return reply, nil
+}

--- a/cardinal/query_test.go
+++ b/cardinal/query_test.go
@@ -1,0 +1,75 @@
+package cardinal_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+type QueryHealthRequest struct {
+	Min int
+}
+
+type QueryHealthResponse struct {
+	IDs []cardinal.EntityID
+}
+
+func handleQueryHealth(worldCtx cardinal.WorldContext, request *QueryHealthRequest) (*QueryHealthResponse, error) {
+	q, err := worldCtx.NewSearch(cardinal.Exact(Health{}))
+	if err != nil {
+		return nil, err
+	}
+	resp := &QueryHealthResponse{}
+	err = q.Each(worldCtx, func(id cardinal.EntityID) bool {
+		health, err := cardinal.GetComponent[Health](worldCtx, id)
+		if err != nil {
+			return true
+		}
+		if health.Value < request.Min {
+			return true
+		}
+		resp.IDs = append(resp.IDs, id)
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+var queryHealth = cardinal.NewQueryType[*QueryHealthRequest, *QueryHealthResponse]("query_health", handleQueryHealth)
+
+func TestQueryExample(t *testing.T) {
+	world, _ := makeWorldAndTicker(t)
+	assert.NilError(t, cardinal.RegisterComponent[Health](world))
+	assert.NilError(t, cardinal.RegisterQueries(world, queryHealth))
+	go world.StartGame()
+
+	worldCtx := test_utils.WorldToWorldContext(world)
+	ids, err := cardinal.CreateMany(worldCtx, 100, Health{})
+	assert.NilError(t, err)
+	// Give each new entity health based on the ever-increasing index
+	for i, id := range ids {
+		assert.NilError(t, cardinal.UpdateComponent[Health](worldCtx, id, func(h *Health) *Health {
+			h.Value = i
+			return h
+		}))
+	}
+
+	// No entities should have health over a million.
+	resp, err := queryHealth.DoQuery(worldCtx, &QueryHealthRequest{1_000_000})
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(resp.IDs))
+
+	// All entities should have health over -100
+	resp, err = queryHealth.DoQuery(worldCtx, &QueryHealthRequest{-100})
+	assert.NilError(t, err)
+	assert.Equal(t, 100, len(resp.IDs))
+
+	// Exactly 10 entities should have health at or above 90
+	resp, err = queryHealth.DoQuery(worldCtx, &QueryHealthRequest{90})
+	assert.NilError(t, err)
+	assert.Equal(t, 10, len(resp.IDs))
+}

--- a/cardinal/search_test.go
+++ b/cardinal/search_test.go
@@ -1,0 +1,82 @@
+package cardinal_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+type Alpha struct{}
+
+func (Alpha) Name() string { return "alpha" }
+
+type Beta struct{}
+
+func (Beta) Name() string { return "beta" }
+
+type Gamma struct{}
+
+func (Gamma) Name() string { return "gamma" }
+
+func TestSearchExample(t *testing.T) {
+	world, _ := makeWorldAndTicker(t)
+	assert.NilError(t, cardinal.RegisterComponent[Alpha](world))
+	assert.NilError(t, cardinal.RegisterComponent[Beta](world))
+	assert.NilError(t, cardinal.RegisterComponent[Gamma](world))
+
+	worldCtx := test_utils.WorldToWorldContext(world)
+	_, err := cardinal.CreateMany(worldCtx, 10, Alpha{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Beta{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Gamma{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Alpha{}, Beta{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Alpha{}, Gamma{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Beta{}, Gamma{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Alpha{}, Beta{}, Gamma{})
+	assert.NilError(t, err)
+
+	testCases := []struct {
+		name   string
+		filter cardinal.Filter
+		want   int
+	}{
+		{
+			"exactly alpha",
+			cardinal.Exact(Alpha{}),
+			10,
+		},
+		{
+			"contains alpha",
+			cardinal.Contains(Alpha{}),
+			40,
+		},
+		{
+			"beta or gamma",
+			cardinal.Or(
+				cardinal.Exact(Beta{}),
+				cardinal.Exact(Gamma{}),
+			),
+			20,
+		},
+		{
+			"not alpha",
+			cardinal.Not(cardinal.Exact(Alpha{})),
+			60,
+		},
+	}
+	for _, tc := range testCases {
+		msg := "problem with " + tc.name
+		q, err := worldCtx.NewSearch(tc.filter)
+		assert.NilError(t, err, msg)
+		count, err := q.Count(worldCtx)
+		assert.NilError(t, err, msg)
+		assert.Equal(t, tc.want, count, msg)
+	}
+}

--- a/cardinal/system_test.go
+++ b/cardinal/system_test.go
@@ -1,0 +1,65 @@
+package cardinal_test
+
+import (
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+type Health struct {
+	Value int
+}
+
+func (Health) Name() string { return "health" }
+
+func HealthSystem(worldCtx cardinal.WorldContext) error {
+	q, err := worldCtx.NewSearch(cardinal.Exact(Health{}))
+	if err != nil {
+		return err
+	}
+	var errs []error
+	errs = append(errs, q.Each(worldCtx, func(id cardinal.EntityID) bool {
+		errs = append(errs, cardinal.UpdateComponent[Health](worldCtx, id, func(h *Health) *Health {
+			h.Value += 1
+			return h
+		}))
+		return true
+	}))
+	if err := errors.Join(errs...); err != nil {
+		return err
+	}
+	return err
+}
+
+func TestSystemExample(t *testing.T) {
+	world, doTick := makeWorldAndTicker(t)
+	assert.NilError(t, cardinal.RegisterComponent[Health](world))
+	cardinal.RegisterSystems(world, HealthSystem)
+
+	worldCtx := test_utils.WorldToWorldContext(world)
+	ids, err := cardinal.CreateMany(worldCtx, 100, Health{})
+	assert.NilError(t, err)
+	go world.StartGame()
+
+	// Make sure we have 100 entities all with a health of 0
+	for _, id := range ids {
+		health, err := cardinal.GetComponent[Health](worldCtx, id)
+		assert.NilError(t, err)
+		assert.Equal(t, 0, health.Value)
+	}
+
+	// do 5 ticks
+	for i := 0; i < 5; i++ {
+		doTick()
+	}
+
+	// Health should be 5 for everyone
+	for _, id := range ids {
+		health, err := cardinal.GetComponent[Health](worldCtx, id)
+		assert.NilError(t, err)
+		assert.Equal(t, 5, health.Value)
+	}
+}

--- a/cardinal/test_utils/test_utils.go
+++ b/cardinal/test_utils/test_utils.go
@@ -115,11 +115,7 @@ func SetTestTimeout(t *testing.T, timeout time.Duration) {
 }
 
 func WorldToWorldContext(world *cardinal.World) cardinal.WorldContext {
-	var stolenContext cardinal.WorldContext
-	world.Init(func(worldCtx cardinal.WorldContext) {
-		stolenContext = worldCtx
-	})
-	return stolenContext
+	return cardinal.TestingWorldToWorldContext(world)
 }
 
 var (
@@ -147,20 +143,7 @@ func uniqueSignature() *sign.SignedPayload {
 
 func AddTransactionToWorldByAnyTransaction(world *cardinal.World, cardinalTx cardinal.AnyTransaction, value any) {
 	worldCtx := WorldToWorldContext(world)
-	var ecsWorld *ecs.World
-
-	// There are two options for converting a cardinal.World into an ecs.World.
-
-	// Option A: Use a public method on the worldCtx object. This has the advantage that the "TestOnlyGetECSWorld"
-	// method does NOT show up in the godoc, however the type assertion is convoluted.
-	type HasTestOnlyGetECSWorld interface {
-		TestOnlyGetECSWorld() *ecs.World
-	}
-	ecsWorld = worldCtx.(HasTestOnlyGetECSWorld).TestOnlyGetECSWorld()
-
-	// Option B: Just make the conversion method a top level function. This method (and implementation details) are more
-	// direct, however this means the "TestOnlyGetECSWorld" method will appear in the godoc.
-	ecsWorld = cardinal.TestOnlyGetECSWorld(worldCtx)
+	ecsWorld := cardinal.TestingWorldContextToECSWorld(worldCtx)
 
 	txs, err := ecsWorld.ListTransactions()
 	if err != nil {

--- a/cardinal/testing.go
+++ b/cardinal/testing.go
@@ -1,0 +1,14 @@
+package cardinal
+
+import "pkg.world.dev/world-engine/cardinal/ecs"
+
+// This file contains helper methods that should only be used in the context of running tests.
+
+func TestingWorldToWorldContext(world *World) WorldContext {
+	ecsWorldCtx := ecs.NewWorldContext(world.implWorld)
+	return &worldContext{implContext: ecsWorldCtx}
+}
+
+func TestingWorldContextToECSWorld(worldCtx WorldContext) *ecs.World {
+	return worldCtx.getECSWorldContext().GetWorld()
+}

--- a/cardinal/transaction_test.go
+++ b/cardinal/transaction_test.go
@@ -1,0 +1,60 @@
+package cardinal_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+type AddHealthToEntityTx struct {
+	TargetID cardinal.EntityID
+	Amount   int
+}
+
+type AddHealthToEntityResult struct{}
+
+var addHealthToEntity = cardinal.NewTransactionType[AddHealthToEntityTx, AddHealthToEntityResult]("add_health")
+
+func TestTransactionExample(t *testing.T) {
+	world, doTick := makeWorldAndTicker(t)
+	assert.NilError(t, cardinal.RegisterComponent[Health](world))
+	assert.NilError(t, cardinal.RegisterTransactions(world, addHealthToEntity))
+	cardinal.RegisterSystems(world, func(worldCtx cardinal.WorldContext) error {
+		for _, tx := range addHealthToEntity.In(worldCtx) {
+			targetID := tx.Value().TargetID
+			err := cardinal.UpdateComponent[Health](worldCtx, targetID, func(h *Health) *Health {
+				h.Value = tx.Value().Amount
+				return h
+			})
+			assert.Check(t, err == nil)
+		}
+		return nil
+	})
+	go world.StartGame()
+
+	testWorldCtx := test_utils.WorldToWorldContext(world)
+	ids, err := cardinal.CreateMany(testWorldCtx, 10, Health{})
+	assert.NilError(t, err)
+
+	// Queue up the transaction.
+	idToModify := ids[3]
+	amountToModify := 20
+
+	test_utils.AddTransactionToWorldByAnyTransaction(world, addHealthToEntity, AddHealthToEntityTx{idToModify, amountToModify})
+
+	// The health change should be applied during this tick
+	doTick()
+
+	// Make sure the target entity had its health updated.
+	for _, id := range ids {
+		health, err := cardinal.GetComponent[Health](testWorldCtx, id)
+		assert.NilError(t, err)
+		if id == idToModify {
+			assert.Equal(t, amountToModify, health.Value)
+		} else {
+			assert.Equal(t, 0, health.Value)
+		}
+	}
+}

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -29,6 +29,7 @@ type World struct {
 	tickChannel     <-chan time.Time
 	tickDoneChannel chan<- uint64
 	serverOptions   []server.Option
+	cleanup         func()
 }
 
 type (
@@ -96,9 +97,11 @@ func NewMockWorld(opts ...WorldOption) (*World, error) {
 	ecsOptions, serverOptions, cardinalOptions := separateOptions(opts)
 	eventHub := events.CreateWebSocketEventHub()
 	ecsOptions = append(ecsOptions, ecs.WithEventHub(eventHub))
+	implWorld, mockWorldCleanup := ecs.NewMockWorld(ecsOptions...)
 	world := &World{
-		implWorld:     ecs.NewMockWorld(ecsOptions...),
+		implWorld:     implWorld,
 		serverOptions: serverOptions,
+		cleanup:       mockWorldCleanup,
 	}
 	world.isGameRunning.Store(false)
 	for _, opt := range cardinalOptions {
@@ -202,6 +205,12 @@ func (w *World) IsGameRunning() bool {
 }
 
 func (w *World) ShutDown() error {
+	if w.cleanup != nil {
+		w.cleanup()
+	}
+	if w.evmServer != nil {
+		w.evmServer.Shutdown()
+	}
 	if !w.IsGameRunning() {
 		return errors.New("game is not running")
 	}

--- a/cardinal/world_context.go
+++ b/cardinal/world_context.go
@@ -7,9 +7,9 @@ import (
 
 type WorldContext interface {
 	NewSearch(filter Filter) (*Search, error)
-	getECSWorldContext() ecs.WorldContext
 	CurrentTick() uint64
 	Logger() *zerolog.Logger
+	getECSWorldContext() ecs.WorldContext
 }
 
 type worldContext struct {
@@ -34,4 +34,13 @@ func (wCtx *worldContext) NewSearch(filter Filter) (*Search, error) {
 
 func (wCtx *worldContext) getECSWorldContext() ecs.WorldContext {
 	return wCtx.implContext
+}
+
+func (w *worldContext) TestOnlyGetECSWorld() *ecs.World {
+	return w.implContext.GetWorld()
+}
+
+func TestOnlyGetECSWorld(worldCtx WorldContext) *ecs.World {
+	w := worldCtx.(*worldContext)
+	return w.implContext.GetWorld()
 }


### PR DESCRIPTION


## What is the purpose of the change

Add test files to the cardinal package to demonstrate how to test various features of cardinal (and to test the cardinal package itself).

There are two aspects of this PR that I'd like some specific feedback on:
1) The new private method in test_utils called "uniqueSignature" is lifted directly from `world-engine/cardinal/ecs/internal/testutil`. Should this internal testutil package get lifted out into a common area?

2) In test_utils.AddTransactionToWorldByAnyTransaction I have 2 methods for converting an externally facing *cardinal.World into an internal *ecs.World. Do you all have a preference? I'd prefer to keep it so the cardinal godoc package does not list any TestOnly methods, but the resulting pattern for accessing the data is a little weird.

## Brief Changelog

- Updated ecs code to allow for the shutting down of an in-memory redis server (otherwise, multiple tests will end up trying to use the same port for redis and fail).
- Updated evm code so grpc server can be shut down (again, so tests don't fight over the same port).
- Added some code to the test_utils package so a user can get a cardinal.WorldContext object outside of systems and queries (this allows for setting up and asserting the game state is correct).

## Testing and Verifying

Unit tests were added.
