### PR TITLE
chore(cardinal): MakeWorldAndTicker accepts options

### DIFF
--- a/cardinal/test_utils/test_utils.go
+++ b/cardinal/test_utils/test_utils.go
@@ -171,12 +171,8 @@ func AddTransactionToWorldByAnyTransaction(world *cardinal.World, cardinalTx car
 // end of the test. If doTick takes longer than 5 seconds to run, t.Fatal will be called.
 func MakeWorldAndTicker(t *testing.T, opts ...cardinal.WorldOption) (world *cardinal.World, doTick func()) {
 	startTickCh, doneTickCh := make(chan time.Time), make(chan uint64)
-	options := make([]cardinal.WorldOption, 0)
-	options = append(opts,
-		cardinal.WithTickChannel(startTickCh),
-		cardinal.WithTickDoneChannel(doneTickCh),
-	)
-	world, err := cardinal.NewMockWorld(options...)
+	opts = append(opts, cardinal.WithTickChannel(startTickCh), cardinal.WithTickDoneChannel(doneTickCh))
+	world, err := cardinal.NewMockWorld(opts...)
 	if err != nil {
 		t.Fatalf("unable to make mock world: %v", err)
 	}

--- a/cardinal/test_utils/test_utils.go
+++ b/cardinal/test_utils/test_utils.go
@@ -169,11 +169,14 @@ func AddTransactionToWorldByAnyTransaction(world *cardinal.World, cardinalTx car
 // MakeWorldAndTicker sets up a cardinal.World as well as a function that can execute one game tick. The *cardinal.World
 // will be automatically started when doTick is called for the first time. The cardinal.World will be shut down at the
 // end of the test. If doTick takes longer than 5 seconds to run, t.Fatal will be called.
-func MakeWorldAndTicker(t *testing.T) (world *cardinal.World, doTick func()) {
+func MakeWorldAndTicker(t *testing.T, opts ...cardinal.WorldOption) (world *cardinal.World, doTick func()) {
 	startTickCh, doneTickCh := make(chan time.Time), make(chan uint64)
-	world, err := cardinal.NewMockWorld(
+	options := make([]cardinal.WorldOption, 0)
+	options = append(opts,
 		cardinal.WithTickChannel(startTickCh),
-		cardinal.WithTickDoneChannel(doneTickCh))
+		cardinal.WithTickDoneChannel(doneTickCh),
+	)
+	world, err := cardinal.NewMockWorld(options...)
 	if err != nil {
 		t.Fatalf("unable to make mock world: %v", err)
 	}


### PR DESCRIPTION
Closes WORLD-458

## Brief Changelog

- Edit the `MakeWorldAndTicker` function to accept variadic `WorldOption`s so that I can feed it options like ReceiptHistory size and such.

## Testing and Verifying

This change is already covered by existing tests.
