### PR TITLE
chore: add `go mod vendor` to test game/nakama start script

### DIFF
--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -6,6 +6,7 @@ rollup:
 	./chain/scripts/start.sh --build
 
 game:
+	cd internal/e2e/tester/cardinal && go mod vendor
 	@docker compose up game nakama --abort-on-container-exit postgres redis
 
 forge-build: |


### PR DESCRIPTION
## What is the purpose of the change

adds `go mod vendor` to test game/nakama start make script.

## Brief Changelog


## Testing and Verifying
