### PR TITLE
feat(cardinal): create new init system.

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -32,7 +32,7 @@ func TestCanQueryInsideSystem(t *testing.T) {
 	world, doTick := testutils.MakeWorldAndTicker(t, cardinal.WithCORS())
 	assert.NilError(t, cardinal.RegisterComponent[Foo](world))
 	wantNumOfEntities := 10
-	world.Init(func(worldCtx cardinal.WorldContext) {
+	world.RunInContextOfWorldContext(func(worldCtx cardinal.WorldContext) {
 		_, err := cardinal.CreateMany(worldCtx, wantNumOfEntities, Foo{})
 		assert.NilError(t, err)
 	})
@@ -63,9 +63,12 @@ func TestShutdownViaSignal(t *testing.T) {
 	assert.NilError(t, cardinal.RegisterComponent[Foo](world))
 	assert.NilError(t, err)
 	wantNumOfEntities := 10
-	world.Init(func(worldCtx cardinal.WorldContext) {
-		_, err := cardinal.CreateMany(worldCtx, wantNumOfEntities, Foo{})
-		assert.NilError(t, err)
+	world.Init(func(worldCtx cardinal.WorldContext) error {
+		_, err := cardinal.CreateMany(worldCtx, wantNumOfEntities/2, Foo{})
+		if err != nil {
+			return err
+		}
+		return nil
 	})
 	wg.Add(1)
 	go func() {
@@ -77,6 +80,10 @@ func TestShutdownViaSignal(t *testing.T) {
 		// wait until game loop is running
 		time.Sleep(500 * time.Millisecond)
 	}
+	world.RunInContextOfWorldContext(func(worldCtx cardinal.WorldContext) {
+		_, err := cardinal.CreateMany(worldCtx, wantNumOfEntities/2, Foo{})
+		assert.NilError(t, err)
+	})
 	// test CORS with cardinal
 	client := &http.Client{}
 	req, err := http.NewRequest(http.MethodPost, "http://localhost:4040/query/http/endpoints", nil)

--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -32,10 +32,9 @@ func TestCanQueryInsideSystem(t *testing.T) {
 	world, doTick := testutils.MakeWorldAndTicker(t, cardinal.WithCORS())
 	assert.NilError(t, cardinal.RegisterComponent[Foo](world))
 	wantNumOfEntities := 10
-	world.RunInContextOfWorldContext(func(worldCtx cardinal.WorldContext) {
-		_, err := cardinal.CreateMany(worldCtx, wantNumOfEntities, Foo{})
-		assert.NilError(t, err)
-	})
+	wCtx := cardinal.TestingWorldToWorldContext(world)
+	_, err := cardinal.CreateMany(wCtx, wantNumOfEntities, Foo{})
+	assert.NilError(t, err)
 	gotNumOfEntities := 0
 	cardinal.RegisterSystems(world, func(worldCtx cardinal.WorldContext) error {
 		q, err := worldCtx.NewSearch(cardinal.Exact(Foo{}))
@@ -50,7 +49,7 @@ func TestCanQueryInsideSystem(t *testing.T) {
 
 	doTick()
 	assert.Equal(t, world.CurrentTick(), uint64(1))
-	err := world.ShutDown()
+	err = world.ShutDown()
 	assert.Assert(t, err)
 	assert.Equal(t, gotNumOfEntities, wantNumOfEntities)
 }
@@ -80,10 +79,9 @@ func TestShutdownViaSignal(t *testing.T) {
 		// wait until game loop is running
 		time.Sleep(500 * time.Millisecond)
 	}
-	world.RunInContextOfWorldContext(func(worldCtx cardinal.WorldContext) {
-		_, err := cardinal.CreateMany(worldCtx, wantNumOfEntities/2, Foo{})
-		assert.NilError(t, err)
-	})
+	wCtx := cardinal.TestingWorldToWorldContext(world)
+	_, err = cardinal.CreateMany(wCtx, wantNumOfEntities/2, Foo{})
+	assert.NilError(t, err)
 	// test CORS with cardinal
 	client := &http.Client{}
 	req, err := http.NewRequest(http.MethodPost, "http://localhost:4040/query/http/endpoints", nil)

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -6,12 +6,13 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"pkg.world.dev/world-engine/cardinal/ecs/message"
 	"reflect"
 	"runtime"
 	"sync/atomic"
 	"syscall"
 	"time"
+
+	"pkg.world.dev/world-engine/cardinal/ecs/message"
 
 	"github.com/rs/zerolog/log"
 	"pkg.world.dev/world-engine/cardinal/ecs"
@@ -285,7 +286,14 @@ func (w *World) Tick(ctx context.Context) error {
 	return w.implWorld.Tick(ctx)
 }
 
-func (w *World) Init(fn func(WorldContext)) {
+func (w *World) RunInContextOfWorldContext(fn func(WorldContext)) {
 	ecsWorldCtx := ecs.NewWorldContext(w.implWorld)
 	fn(&worldContext{implContext: ecsWorldCtx})
+}
+
+// Init Registers a system that only runs once on a new game before tick 0.
+func (w *World) Init(system System) {
+	w.implWorld.AddInitSystem(func(ecsWctx ecs.WorldContext) error {
+		return system(&worldContext{implContext: ecsWctx})
+	})
 }

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -286,11 +286,6 @@ func (w *World) Tick(ctx context.Context) error {
 	return w.implWorld.Tick(ctx)
 }
 
-func (w *World) RunInContextOfWorldContext(fn func(WorldContext)) {
-	ecsWorldCtx := ecs.NewWorldContext(w.implWorld)
-	fn(&worldContext{implContext: ecsWorldCtx})
-}
-
 // Init Registers a system that only runs once on a new game before tick 0.
 func (w *World) Init(system System) {
 	w.implWorld.AddInitSystem(func(ecsWctx ecs.WorldContext) error {


### PR DESCRIPTION
Closes: #528

## What is the purpose of the change

Allows the developer to register a system for initialization. Sort of like a constructor. 

This replaces world.Init which would just run a function in the context of worldContet. When you used the old world.Init before starting the game loop it could trigger an error if entities were created. 

By default registered init system will do nothing.

## Brief Changelog

Modified some tests to check for stuff. 
Renamed the old init to `RunInContextOfWorldContext`
Made new `Init` function that registers a "constructor" system only at tick 0. 