### PR TITLE
fix(cardinal): fix register systems bug

### DIFF
--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -226,8 +226,9 @@ func (w *World) ShutDown() error {
 
 func RegisterSystems(w *World, systems ...System) {
 	for _, system := range systems {
+		sys := system
 		w.implWorld.AddSystem(func(wCtx ecs.WorldContext) error {
-			return system(&worldContext{
+			return sys(&worldContext{
 				implContext: wCtx,
 			})
 		})


### PR DESCRIPTION
## What is the purpose of the change

alas, the age old bug you cant avoid. golang re-uses pointers for loop variables, thus we end up registering the same system over and over and over and over...

## Testing and Verifying

This change is already covered by existing tests, such as _(please describe tests)_.