### PR TITLE
feat(cardinal): add panics for transactions and queries with empty args (WORLD-135, WORLD-134)

### DIFF
--- a/cardinal/ecs/query.go
+++ b/cardinal/ecs/query.go
@@ -57,13 +57,19 @@ func WithQueryEVMSupport[Request, Reply any]() func(transactionType *QueryType[R
 	}
 }
 
-var _ IQuery = NewQueryType[struct{}, struct{}]("", nil)
+var _ IQuery = &QueryType[struct{}, struct{}]{}
 
 func NewQueryType[Request any, Reply any](
 	name string,
 	handler func(wCtx WorldContext, req Request) (Reply, error),
 	opts ...func() func(queryType *QueryType[Request, Reply]),
 ) *QueryType[Request, Reply] {
+	if name == "" {
+		panic("cannot create query without name")
+	}
+	if handler == nil {
+		panic("cannot create query without handler")
+	}
 	var req Request
 	var rep Reply
 	reqType := reflect.TypeOf(req)

--- a/cardinal/ecs/query_test.go
+++ b/cardinal/ecs/query_test.go
@@ -2,6 +2,7 @@ package ecs_test
 
 import (
 	"context"
+	"github.com/stretchr/testify/require"
 	"testing"
 
 	"pkg.world.dev/world-engine/cardinal/evm"
@@ -91,4 +92,38 @@ func TestQueryEVM(t *testing.T) {
 	assert.Equal(t, ok, true)
 	// should be same!
 	assert.Equal(t, reply, expectedReply)
+}
+
+func TestPanicsOnNoNameOrHandler(t *testing.T) {
+	type foo struct{}
+	testCases := []struct {
+		name        string
+		createQuery func()
+		shouldPanic bool
+	}{
+		{
+			name: "panic on no name",
+			createQuery: func() {
+				ecs.NewQueryType[foo, foo]("", nil)
+			},
+			shouldPanic: true,
+		},
+		{
+			name: "panic on no handler",
+			createQuery: func() {
+				ecs.NewQueryType[foo, foo]("foo", nil)
+			},
+			shouldPanic: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if tc.shouldPanic {
+				require.Panics(t, tc.createQuery)
+			} else {
+				require.NotPanics(t, tc.createQuery)
+			}
+		})
+	}
 }

--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -16,7 +16,7 @@ var (
 	ErrEVMTypeNotSet = errors.New("EVM type is not set")
 )
 
-var _ transaction.ITransaction = NewTransactionType[struct{}, struct{}]("")
+var _ transaction.ITransaction = &TransactionType[struct{}, struct{}]{}
 
 // TransactionType helps manage adding transactions (aka events) to the world transaction queue. It also assists
 // in the using of transactions inside of System functions.
@@ -50,7 +50,9 @@ func NewTransactionType[In, Out any](
 	name string,
 	opts ...func() func(*TransactionType[In, Out]),
 ) *TransactionType[In, Out] {
-
+	if name == "" {
+		panic("cannot create transaction without name")
+	}
 	var in In
 	var out Out
 	inType := reflect.TypeOf(in)

--- a/cardinal/ecs/transaction/transaction_test.go
+++ b/cardinal/ecs/transaction/transaction_test.go
@@ -3,6 +3,7 @@ package transaction_test
 import (
 	"context"
 	"errors"
+	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
 
@@ -561,4 +562,11 @@ func TestCopyTransactions(t *testing.T) {
 	copyTxq := txq.CopyTransactions()
 	assert.Equal(t, copyTxq.GetAmountOfTxs(), 2)
 	assert.Equal(t, txq.GetAmountOfTxs(), 0)
+}
+
+func TestNewTransactionPanicsIfNoName(t *testing.T) {
+	type Foo struct{}
+	require.Panics(t, func() {
+		ecs.NewTransactionType[Foo, Foo]("")
+	})
 }


### PR DESCRIPTION
## What is the purpose of the change

adds panics on empty arguments to tx and queries

## Brief Changelog

- add panic for empty name and handler on queries
- add panic for empty name on txs
- change interface guards for tx and qs
- add tests

## Testing and Verifying

unit tests for query and txs
