### PR TITLE
feat(cardinal): create debug endpoint that lists all entities in the game

### DIFF
--- a/cardinal/ecs/filter.go
+++ b/cardinal/ecs/filter.go
@@ -9,6 +9,9 @@ type Filterable interface {
 	ConvertToComponentFilter(world *World) (filter.ComponentFilter, error)
 }
 
+type all struct {
+}
+
 type and struct {
 	filters []Filterable
 }
@@ -27,6 +30,10 @@ type contains struct {
 
 type exact struct {
 	components []metadata.Component
+}
+
+func All() Filterable {
+	return &all{}
 }
 
 func And(filters ...Filterable) Filterable {
@@ -103,4 +110,8 @@ func (s exact) ConvertToComponentFilter(world *World) (filter.ComponentFilter, e
 		acc = append(acc, c)
 	}
 	return filter.Exact(acc...), nil
+}
+
+func (a all) ConvertToComponentFilter(_ *World) (filter.ComponentFilter, error) {
+	return filter.All(), nil
 }

--- a/cardinal/ecs/filter/all.go
+++ b/cardinal/ecs/filter/all.go
@@ -1,0 +1,14 @@
+package filter
+
+import "pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+
+type all struct {
+}
+
+func All() ComponentFilter {
+	return &all{}
+}
+
+func (f *all) MatchesComponents(_ []metadata.ComponentMetadata) bool {
+	return true
+}

--- a/cardinal/ecs/filter/filter_test.go
+++ b/cardinal/ecs/filter/filter_test.go
@@ -20,6 +20,36 @@ func (gammaComponent) Name() string {
 	return "gamma"
 }
 
+func TestGetEverythingFilter(t *testing.T) {
+	world := ecs.NewTestWorld(t)
+
+	assert.NilError(t, ecs.RegisterComponent[Alpha](world))
+	assert.NilError(t, ecs.RegisterComponent[Beta](world))
+	assert.NilError(t, ecs.RegisterComponent[Gamma](world))
+
+	assert.NilError(t, world.LoadGameState())
+
+	subsetCount := 50
+	wCtx := ecs.NewWorldContext(world)
+	_, err := component.CreateMany(wCtx, subsetCount, Alpha{}, Beta{})
+	assert.NilError(t, err)
+	// Make some entities that have all 3 component.
+	_, err = component.CreateMany(wCtx, 20, Alpha{}, Beta{}, Gamma{})
+	assert.NilError(t, err)
+
+	count := 0
+	// Loop over every entity. There should
+	// only be 50 + 20 entities.
+	q, err := wCtx.NewSearch(ecs.All())
+	assert.NilError(t, err)
+	err = q.Each(wCtx, func(id entity.ID) bool {
+		count++
+		return true
+	})
+	assert.NilError(t, err)
+	assert.Equal(t, count, subsetCount+20)
+}
+
 func TestCanFilterByArchetype(t *testing.T) {
 	world := ecs.NewTestWorld(t)
 

--- a/cardinal/filter.go
+++ b/cardinal/filter.go
@@ -9,6 +9,9 @@ type Filter interface {
 	convertToFilterable() ecs.Filterable
 }
 
+type all struct {
+}
+
 type and struct {
 	filters []Filter
 }
@@ -27,6 +30,10 @@ type contains struct {
 
 type exact struct {
 	components []metadata.Component
+}
+
+func All() Filter {
+	return &all{}
 }
 
 func And(filters ...Filter) Filter {
@@ -78,4 +85,8 @@ func (s contains) convertToFilterable() ecs.Filterable {
 
 func (s exact) convertToFilterable() ecs.Filterable {
 	return ecs.Exact(s.components...)
+}
+
+func (a all) convertToFilterable() ecs.Filterable {
+	return ecs.All()
 }

--- a/cardinal/search_test.go
+++ b/cardinal/search_test.go
@@ -78,6 +78,11 @@ func TestSearchExample(t *testing.T) {
 				cardinal.Contains(Beta{}),
 			), 20,
 		},
+		{
+			"all",
+			cardinal.All(),
+			70,
+		},
 	}
 	for _, tc := range testCases {
 		msg := "problem with " + tc.name

--- a/cardinal/server/debug.go
+++ b/cardinal/server/debug.go
@@ -1,0 +1,56 @@
+package server
+
+import (
+	"encoding/json"
+
+	"github.com/go-openapi/runtime/middleware/untyped"
+	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/entity"
+	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+)
+
+type DebugStateElement struct {
+	ID   entity.ID         `json:"id"`
+	Data []json.RawMessage `json:"data"`
+}
+
+type DebugStateResponse = []*DebugStateElement
+
+// register debug endpoints for swagger server.
+func (handler *Handler) registerDebugHandlerSwagger(api *untyped.API) {
+	// request name not required. This handler doesn't use anything in the request.
+	debugStateHandler :=
+		createSwaggerQueryHandler[interface{}, DebugStateResponse](
+			"", func(i *interface{}) (*DebugStateResponse, error) {
+				result := make(DebugStateResponse, 0)
+				search := ecs.NewSearch(filter.All())
+				wCtx := ecs.NewReadOnlyWorldContext(handler.w)
+
+				err := search.Each(wCtx, func(id entity.ID) bool {
+					components, err := handler.w.StoreManager().GetComponentTypesForEntity(id)
+					if err != nil {
+						return false
+					}
+					resultElement := DebugStateElement{
+						ID:   id,
+						Data: make([]json.RawMessage, 0),
+					}
+					for _, c := range components {
+						data, err := ecs.GetRawJSONOfComponent(handler.w, c, id)
+						if err != nil {
+							return false
+						}
+						resultElement.Data = append(resultElement.Data, data)
+					}
+					result = append(result, &resultElement)
+					return true
+				})
+				if err != nil {
+					return nil, err
+				}
+
+				return &result, nil
+			})
+
+	api.RegisterOperation("GET", "/debug/state", debugStateHandler)
+}

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -10,11 +10,12 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"pkg.world.dev/world-engine/cardinal/testutils"
 	"reflect"
 	"strconv"
 	"testing"
 	"time"
+
+	"pkg.world.dev/world-engine/cardinal/testutils"
 
 	"github.com/gorilla/websocket"
 	"pkg.world.dev/world-engine/cardinal/ecs/component"
@@ -64,6 +65,55 @@ func TestHealthEndpoint(t *testing.T) {
 		assert.Assert(t, healthResponse.IsServerRunning)
 		isGameLoopRunning = healthResponse.IsGameLoopRunning
 	}
+}
+
+type Alpha struct{}
+
+func (Alpha) Name() string { return "alpha" }
+
+type Beta struct{}
+
+func (Beta) Name() string { return "beta" }
+
+type Gamma struct{}
+
+func (Gamma) Name() string { return "gamma" }
+
+func TestDebugEndpoint(t *testing.T) {
+	world := ecs.NewTestWorld(t)
+
+	assert.NilError(t, ecs.RegisterComponent[Alpha](world))
+	assert.NilError(t, ecs.RegisterComponent[Beta](world))
+	assert.NilError(t, ecs.RegisterComponent[Gamma](world))
+
+	assert.NilError(t, world.LoadGameState())
+	ctx := context.Background()
+	worldCtx := ecs.NewWorldContext(world)
+	_, err := component.CreateMany(worldCtx, 10, Alpha{})
+	assert.NilError(t, err)
+	_, err = component.CreateMany(worldCtx, 10, Beta{})
+	assert.NilError(t, err)
+	_, err = component.CreateMany(worldCtx, 10, Gamma{})
+	assert.NilError(t, err)
+	_, err = component.CreateMany(worldCtx, 10, Alpha{}, Beta{})
+	assert.NilError(t, err)
+	_, err = component.CreateMany(worldCtx, 10, Alpha{}, Gamma{})
+	assert.NilError(t, err)
+	_, err = component.CreateMany(worldCtx, 10, Beta{}, Gamma{})
+	assert.NilError(t, err)
+	_, err = component.CreateMany(worldCtx, 10, Alpha{}, Beta{}, Gamma{})
+	assert.NilError(t, err)
+	err = world.Tick(ctx)
+	assert.NilError(t, err)
+	txh := testutils.MakeTestTransactionHandler(t, world, server.DisableSignatureVerification())
+	resp := txh.Get("debug/state")
+	assert.Equal(t, resp.StatusCode, 200)
+	bz, err := io.ReadAll(resp.Body)
+	assert.NilError(t, err)
+	data := make([]json.RawMessage, 0)
+	err = json.Unmarshal(bz, &data)
+	assert.NilError(t, err)
+	assert.Equal(t, len(data), 10*7)
 }
 
 func TestShutDownViaMethod(t *testing.T) {

--- a/cardinal/server/swagger.yml
+++ b/cardinal/server/swagger.yml
@@ -1,375 +1,405 @@
 consumes:
-    - application/json
+  - application/json
 info:
-    description: Backend server for World Engine
-    title: Cardinal
-    version: 0.0.1
+  description: Backend server for World Engine
+  title: Cardinal
+  version: 0.0.1
 produces:
-    - application/json
+  - application/json
 schemes:
-    - http
-    - ws
+  - http
+  - ws
 swagger: "2.0"
 
 paths:
-    /events:
-        get:
-            summary: Endpoint for events
-            description: websocket connection for events.
-            produces:
-                - application/json
-            responses:
-                '101':
-                    description: switch protocol to ws
-    /health:
-        get:
-            summary: Get information on status of world-engine
-            description: Displays information on http server and world game loop
-            produces:
-                - application/json
-            responses:
-                '200':
-                    description: successful operation
-                    schema:
-                        $ref: '#/definitions/HealthReply'
-    /tx/game/{txType}:
-        post:
-            summary: Submit a transaction to Cardinal
-            description: Submit a transaction to Cardinal
-            consumes:
-                - application/json
-            produces:
-                - application/json
-            parameters:
-                - name: txType
-                  in: path
-                  description: label of the transaction that wants to be submitted
-                  required: true
-                  type: string
-                - name: txBody
-                  in: body
-                  description: Transaction details
-                  required: true
-                  schema:
-                      $ref: '#/definitions/TxRequest'
-            responses:
-                '200':
-                    description: successful operation
-                    schema:
-                        $ref: '#/definitions/TxReply'
-                '400':
-                    description: Invalid transaction request
-    /tx/persona/create-persona:
-        post:
-            summary: Create a Persona transaction to Cardinal
-            description: Create a Persona transaction to Cardinal
-            consumes:
-                - application/json
-            produces:
-                - application/json
-            parameters:
-                - name: txBody
-                  in: body
-                  description: Transaction details
-                  required: true
-                  schema:
-                      $ref: '#/definitions/TxRequestWithCreatePersona'
-            responses:
-                '200':
-                    description: successful operation
-                    schema:
-                        $ref: '#/definitions/TxReply'
-                '400':
-                    description: Invalid transaction request
-    /query/game/cql:
-        post:
-            summary: Query the ecs with CQL (cardinal query language)
-            description: Query the ecs with CQL (cardinal query language)
-            consumes:
-                - application/json
-            produces:
-                - application/json
-            operationId: cql
-            responses:
-                200:
-                    description: cql results
-                    schema:
-                        $ref: '#/definitions/CQLResponse'
-            parameters:
-                - name: cql
-                  description: cql (cardinal query language)
-                  in: body
-                  required: true
-                  schema:
-                      $ref: '#/definitions/CQLRequest'
+  /debug/state:
+    get:
+      summary: Get information on all entities and components in world-engine
+      description: Displays the entire game state.
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/DebugStateResponse'
+  /events:
+    get:
+      summary: Endpoint for events
+      description: websocket connection for events.
+      produces:
+        - application/json
+      responses:
+        '101':
+          description: switch protocol to ws
+  /health:
+    get:
+      summary: Get information on status of world-engine
+      description: Displays information on http server and world game loop
+      produces:
+        - application/json
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/HealthReply'
+  /tx/game/{txType}:
+    post:
+      summary: Submit a transaction to Cardinal
+      description: Submit a transaction to Cardinal
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: txType
+          in: path
+          description: label of the transaction that wants to be submitted
+          required: true
+          type: string
+        - name: txBody
+          in: body
+          description: Transaction details
+          required: true
+          schema:
+            $ref: '#/definitions/TxRequest'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/TxReply'
+        '400':
+          description: Invalid transaction request
+  /tx/persona/create-persona:
+    post:
+      summary: Create a Persona transaction to Cardinal
+      description: Create a Persona transaction to Cardinal
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      parameters:
+        - name: txBody
+          in: body
+          description: Transaction details
+          required: true
+          schema:
+            $ref: '#/definitions/TxRequestWithCreatePersona'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/TxReply'
+        '400':
+          description: Invalid transaction request
+  /query/game/cql:
+    post:
+      summary: Query the ecs with CQL (cardinal query language)
+      description: Query the ecs with CQL (cardinal query language)
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: cql
+      responses:
+        200:
+          description: cql results
+          schema:
+            $ref: '#/definitions/CQLResponse'
+      parameters:
+        - name: cql
+          description: cql (cardinal query language)
+          in: body
+          required: true
+          schema:
+            $ref: '#/definitions/CQLRequest'
 
-    /query/game/{queryType}:
-        post:
-            summary: Query the ecs
-            description: Query the ecs
-            consumes:
-                - application/json
-            produces:
-                - application/json
-            operationId: query
-            parameters:
-                - name: queryType
-                  in: path
-                  description: The query type
-                  required: true
-                  type: string
-                - name: queryBody
-                  required: true
-                  in: body
-                  schema: {}
-            responses:
-                '200':
-                    description: query response
-                    schema: {}
-                '400':
-                    description: Invalid query request
-    /query/persona/signer:
-        post:
-            summary: Get persona data from cardinal
-            description: Get persona data from cardinal
-            consumes:
-                - application/json
-            produces:
-                - application/json
-            operationId: query
-            parameters:
-                - name: QueryPersonaSignerRequest
-                  required: true
-                  in: body
-                  schema:
-                      $ref: '#/definitions/QueryPersonaSignerRequest'
-            responses:
-                '200':
-                    description: query response
-                    schema:
-                        $ref: '#/definitions/QueryPersonaSignerResponse'
-                '400':
-                    description: Invalid query request
-    /query/http/endpoints:
-        post:
-            summary: Get all http endpoints from cardinal
-            description: Get all http endpoints from cardinal
-            consumes:
-                - application/json
-            produces:
-                - application/json
-            operationId: query
-            responses:
-                '200':
-                    description: list of query endpoints
-                    schema:
-                        $ref: '#/definitions/QueryListEndpoints'
-                '400':
-                    description: Invalid query request
-    /query/receipts/list:
-        post:
-            summary: Get transaction receipts from Cardinal
-            description: Get transaction receipts from Cardinal
-            consumes:
-                - application/json
-            produces:
-                - application/json
-            operationId: receipts
-            parameters:
-                - name: ListTxReceiptsRequest
-                  required: true
-                  in: body
-                  schema:
-                      $ref: '#/definitions/ListTxReceiptsRequest'
-            responses:
-                '200':
-                    description: successful operation
-                    schema:
-                        $ref: '#/definitions/ListTxReceiptsReply'
-                '400':
-                    description: Invalid transaction request
+  /query/game/{queryType}:
+    post:
+      summary: Query the ecs
+      description: Query the ecs
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: query
+      parameters:
+        - name: queryType
+          in: path
+          description: The query type
+          required: true
+          type: string
+        - name: queryBody
+          required: true
+          in: body
+          schema: { }
+      responses:
+        '200':
+          description: query response
+          schema: { }
+        '400':
+          description: Invalid query request
+  /query/persona/signer:
+    post:
+      summary: Get persona data from cardinal
+      description: Get persona data from cardinal
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: query
+      parameters:
+        - name: QueryPersonaSignerRequest
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/QueryPersonaSignerRequest'
+      responses:
+        '200':
+          description: query response
+          schema:
+            $ref: '#/definitions/QueryPersonaSignerResponse'
+        '400':
+          description: Invalid query request
+  /query/http/endpoints:
+    post:
+      summary: Get all http endpoints from cardinal
+      description: Get all http endpoints from cardinal
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: query
+      responses:
+        '200':
+          description: list of query endpoints
+          schema:
+            $ref: '#/definitions/QueryListEndpoints'
+        '400':
+          description: Invalid query request
+  /query/receipts/list:
+    post:
+      summary: Get transaction receipts from Cardinal
+      description: Get transaction receipts from Cardinal
+      consumes:
+        - application/json
+      produces:
+        - application/json
+      operationId: receipts
+      parameters:
+        - name: ListTxReceiptsRequest
+          required: true
+          in: body
+          schema:
+            $ref: '#/definitions/ListTxReceiptsRequest'
+      responses:
+        '200':
+          description: successful operation
+          schema:
+            $ref: '#/definitions/ListTxReceiptsReply'
+        '400':
+          description: Invalid transaction request
 
 definitions:
-    HealthReply:
-        type: object
-        required:
-            - isServerRunning
-            - isGameLoopRunning
-        properties:
-            isServerRunning:
-                type: boolean
-            isGameLoopRunning:
-                type: boolean
-    CQLResponse:
+  DebugStateResponse:
+    type: array
+    items:
+      $ref: "#/definitions/DebugStateResponseElement"
+  DebugStateResponseElement:
+    type: object
+    required:
+      - id
+      - data
+    properties:
+      id:
+        type: string
+      data:
+        type: array
+  HealthReply:
+    type: object
+    required:
+      - isServerRunning
+      - isGameLoopRunning
+    properties:
+      isServerRunning:
+        type: boolean
+      isGameLoopRunning:
+        type: boolean
+  CQLResponse:
+    type: array
+    items:
+      - $ref: "#/definitions/CQLResponseElement"
+  CQLResponseElement:
+    type: object
+    required:
+      - id
+      - data
+    properties:
+      id:
+        type: integer
+      data:
+        type: array
+  CQLRequest:
+    type: object
+    required:
+      - CQL
+    properties:
+      CQL:
+        type: string
+        example: "(EXACT(energyComponent) | CONTAINS(healthComponent)) & CONTAINS(goodGuyComponent)"
+  TxRequestWithCreatePersona:
+    required:
+      - personaTag
+      - namespace
+      - nonce
+      - signature
+      - body
+    type: object
+    properties:
+      personaTag:
+        type: string
+        example: CoolMage
+      namespace:
+        type: string
+        example: agar-shooter
+      nonce:
+        type: integer
+        format: int64
+      signature:
+        type: string
+      body:
+        $ref: '#/definitions/CreatePersonaTransaction'
+  CreatePersonaTransaction:
+    type: object
+    required:
+      - personaTag
+      - signerAddress
+    properties:
+      personaTag:
+        type: string
+      signerAddress:
+        type: string
+  CreatePersonaTransactionResult:
+    type: object
+    required:
+      - success
+    properties:
+      success:
+        type: boolean
+  QueryPersonaSignerRequest:
+    type: object
+    required:
+      - personaTag
+      - tick
+    properties:
+      personaTag:
+        type: string
+      tick:
+        type: integer
+        format: int64
+  QueryPersonaSignerResponse:
+    type: object
+    required:
+      - status
+      - signerAddress
+    properties:
+      status:
+        type: string
+      signerAddress:
+        type: string
+  QueryListEndpoints:
+    type: object
+    required:
+      - txEndpoints
+      - queryEndpoints
+      - debugEndpoints
+    properties:
+      txEndpoints:
         type: array
         items:
-            - $ref: "#/definitions/CQLResponseElement"
-    CQLResponseElement:
-        type: object
-        required:
-            - id
-            - data
-        properties:
-            id:
-                type: integer
-            data:
-                type: array
-    CQLRequest:
-        type: object
-        required:
-            - CQL
-        properties:
-            CQL:
-                type: string
-                example: "(EXACT(energyComponent) | CONTAINS(healthComponent)) & CONTAINS(goodGuyComponent)"
-    TxRequestWithCreatePersona:
-        required:
-            - personaTag
-            - namespace
-            - nonce
-            - signature
-            - body
-        type: object
-        properties:
-            personaTag:
-                type: string
-                example: CoolMage
-            namespace:
-                type: string
-                example: agar-shooter
-            nonce:
-                type: integer
-                format: int64
-            signature:
-                type: string
-            body:
-                $ref: '#/definitions/CreatePersonaTransaction'
-    CreatePersonaTransaction:
-        type: object
-        required:
-            - personaTag
-            - signerAddress
-        properties:
-            personaTag:
-                type: string
-            signerAddress:
-                type: string
-    CreatePersonaTransactionResult:
-        type: object
-        required:
-            - success
-        properties:
-            success:
-                type: boolean
-    QueryPersonaSignerRequest:
-        type: object
-        required:
-            - personaTag
-            - tick
-        properties:
-            personaTag:
-                type: string
-            tick:
-                type: integer
-                format: int64
-    QueryPersonaSignerResponse:
-        type: object
-        required:
-            - status
-            - signerAddress
-        properties:
-            status:
-                type: string
-            signerAddress:
-                type: string
-    QueryListEndpoints:
-        type: object
-        required:
-            - txEndpoints
-            - queryEndpoints
-        properties:
-            txEndpoints:
-                type: array
-                items:
-                    type: string
-            queryEndpoints:
-                type: array
-                items:
-                    type: string
+          type: string
+      queryEndpoints:
+        type: array
         items:
-            type: string
-    TxReply:
-        required:
-            - txHash
-            - tick
+          type: string
+      debugEndpoints:
+        type: array
+        items:
+          type: string
+    items:
+      type: string
+  TxReply:
+    required:
+      - txHash
+      - tick
+    type: object
+    properties:
+      txHash:
+        type: string
+      tick:
+        type: integer
+        format: int64
+  TxRequest:
+    required:
+      - personaTag
+      - namespace
+      - nonce
+      - signature
+      - body
+    type: object
+    properties:
+      personaTag:
+        type: string
+        example: CoolMage
+      namespace:
+        type: string
+        example: agar-shooter
+      nonce:
+        type: integer
+        format: int64
+      signature:
+        type: string
+      body:
         type: object
-        properties:
-            txHash:
-                type: string
-            tick:
-                type: integer
-                format: int64
-    TxRequest:
-        required:
-            - personaTag
-            - namespace
-            - nonce
-            - signature
-            - body
-        type: object
-        properties:
-            personaTag:
-                type: string
-                example: CoolMage
-            namespace:
-                type: string
-                example: agar-shooter
-            nonce:
-                type: integer
-                format: int64
-            signature:
-                type: string
-            body:
-                type: object
-    ListTxReceiptsRequest:
-        required:
-            - startTick
-        type: object
-        properties:
-            startTick:
-                type: integer
-                format: int64
-    ListTxReceiptsReply:
-        required:
-            - startTick
-            - endTick
-            - receipts
-        type: object
-        properties:
-            startTick:
-                type: integer
-                format: int64
-            endTick:
-                type: integer
-                format: int64
-            receipts:
-                type: array
-                items:
-                    $ref: '#/definitions/Receipts'
-    Receipts:
-        required:
-            - txHash
-            - tick
-            - result
-            - errors
-        type: object
-        properties:
-            txHash:
-                type: string
-            tick:
-                type: integer
-            result: {}
-            errors:
-                type: array
-                items:
-                    type: string
+  ListTxReceiptsRequest:
+    required:
+      - startTick
+    type: object
+    properties:
+      startTick:
+        type: integer
+        format: int64
+  ListTxReceiptsReply:
+    required:
+      - startTick
+      - endTick
+      - receipts
+    type: object
+    properties:
+      startTick:
+        type: integer
+        format: int64
+      endTick:
+        type: integer
+        format: int64
+      receipts:
+        type: array
+        items:
+          $ref: '#/definitions/Receipts'
+  Receipts:
+    required:
+      - txHash
+      - tick
+      - result
+      - errors
+    type: object
+    properties:
+      txHash:
+        type: string
+      tick:
+        type: integer
+      result: { }
+      errors:
+        type: array
+        items:
+          type: string

--- a/cardinal/testutils/test_utils.go
+++ b/cardinal/testutils/test_utils.go
@@ -2,6 +2,7 @@ package testutils
 
 import (
 	"bytes"
+	"context"
 	"crypto/ecdsa"
 	"encoding/json"
 	"errors"
@@ -93,6 +94,16 @@ func (t *TestTransactionHandler) Post(path string, payload any) *http.Response {
 	assert.NilError(t.T, err)
 	//nolint:noctx // its for a test its ok.
 	res, err := http.Post(t.MakeHTTPURL(path), "application/json", bytes.NewReader(bz))
+	assert.NilError(t.T, err)
+	return res
+}
+
+func (t *TestTransactionHandler) Get(path string) *http.Response {
+	url := t.MakeHTTPURL(path)
+	ctx := context.Background()
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	assert.NilError(t.T, err)
+	res, err := http.DefaultClient.Do(req)
 	assert.NilError(t.T, err)
 	return res
 }


### PR DESCRIPTION
Closes: #503

## What is the purpose of the change

Added a new filter called `All` This filter lives alongside `And` `Or` `Contains` and `Exact`. 
This filter is axiomatic meaning it is like `Contains` or `Exact` in that it is not constructed as a composition of other filters. 
`All` contains no components it simply matches true for every thing. 

in the future this new feature can be extended to CQL. 

Added a new route:

`/debug/state` that will do a search query using the All filter. 

## Testing and Verifying

Added a unit test on ecs.Search.
Added a integration test on the route `/debug/state`. 

