### PR TITLE
refactor(cardinal): Remove the unused TxBatch struct

### DIFF
--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -475,11 +475,6 @@ func (w *World) EndGameLoop() {
 	}
 }
 
-type TxBatch struct {
-	TxID transaction.TypeID `json:"txId,omitempty"`
-	Txs  []any              `json:"txs,omitempty"`
-}
-
 const (
 	storeArchetypeCompIdxKey  = "arch_component_index"
 	storeArchetypeAccessorKey = "arch_accessor"


### PR DESCRIPTION
Closes: #WORLD-448

## What is the purpose of the change

Remove the unused TxBatch struct

## Testing and Verifying

This change is a trivial rework/code cleanup without any test coverage.
