### PR TITLE
fix(internal): add CLIENT_CERT_PATH for e2e shard squencer client tester

### DIFF
--- a/internal/e2e/tester/cardinal/main.go
+++ b/internal/e2e/tester/cardinal/main.go
@@ -51,7 +51,18 @@ func setupAdapter() shard.Adapter {
 		ShardSequencerAddr: shardReceiverAddr,
 		EVMBaseShardAddr:   baseShardAddr,
 	}
-	adapter, err := shard.NewAdapter(cfg)
+
+	var opts []shard.Option
+	clientCert := os.Getenv("CLIENT_CERT_PATH")
+	if clientCert != "" {
+		log.Print("running shard client with client certification")
+		opts = append(opts, shard.WithCredentials(clientCert))
+	} else {
+		log.Print("WARNING: running shard client without client certification. this will cause issues if " +
+			"the chain instance uses SSL credentials")
+	}
+
+	adapter, err := shard.NewAdapter(cfg, opts...)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Closes: DEVOP-92

## What is the purpose of the change

- Add CLIENT_CERT_PATH on Shard Sequencer (`shard.NewAdapter`) for e2e tester.
- CLIENT_CERT_PATH values =  path of chain/base-shard server SSL CA certs

## Testing and Verifying

This change added tests and can be verified as follows:

- Run the docker compose services using SSL env variable option to enable secure connection.
- Run `go test -v` on `world-engine/internal/e2e` directory.

![image](https://github.com/Argus-Labs/world-engine/assets/29672212/99fe2d04-659a-4577-a1e1-b8b77d55f669)
![image](https://github.com/Argus-Labs/world-engine/assets/29672212/fd67c562-75d1-4f08-a4a9-eb328558cf11)
