### PR TITLE
test(cardinal): Re-add cardinal package tests and add helper function to test_utils t…

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	"gotest.tools/v3/assert"
-
 	"pkg.world.dev/world-engine/cardinal"
 	"pkg.world.dev/world-engine/cardinal/test_utils"
 )
@@ -17,40 +16,29 @@ func (Foo) Name() string { return "foo" }
 func TestCanQueryInsideSystem(t *testing.T) {
 	test_utils.SetTestTimeout(t, 10*time.Second)
 
-	nextTickCh := make(chan time.Time)
-	tickDoneCh := make(chan uint64)
-
-	world, err := cardinal.NewMockWorld(
-		cardinal.WithTickChannel(nextTickCh),
-		cardinal.WithTickDoneChannel(tickDoneCh))
-	assert.NilError(t, err)
+	world, doTick := test_utils.MakeWorldAndTicker(t)
 	assert.NilError(t, cardinal.RegisterComponent[Foo](world))
 
 	wantNumOfEntities := 10
-	world.Init(func(wCtx cardinal.WorldContext) {
-		_, err = cardinal.CreateMany(wCtx, wantNumOfEntities, Foo{})
+	world.Init(func(worldCtx cardinal.WorldContext) {
+		_, err := cardinal.CreateMany(worldCtx, wantNumOfEntities, Foo{})
 		assert.NilError(t, err)
 	})
 	gotNumOfEntities := 0
-	cardinal.RegisterSystems(world, func(wCtx cardinal.WorldContext) error {
-		q, err := wCtx.NewSearch(cardinal.Exact(Foo{}))
+	cardinal.RegisterSystems(world, func(worldCtx cardinal.WorldContext) error {
+		q, err := worldCtx.NewSearch(cardinal.Exact(Foo{}))
 		assert.NilError(t, err)
-		err = q.Each(wCtx, func(cardinal.EntityID) bool {
+		err = q.Each(worldCtx, func(cardinal.EntityID) bool {
 			gotNumOfEntities++
 			return true
 		})
 		assert.NilError(t, err)
 		return nil
 	})
-	go func() {
-		_ = world.StartGame()
-	}()
-	for !world.IsGameRunning() {
-		time.Sleep(time.Second) //starting game async, must wait until game is running before testing everything.
-	}
-	nextTickCh <- time.Now()
-	<-tickDoneCh
-	err = world.ShutDown()
+
+	doTick()
+
+	err := world.ShutDown()
 	assert.Assert(t, err)
 	assert.Equal(t, gotNumOfEntities, wantNumOfEntities)
 }

--- a/cardinal/component_test.go
+++ b/cardinal/component_test.go
@@ -1,0 +1,90 @@
+package cardinal_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+type Height struct {
+	Inches int
+}
+
+func (Height) Name() string { return "height" }
+
+type Weight struct {
+	Pounds int
+}
+
+func (Weight) Name() string { return "weight" }
+
+type Age struct {
+	Years int
+}
+
+func (Age) Name() string { return "age" }
+
+func TestComponentExample(t *testing.T) {
+	world, _ := test_utils.MakeWorldAndTicker(t)
+
+	assert.NilError(t, cardinal.RegisterComponent[Height](world))
+	assert.NilError(t, cardinal.RegisterComponent[Weight](world))
+	assert.NilError(t, cardinal.RegisterComponent[Age](world))
+
+	testWorldCtx := test_utils.WorldToWorldContext(world)
+	startHeight := 72
+	startWeight := 200
+	startAge := 30
+
+	peopleIDs, err := cardinal.CreateMany(testWorldCtx, 10, Height{startHeight}, Weight{startWeight}, Age{startAge})
+	assert.NilError(t, err)
+
+	targetID := peopleIDs[4]
+	height, err := cardinal.GetComponent[Height](testWorldCtx, targetID)
+	assert.NilError(t, err)
+	assert.Equal(t, startHeight, height.Inches)
+
+	assert.NilError(t, cardinal.RemoveComponentFrom[Age](testWorldCtx, targetID))
+
+	// Age was removed form exactly 1 entity.
+	search, err := testWorldCtx.NewSearch(cardinal.Exact(Height{}, Weight{}))
+	assert.NilError(t, err)
+	count, err := search.Count(testWorldCtx)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, count)
+
+	// The rest of the entities still have the Age field.
+	search, err = testWorldCtx.NewSearch(cardinal.Contains(Age{}))
+	assert.NilError(t, err)
+	count, err = search.Count(testWorldCtx)
+	assert.NilError(t, err)
+	assert.Equal(t, len(peopleIDs)-1, count)
+
+	// Age does not exist on the target ID, so this should result in an error
+	err = cardinal.UpdateComponent[Age](testWorldCtx, targetID, func(a *Age) *Age {
+		return a
+	})
+	assert.Check(t, err != nil)
+
+	heavyWeight := 999
+	err = cardinal.UpdateComponent[Weight](testWorldCtx, targetID, func(w *Weight) *Weight {
+		w.Pounds = heavyWeight
+		return w
+	})
+	assert.NilError(t, err)
+
+	// Adding the Age component to the targetID should not change the weight component
+	assert.NilError(t, cardinal.AddComponentTo[Age](testWorldCtx, targetID))
+
+	for _, id := range peopleIDs {
+		weight, err := cardinal.GetComponent[Weight](testWorldCtx, id)
+		assert.NilError(t, err)
+		if id == targetID {
+			assert.Equal(t, heavyWeight, weight.Pounds)
+		} else {
+			assert.Equal(t, startWeight, weight.Pounds)
+		}
+	}
+}

--- a/cardinal/ecs/mock_world.go
+++ b/cardinal/ecs/mock_world.go
@@ -2,35 +2,37 @@ package ecs
 
 import (
 	"fmt"
-	"log"
 	"testing"
 
-	"gotest.tools/v3/assert"
-
 	"github.com/alicebob/miniredis/v2"
+	"github.com/rs/zerolog/log"
+	"gotest.tools/v3/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs/ecb"
-
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
 
 // NewMockWorld creates an ecs.World that uses a mock redis DB as the storage
 // layer. This is only suitable for local development. If you are creating an ecs.World for
 // unit tests, use NewTestWorld.
-func NewMockWorld(opts ...Option) *World {
+func NewMockWorld(opts ...Option) (world *World, cleanup func()) {
 	// We manually set the start address to make the port deterministic
 	s := miniredis.NewMiniRedis()
 	err := s.StartAddr(":12345")
 	if err != nil {
 		panic("Unable to initialize in-memory redis")
 	}
-	log.Printf("Miniredis started at %s", s.Addr())
+	log.Logger.Debug().Msgf("miniredis started at %s", s.Addr())
 
 	w, err := newMockWorld(s, opts...)
 	if err != nil {
 		panic(fmt.Errorf("unable to initialize world: %w", err))
 	}
 
-	return w
+	return w, func() {
+		log.Logger.Debug().Msg("miniredis shutting down")
+		s.Close()
+		log.Logger.Debug().Msg("successfully shut down miniredis")
+	}
 }
 
 // NewTestWorld creates an ecs.World suitable for running in tests. Relevant resources

--- a/cardinal/evm/server.go
+++ b/cardinal/evm/server.go
@@ -39,6 +39,7 @@ type Server interface {
 	routerv1.MsgServer
 	// Serve serves the application in a new go routine.
 	Serve() error
+	Shutdown()
 }
 
 // txByID maps transaction type ID's to transaction types.
@@ -58,6 +59,8 @@ type msgServerImpl struct {
 	// opts
 	creds credentials.TransportCredentials
 	port  string
+
+	shutdown func()
 }
 
 // NewServer returns a new EVM connection server. This server is responsible for handling requests originating from
@@ -170,7 +173,14 @@ func (s *msgServerImpl) Serve() error {
 			log.Fatal(err)
 		}
 	}()
+	s.shutdown = server.GracefulStop
 	return nil
+}
+
+func (s *msgServerImpl) Shutdown() {
+	if s.shutdown != nil {
+		s.shutdown()
+	}
 }
 
 const (

--- a/cardinal/query.go
+++ b/cardinal/query.go
@@ -42,3 +42,12 @@ func NewQueryTypeWithEVMSupport[Request, Reply any](name string, handler func(Wo
 func (r *QueryType[Request, Reply]) Convert() ecs.IQuery {
 	return r.impl
 }
+
+func (q *QueryType[Request, Reply]) DoQuery(worldCtx WorldContext, req Request) (reply Reply, err error) {
+	iface, err := q.impl.HandleQuery(worldCtx.getECSWorldContext(), req)
+	if err != nil {
+		return reply, err
+	}
+	reply = iface.(Reply)
+	return reply, nil
+}

--- a/cardinal/query_test.go
+++ b/cardinal/query_test.go
@@ -1,0 +1,74 @@
+package cardinal_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+type QueryHealthRequest struct {
+	Min int
+}
+
+type QueryHealthResponse struct {
+	IDs []cardinal.EntityID
+}
+
+func handleQueryHealth(worldCtx cardinal.WorldContext, request *QueryHealthRequest) (*QueryHealthResponse, error) {
+	q, err := worldCtx.NewSearch(cardinal.Exact(Health{}))
+	if err != nil {
+		return nil, err
+	}
+	resp := &QueryHealthResponse{}
+	err = q.Each(worldCtx, func(id cardinal.EntityID) bool {
+		health, err := cardinal.GetComponent[Health](worldCtx, id)
+		if err != nil {
+			return true
+		}
+		if health.Value < request.Min {
+			return true
+		}
+		resp.IDs = append(resp.IDs, id)
+		return true
+	})
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}
+
+var queryHealth = cardinal.NewQueryType[*QueryHealthRequest, *QueryHealthResponse]("query_health", handleQueryHealth)
+
+func TestQueryExample(t *testing.T) {
+	world, _ := test_utils.MakeWorldAndTicker(t)
+	assert.NilError(t, cardinal.RegisterComponent[Health](world))
+	assert.NilError(t, cardinal.RegisterQueries(world, queryHealth))
+
+	worldCtx := test_utils.WorldToWorldContext(world)
+	ids, err := cardinal.CreateMany(worldCtx, 100, Health{})
+	assert.NilError(t, err)
+	// Give each new entity health based on the ever-increasing index
+	for i, id := range ids {
+		assert.NilError(t, cardinal.UpdateComponent[Health](worldCtx, id, func(h *Health) *Health {
+			h.Value = i
+			return h
+		}))
+	}
+
+	// No entities should have health over a million.
+	resp, err := queryHealth.DoQuery(worldCtx, &QueryHealthRequest{1_000_000})
+	assert.NilError(t, err)
+	assert.Equal(t, 0, len(resp.IDs))
+
+	// All entities should have health over -100
+	resp, err = queryHealth.DoQuery(worldCtx, &QueryHealthRequest{-100})
+	assert.NilError(t, err)
+	assert.Equal(t, 100, len(resp.IDs))
+
+	// Exactly 10 entities should have health at or above 90
+	resp, err = queryHealth.DoQuery(worldCtx, &QueryHealthRequest{90})
+	assert.NilError(t, err)
+	assert.Equal(t, 10, len(resp.IDs))
+}

--- a/cardinal/search_test.go
+++ b/cardinal/search_test.go
@@ -1,0 +1,82 @@
+package cardinal_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+type Alpha struct{}
+
+func (Alpha) Name() string { return "alpha" }
+
+type Beta struct{}
+
+func (Beta) Name() string { return "beta" }
+
+type Gamma struct{}
+
+func (Gamma) Name() string { return "gamma" }
+
+func TestSearchExample(t *testing.T) {
+	world, _ := test_utils.MakeWorldAndTicker(t)
+	assert.NilError(t, cardinal.RegisterComponent[Alpha](world))
+	assert.NilError(t, cardinal.RegisterComponent[Beta](world))
+	assert.NilError(t, cardinal.RegisterComponent[Gamma](world))
+
+	worldCtx := test_utils.WorldToWorldContext(world)
+	_, err := cardinal.CreateMany(worldCtx, 10, Alpha{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Beta{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Gamma{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Alpha{}, Beta{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Alpha{}, Gamma{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Beta{}, Gamma{})
+	assert.NilError(t, err)
+	_, err = cardinal.CreateMany(worldCtx, 10, Alpha{}, Beta{}, Gamma{})
+	assert.NilError(t, err)
+
+	testCases := []struct {
+		name   string
+		filter cardinal.Filter
+		want   int
+	}{
+		{
+			"exactly alpha",
+			cardinal.Exact(Alpha{}),
+			10,
+		},
+		{
+			"contains alpha",
+			cardinal.Contains(Alpha{}),
+			40,
+		},
+		{
+			"beta or gamma",
+			cardinal.Or(
+				cardinal.Exact(Beta{}),
+				cardinal.Exact(Gamma{}),
+			),
+			20,
+		},
+		{
+			"not alpha",
+			cardinal.Not(cardinal.Exact(Alpha{})),
+			60,
+		},
+	}
+	for _, tc := range testCases {
+		msg := "problem with " + tc.name
+		q, err := worldCtx.NewSearch(tc.filter)
+		assert.NilError(t, err, msg)
+		count, err := q.Count(worldCtx)
+		assert.NilError(t, err, msg)
+		assert.Equal(t, tc.want, count, msg)
+	}
+}

--- a/cardinal/system_test.go
+++ b/cardinal/system_test.go
@@ -62,3 +62,22 @@ func TestSystemExample(t *testing.T) {
 		assert.Equal(t, 5, health.Value)
 	}
 }
+
+func TestCanRegisterMultipleSystem(t *testing.T) {
+	world, doTick := test_utils.MakeWorldAndTicker(t)
+	var firstSystemCalled bool
+	var secondSystemCalled bool
+
+	cardinal.RegisterSystems(world, func(context cardinal.WorldContext) error {
+		firstSystemCalled = true
+		return nil
+	}, func(context cardinal.WorldContext) error {
+		secondSystemCalled = true
+		return nil
+	})
+
+	doTick()
+
+	assert.Check(t, firstSystemCalled)
+	assert.Check(t, secondSystemCalled)
+}

--- a/cardinal/system_test.go
+++ b/cardinal/system_test.go
@@ -1,0 +1,64 @@
+package cardinal_test
+
+import (
+	"errors"
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+type Health struct {
+	Value int
+}
+
+func (Health) Name() string { return "health" }
+
+func HealthSystem(worldCtx cardinal.WorldContext) error {
+	q, err := worldCtx.NewSearch(cardinal.Exact(Health{}))
+	if err != nil {
+		return err
+	}
+	var errs []error
+	errs = append(errs, q.Each(worldCtx, func(id cardinal.EntityID) bool {
+		errs = append(errs, cardinal.UpdateComponent[Health](worldCtx, id, func(h *Health) *Health {
+			h.Value += 1
+			return h
+		}))
+		return true
+	}))
+	if err := errors.Join(errs...); err != nil {
+		return err
+	}
+	return err
+}
+
+func TestSystemExample(t *testing.T) {
+	world, doTick := test_utils.MakeWorldAndTicker(t)
+	assert.NilError(t, cardinal.RegisterComponent[Health](world))
+	cardinal.RegisterSystems(world, HealthSystem)
+
+	worldCtx := test_utils.WorldToWorldContext(world)
+	ids, err := cardinal.CreateMany(worldCtx, 100, Health{})
+	assert.NilError(t, err)
+
+	// Make sure we have 100 entities all with a health of 0
+	for _, id := range ids {
+		health, err := cardinal.GetComponent[Health](worldCtx, id)
+		assert.NilError(t, err)
+		assert.Equal(t, 0, health.Value)
+	}
+
+	// do 5 ticks
+	for i := 0; i < 5; i++ {
+		doTick()
+	}
+
+	// Health should be 5 for everyone
+	for _, id := range ids {
+		health, err := cardinal.GetComponent[Health](worldCtx, id)
+		assert.NilError(t, err)
+		assert.Equal(t, 5, health.Value)
+	}
+}

--- a/cardinal/transaction_test.go
+++ b/cardinal/transaction_test.go
@@ -1,0 +1,59 @@
+package cardinal_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+type AddHealthToEntityTx struct {
+	TargetID cardinal.EntityID
+	Amount   int
+}
+
+type AddHealthToEntityResult struct{}
+
+var addHealthToEntity = cardinal.NewTransactionType[AddHealthToEntityTx, AddHealthToEntityResult]("add_health")
+
+func TestTransactionExample(t *testing.T) {
+	world, doTick := test_utils.MakeWorldAndTicker(t)
+	assert.NilError(t, cardinal.RegisterComponent[Health](world))
+	assert.NilError(t, cardinal.RegisterTransactions(world, addHealthToEntity))
+	cardinal.RegisterSystems(world, func(worldCtx cardinal.WorldContext) error {
+		for _, tx := range addHealthToEntity.In(worldCtx) {
+			targetID := tx.Value().TargetID
+			err := cardinal.UpdateComponent[Health](worldCtx, targetID, func(h *Health) *Health {
+				h.Value = tx.Value().Amount
+				return h
+			})
+			assert.Check(t, err == nil)
+		}
+		return nil
+	})
+
+	testWorldCtx := test_utils.WorldToWorldContext(world)
+	ids, err := cardinal.CreateMany(testWorldCtx, 10, Health{})
+	assert.NilError(t, err)
+
+	// Queue up the transaction.
+	idToModify := ids[3]
+	amountToModify := 20
+
+	test_utils.AddTransactionToWorldByAnyTransaction(world, addHealthToEntity, AddHealthToEntityTx{idToModify, amountToModify})
+
+	// The health change should be applied during this tick
+	doTick()
+
+	// Make sure the target entity had its health updated.
+	for _, id := range ids {
+		health, err := cardinal.GetComponent[Health](testWorldCtx, id)
+		assert.NilError(t, err)
+		if id == idToModify {
+			assert.Equal(t, amountToModify, health.Value)
+		} else {
+			assert.Equal(t, 0, health.Value)
+		}
+	}
+}

--- a/cardinal/world_context.go
+++ b/cardinal/world_context.go
@@ -7,9 +7,9 @@ import (
 
 type WorldContext interface {
 	NewSearch(filter Filter) (*Search, error)
-	getECSWorldContext() ecs.WorldContext
 	CurrentTick() uint64
 	Logger() *zerolog.Logger
+	getECSWorldContext() ecs.WorldContext
 }
 
 type worldContext struct {


### PR DESCRIPTION
…hat will start/stop a cardinal.World object correctly between tests


## What is the purpose of the change

- Re-add the test files to the cardinal package.
- Add a helper in test_utils that (should) start up a cardinal.World within a test context and properly shut it down between tests. This requires a change to the world.Shutdown method that makes shutting down a non-started world NOT an error.

## Testing and Verifying

Please checkout this branch and run the `cardinal` tests locally to verify they don't hang. You can also use `--count` to make extra sure resources are cleaned up between similar tests.

`go test --count=10`
