### PR TITLE
test(cardinal): test coverage for api protection cardinal transaction.go

### DIFF
--- a/cardinal/component_test.go
+++ b/cardinal/component_test.go
@@ -1,10 +1,12 @@
 package cardinal_test
 
 import (
-	"pkg.world.dev/world-engine/cardinal/testutils"
 	"testing"
 
+	"pkg.world.dev/world-engine/cardinal/testutils"
+
 	"gotest.tools/v3/assert"
+
 	"pkg.world.dev/world-engine/cardinal"
 )
 
@@ -34,6 +36,9 @@ func TestComponentExample(t *testing.T) {
 	assert.NilError(t, cardinal.RegisterComponent[Age](world))
 
 	testWorldCtx := testutils.WorldToWorldContext(world)
+	assert.Equal(t, testWorldCtx.CurrentTick(), uint64(0))
+	testWorldCtx.Logger().Info().Msg("test") // Check for compile errors.
+	testWorldCtx.EmitEvent("test")           // test for compiler errors, a check for this lives in e2e tests.
 	startHeight := 72
 	startWeight := 200
 	startAge := 30

--- a/cardinal/transaction.go
+++ b/cardinal/transaction.go
@@ -12,12 +12,6 @@ type AnyTransaction interface {
 	Convert() transaction.ITransaction
 }
 
-// TransactionQueue contains the entire set of transactions that should be processed in a game tick. It is a parameter
-// to a System function. Access the transactions of a particular type by using TransactionType.In.
-type TransactionQueue struct {
-	_ *transaction.TxQueue
-}
-
 // TxData represents a single transaction.
 type TxData[T any] struct {
 	impl ecs.TxData[T]

--- a/cardinal/transaction_test.go
+++ b/cardinal/transaction_test.go
@@ -37,7 +37,7 @@ func TestTransactionExample(t *testing.T) {
 	assert.NilError(t, cardinal.RegisterComponent[Health](world))
 	assert.NilError(t, cardinal.RegisterTransactions(world, addHealthToEntity))
 	cardinal.RegisterSystems(world, func(worldCtx cardinal.WorldContext) error {
-		//test In method
+		// test "In" method
 		for _, tx := range addHealthToEntity.In(worldCtx) {
 			targetID := tx.Value().TargetID
 			err := cardinal.UpdateComponent[Health](worldCtx, targetID, func(h *Health) *Health {
@@ -46,7 +46,7 @@ func TestTransactionExample(t *testing.T) {
 			})
 			assert.Check(t, err == nil)
 		}
-		//test same as above but with for each
+		// test same as above but with forEach
 		addHealthToEntity.ForEach(worldCtx, func(tx cardinal.TxData[AddHealthToEntityTx]) (AddHealthToEntityResult, error) {
 			targetID := tx.Value().TargetID
 			err := cardinal.UpdateComponent[Health](worldCtx, targetID, func(h *Health) *Health {


### PR DESCRIPTION
Closes: #490

A bunch of tests for more coverage of transaction. 

Removed 

type TransactionQueue struct {
	_ *transaction.TxQueue
}

Seems to never be used. 
