### PR TITLE
fix(cardinal): When removing an entity, remove the relveant component from the pendi…

### DIFF
--- a/cardinal/ecs/ecb/ecb.go
+++ b/cardinal/ecs/ecb/ecb.go
@@ -144,6 +144,14 @@ func (m *Manager) RemoveEntity(idToRemove entity.ID) error {
 		m.entityIDToOriginArchID[idToRemove] = archID
 	}
 	delete(m.entityIDToArchID, idToRemove)
+
+	comps := m.GetComponentTypesForArchID(archID)
+	for _, comp := range comps {
+		key := compKey{comp.ID(), idToRemove}
+		delete(m.compValues, key)
+		m.compValuesToDelete[key] = true
+	}
+
 	return nil
 }
 

--- a/cardinal/ecs/ecb/recovery_test.go
+++ b/cardinal/ecs/ecb/recovery_test.go
@@ -271,3 +271,23 @@ func TestArchetypeCountTracksDiscardedChanges(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, 1, manager.ArchetypeCount())
 }
+
+func TestCannotFetchComponentOnRemovedEntityAfterCommit(t *testing.T) {
+	manager := newCmdBufferForTest(t)
+
+	id, err := manager.CreateEntity(fooComp, barComp)
+	assert.NilError(t, err)
+	_, err = manager.GetComponentForEntity(fooComp, id)
+	assert.NilError(t, err)
+	assert.NilError(t, manager.RemoveEntity(id))
+
+	// The entity has been removed. Trying to get a component for the entity should fail.
+	_, err = manager.GetComponentForEntity(fooComp, id)
+	assert.Check(t, err != nil)
+
+	assert.NilError(t, manager.CommitPending())
+
+	// Trying to get the same component after committing to the DB should also fail.
+	_, err = manager.GetComponentForEntity(fooComp, id)
+	assert.Check(t, err != nil)
+}

--- a/cardinal/entity_test.go
+++ b/cardinal/entity_test.go
@@ -1,0 +1,38 @@
+package cardinal_test
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/testutils"
+)
+
+func TestCanRemoveEntity(t *testing.T) {
+	world, _ := testutils.MakeWorldAndTicker(t)
+
+	assert.NilError(t, cardinal.RegisterComponent[Alpha](world))
+
+	testWorldCtx := testutils.WorldToWorldContext(world)
+	ids, err := cardinal.CreateMany(testWorldCtx, 2, Alpha{})
+	assert.NilError(t, err)
+
+	removeID := ids[0]
+	keepID := ids[1]
+
+	assert.NilError(t, cardinal.Remove(testWorldCtx, removeID))
+
+	search, err := testWorldCtx.NewSearch(cardinal.Exact(Alpha{}))
+	assert.NilError(t, err)
+	count := 0
+	assert.NilError(t, search.Each(testWorldCtx, func(id cardinal.EntityID) bool {
+		assert.Equal(t, id, keepID)
+		count++
+		return true
+	}))
+	assert.Equal(t, 1, count)
+
+	// We should not be able to find the component for the removed ID
+	_, err = cardinal.GetComponent[Alpha](testWorldCtx, removeID)
+	assert.Check(t, err != nil)
+}


### PR DESCRIPTION
…ng ecb

Closes: #WORLD-488

## What is the purpose of the change

This fixes a bug where it was possible to get a component's entity after Removing the entity.

ECB caches component values in a local map. Values from this map were not removed when RemoveEntity was called.

## Testing and Verifying

Unit tests have been added