### PR TITLE
chore(cardinal): add log for iterated txs that encounter an error

### DIFF
--- a/cardinal/ecs/transaction.go
+++ b/cardinal/ecs/transaction.go
@@ -159,6 +159,8 @@ func (t *TransactionType[In, Out]) GetReceipt(wCtx WorldContext, hash transactio
 func (t *TransactionType[In, Out]) ForEach(wCtx WorldContext, fn func(TxData[In]) (Out, error)) {
 	for _, tx := range t.In(wCtx) {
 		if result, err := fn(tx); err != nil {
+			wCtx.Logger().Err(err).Msgf("tx %s from %s encountered an error with tx=%+v", tx.TxHash,
+				tx.Sig.PersonaTag, tx.Value)
 			t.AddError(wCtx, tx.TxHash, err)
 		} else {
 			t.SetResult(wCtx, tx.TxHash, result)


### PR DESCRIPTION
## What is the purpose of the change

adds an error log for when systems using tx iterators return an error in the iterator.

## Brief Changelog

- add log

## Testing and Verifying

ran existing test:

```
{"level":"error","system":"ecs_test.TestForEachTransaction.func1","error":"some error","time":"2023-11-01T15:57:57-07:00","message":"tx 0x43fdd7497422eacb6f8af0cf70cabeeb1589190b777e4ca03b3a4db34dbde381 from some-persona-tag encountered an error with tx={GenerateError:true}"}
```
