### PR TITLE
fix(cardinal): Ensure system logs in cardinal contain the system name

### DIFF
--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -118,9 +118,6 @@ func (w *World) AddSystem(s System) {
 }
 
 func (w *World) AddSystems(systems ...System) {
-	if w.stateIsLoaded {
-		panic("cannot register systems after loading game state")
-	}
 	for _, system := range systems {
 		w.AddSystemWithName(system, "")
 	}

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -114,22 +114,30 @@ func (w *World) GetTxQueueAmount() int {
 }
 
 func (w *World) AddSystem(s System) {
-	w.AddSystems(s)
+	w.AddSystemWithName(s, "")
 }
 
-func (w *World) AddSystems(s ...System) {
+func (w *World) AddSystems(systems ...System) {
 	if w.stateIsLoaded {
 		panic("cannot register systems after loading game state")
 	}
-	for _, system := range s {
-		// retrieves function name from system using a reflection trick
-		functionName := filepath.Base(runtime.FuncForPC(reflect.ValueOf(system).Pointer()).Name())
-		sysLogger := w.Logger.CreateSystemLogger(functionName)
-		w.systemLoggers = append(w.systemLoggers, &sysLogger)
-		w.systemNames = append(w.systemNames, functionName)
-		// appends registeredSystem into the member system list in world.
-		w.systems = append(w.systems, system)
+	for _, system := range systems {
+		w.AddSystemWithName(system, "")
 	}
+}
+
+func (w *World) AddSystemWithName(system System, functionName string) {
+	if w.stateIsLoaded {
+		panic("cannot register systems after loading game state")
+	}
+	if functionName == "" {
+		functionName = filepath.Base(runtime.FuncForPC(reflect.ValueOf(system).Pointer()).Name())
+	}
+	sysLogger := w.Logger.CreateSystemLogger(functionName)
+	w.systemLoggers = append(w.systemLoggers, &sysLogger)
+	w.systemNames = append(w.systemNames, functionName)
+	// appends registeredSystem into the member system list in world.
+	w.systems = append(w.systems, system)
 }
 
 func RegisterComponent[T component_metadata.Component](world *World) error {

--- a/cardinal/log_test.go
+++ b/cardinal/log_test.go
@@ -1,0 +1,49 @@
+package cardinal_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/ecs/log"
+	"pkg.world.dev/world-engine/cardinal/test_utils"
+)
+
+const nameOfSystem = "SystemLogMyName"
+
+func SystemLogMyName(worldCtx cardinal.WorldContext) error {
+	worldCtx.Logger().Log().Msg("wanted system name: " + nameOfSystem)
+	return nil
+}
+
+func TestSystemNamesAreCorrectInLogs(t *testing.T) {
+	world, doTick := test_utils.MakeWorldAndTicker(t)
+	ecsWorld := cardinal.TestingWorldContextToECSWorld(cardinal.TestingWorldToWorldContext(world))
+	var buf bytes.Buffer
+	bufLogger := zerolog.New(&buf)
+	cardinalLogger := log.Logger{
+		&bufLogger,
+	}
+	ecsWorld.InjectLogger(&cardinalLogger)
+	cardinal.RegisterSystems(world, SystemLogMyName)
+
+	doTick()
+
+	logLines := strings.Split(buf.String(), "\n")
+	found := false
+	for _, logLine := range logLines {
+		// The one-and-only system emits a log line with "SystemLogMyName" in it. The log should
+		// also automatically include the system name by default, so there should be at least 1 log line that has
+		// the "SystemLogMyName" string twice.
+		count := strings.Count(logLine, nameOfSystem)
+		if count != 2 {
+			continue
+		}
+		found = true
+		break
+	}
+	assert.Check(t, found, "unable to find log line with %q twice", nameOfSystem)
+}

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -3,6 +3,9 @@ package cardinal
 import (
 	"context"
 	"errors"
+	"path/filepath"
+	"reflect"
+	"runtime"
 	"sync/atomic"
 	"time"
 
@@ -223,12 +226,13 @@ func (w *World) ShutDown() error {
 
 func RegisterSystems(w *World, systems ...System) {
 	for _, system := range systems {
+		functionName := filepath.Base(runtime.FuncForPC(reflect.ValueOf(system).Pointer()).Name())
 		sys := system
-		w.implWorld.AddSystem(func(wCtx ecs.WorldContext) error {
+		w.implWorld.AddSystemWithName(func(wCtx ecs.WorldContext) error {
 			return sys(&worldContext{
 				implContext: wCtx,
 			})
-		})
+		}, functionName)
 	}
 }
 


### PR DESCRIPTION
Closes: #WORLD-425

## What is the purpose of the change

Ensure systems registered via the cardinal package include the function name in logs.

## Testing and Verifying

Added unit test to verify the log lines generated in systems contain the system name.