### PR TITLE
feat: add unit-test commands to makefile

### DIFF
--- a/test.mk
+++ b/test.mk
@@ -17,18 +17,13 @@ e2e-nakama:
 #   unit tests	#
 #################
 
-unit-test-cardinal:
-	cd cardinal && go test ./...
+.PHONY: unit-test
 
-
-unit-test-sign:
-	cd sign && go test ./...
-
-unit-test-chain:
-	cd chain && go test ./...
-
+unit-test:
+	cd $(filter-out $@,$(MAKECMDGOALS)) && go test ./...
 
 unit-test-all:
-	$(MAKE) unit-test-cardinal
-	$(MAKE) unit-test-sign
-	$(MAKE) unit-test-chain
+	$(MAKE) unit-test cardinal
+	$(MAKE) unit-test chain
+	$(MAKE) unit-test sign
+

--- a/test.mk
+++ b/test.mk
@@ -12,3 +12,23 @@ e2e-nakama:
 	)
 
 	@docker compose up --build --abort-on-container-exit --exit-code-from test_nakama --attach test_nakama
+
+#################
+#   unit tests	#
+#################
+
+unit-test-cardinal:
+	cd cardinal && go test ./...
+
+
+unit-test-sign:
+	cd sign && go test ./...
+
+unit-test-chain:
+	cd chain && go test ./...
+
+
+unit-test-all:
+	$(MAKE) unit-test-cardinal
+	$(MAKE) unit-test-sign
+	$(MAKE) unit-test-chain


### PR DESCRIPTION
## What is the purpose of the change

adds unit test commands to makefile.

try it out:

make unit-test cardinal
make unit-test chain

make unit-test-all

## Brief Changelog

adds unit test commands to makefile

## Testing and Verifying

see above

This change added tests and can be verified as follows:

_(example:)_

- _Added unit test that validates ..._
- _Added integration tests for end-to-end deployment with ..._
- _Extended integration test for ..._
- _Manually verified the change by ..._
