### PR TITLE
refactor(relay): use event hub methods

### DIFF
--- a/relay/nakama/events.go
+++ b/relay/nakama/events.go
@@ -47,13 +47,13 @@ func createEventHub(logger runtime.Logger) (*EventHub, error) {
 	return &res, nil
 }
 
-func (eh *EventHub) subscribe(session string) chan *Event {
+func (eh *EventHub) Subscribe(session string) chan *Event {
 	channel := make(chan *Event)
 	eh.channels.Store(session, channel)
 	return channel
 }
 
-func (eh *EventHub) unsubscribe(session string) {
+func (eh *EventHub) Unsubscribe(session string) {
 	eventChannelUntyped, ok := eh.channels.Load(session)
 	if !ok {
 		panic(errors.New("session not found"))
@@ -66,40 +66,42 @@ func (eh *EventHub) unsubscribe(session string) {
 	eh.channels.Delete(session)
 }
 
-func (eh *EventHub) shutdown() {
+func (eh *EventHub) Shutdown() {
 	eh.didShutdown.Store(true)
 }
 
 // dispatch continually drains eh.inputConnection (events from cardinal) and sends copies to all subscribed channels.
 // This function is meant to be called in a goroutine.
-func (eh *EventHub) dispatch(log runtime.Logger) error {
+func (eh *EventHub) Dispatch(log runtime.Logger) error {
 	var err error
 	for !eh.didShutdown.Load() {
 		messageType, message, err := eh.inputConnection.ReadMessage() //will block
 		if err != nil {
-			break
+			eh.Shutdown()
+			continue
 		}
 		if messageType != websocket.TextMessage {
-			break
+			eh.Shutdown()
+			continue
 		}
 		eh.channels.Range(func(key any, value any) bool {
 			channel, ok := value.(chan *Event)
 			if !ok {
 				err = errors.New("not a channel")
+				eh.Shutdown()
 				return false
 			}
 			channel <- &Event{message: string(message)}
 			return true
 		})
 		if err != nil {
-			break
+			eh.Shutdown()
+			continue
 		}
 	}
-	eh.didShutdown.Store(true)
 	eh.channels.Range(func(key any, value any) bool {
 		log.Info(fmt.Sprintf("shutting down: %s", key.(string)))
-		channel := value.(chan *Event)
-		close(channel)
+		eh.Unsubscribe(key.(string))
 		return true
 	})
 	err = errors.Join(eh.inputConnection.Close(), err)

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -132,7 +132,7 @@ func initEventHub(ctx context.Context, log runtime.Logger, nk runtime.NakamaModu
 		return err
 	}
 	go func() {
-		err := eventHub.dispatch(log)
+		err := eventHub.Dispatch(log)
 		if err != nil {
 			log.Error("error initializing eventHub: %s", err.Error())
 		}
@@ -140,7 +140,7 @@ func initEventHub(ctx context.Context, log runtime.Logger, nk runtime.NakamaModu
 
 	//for now send to everybody via notifications.
 	go func() {
-		channel := eventHub.subscribe("main")
+		channel := eventHub.Subscribe("main")
 		for event := range channel {
 			err := nk.NotificationSendAll(ctx, "event", map[string]interface{}{"message": event.message}, 1, true)
 			if err != nil {


### PR DESCRIPTION
Closes: #464
## What is the purpose of the change

reuse and rename methods such that it will satisfy a linter that will be added in another PR. 

## Brief Changelog

mostly involves Unsubscribe and Shutdown methods inside the nakama eventHub. 