### PR TITLE
feat(cardinal): WaitForNextTick blocks until a tick has been completed

### DIFF
--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -72,6 +72,9 @@ type World struct {
 	nextComponentID metadata.TypeID
 
 	eventHub events.EventHub
+
+	// addChannelWaitingForNextTick accepts a channel which will be closed after a tick has been completed.
+	addChannelWaitingForNextTick chan chan struct{}
 }
 
 var (
@@ -257,6 +260,8 @@ func NewWorld(nonceStore storage.NonceStorage, entityStore store.IManager, opts 
 		endGameLoopCh:     make(chan bool),
 		nextComponentID:   1,
 		evmTxReceipts:     make(map[string]EVMTxReceipt),
+
+		addChannelWaitingForNextTick: make(chan chan struct{}),
 	}
 	w.isGameLoopRunning.Store(false)
 	w.AddSystems(RegisterPersonaSystem, AuthorizePersonaAddressSystem)
@@ -427,54 +432,66 @@ func (w *World) StartGameLoop(ctx context.Context, tickStart <-chan time.Time, t
 	}
 
 	go func() {
-		tickTheWorld := func() {
-			currTick := w.CurrentTick()
-			if err := w.Tick(ctx); err != nil {
-				w.Logger.Panic().Err(err).Msg("Error running Tick in Game Loop.")
-			}
-			if tickDone != nil {
-				tickDone <- currTick
-			}
-		}
+		var waitingChs []chan struct{}
 		w.isGameLoopRunning.Store(true)
 	loop:
 		for {
 			select {
 			case <-tickStart:
-				tickTheWorld()
+				w.tickTheWorld(ctx, tickDone)
+				closeAllChannels(waitingChs)
+				waitingChs = waitingChs[:0]
 			case <-w.endGameLoopCh:
+				w.drainChannelsWaitingForNextTick()
+				closeAllChannels(waitingChs)
 				if w.GetTxQueueAmount() > 0 {
-					tickTheWorld() // immediately tick if queue is not empty to process all txs if queue is not empty.
+					// immediately tick if queue is not empty to process all txs if queue is not empty.
+					w.tickTheWorld(ctx, tickDone)
 				}
 				break loop
+			case ch := <-w.addChannelWaitingForNextTick:
+				waitingChs = append(waitingChs, ch)
 			}
 		}
 		w.isGameLoopRunning.Store(false)
 	}()
 }
 
-// WaitForNextTick waits for the next tick. It returns true if it successfully waited for the next tick.
-// Returns false if we hit the timout threshold (5s).
-//
-// TODO: we probably want to make this timeout related to the actual tick hz.
-// If a game has 10s ticks, this wouldn't work.
-// ticket: https://linear.app/arguslabs/issue/WORLD-430/make-waitfornextticks-timeout-and-sleep-duration-a-factor-of-the
-func (w *World) WaitForNextTick() bool {
-	current := w.CurrentTick()
-	timeout := time.After(5 * time.Second) //nolint:gomnd // fine for now.
-
-	for {
-		if w.CurrentTick() > current {
-			return true
-		}
-		select {
-		case <-timeout:
-			return false // Timeout reached
-		default:
-			// TODO: sleep time should be a factor of the tick hz itself.
-			time.Sleep(500 * time.Millisecond) //nolint:gomnd // fine for now.
-		}
+func closeAllChannels(chs []chan struct{}) {
+	for _, ch := range chs {
+		close(ch)
 	}
+}
+
+func (w *World) tickTheWorld(ctx context.Context, tickDone chan<- uint64) {
+	currTick := w.CurrentTick()
+	if err := w.Tick(ctx); err != nil {
+		w.Logger.Panic().Err(err).Msg("Error running Tick in Game Loop.")
+	}
+	if tickDone != nil {
+		tickDone <- currTick
+	}
+}
+
+// drainChannelsWaitingForNextTick continually closes any channels that are added to the
+// addChannelWaitingForNextTick channel. This is used when the world is shut down; it ensures
+// any calls to WaitForNextTick that happen after a shutdown will not block.
+func (w *World) drainChannelsWaitingForNextTick() {
+	go func() {
+		for ch := range w.addChannelWaitingForNextTick {
+			close(ch)
+		}
+	}()
+}
+
+// WaitForNextTick blocks until at least one game tick has completed. It returns true if it successfully waited for a
+// tick. False may be returned if the world was shut down while waiting for the next tick to complete.
+func (w *World) WaitForNextTick() (success bool) {
+	startTick := w.CurrentTick()
+	ch := make(chan struct{})
+	w.addChannelWaitingForNextTick <- ch
+	<-ch
+	return w.CurrentTick() > startTick
 }
 
 func (w *World) IsGameLoopRunning() bool {
@@ -560,7 +577,7 @@ func (w *World) RecoverFromChain(ctx context.Context) error {
 		return fmt.Errorf("chain adapter was nil. " +
 			"be sure to use the `WithAdapter` option when creating the world")
 	}
-	if w.tick > 0 {
+	if w.CurrentTick() > 0 {
 		return fmt.Errorf("world recovery should not occur in a world with existing state. please verify all " +
 			"state has been cleared before running recovery")
 	}

--- a/cardinal/evm/server_test.go
+++ b/cardinal/evm/server_test.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"gotest.tools/v3/assert"
-
+	"gotest.tools/v3/assert/cmp"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	routerv1 "pkg.world.dev/world-engine/rift/router/v1"
 	"pkg.world.dev/world-engine/sign"
@@ -48,24 +49,28 @@ func TestServer_SendMessage(t *testing.T) {
 		{Y: 400, Z: false},
 	}
 
-	// need the system to tick for adding the persona + authorized address. so wrapping the test system below
-	// in an enabled block to prevent it from checking test cases until the persona transactions are handled.
-	enabled := false
+	currFooIndex := 0
+	currBarIndex := 0
 
-	// add a system that checks that they are submitted properly to the world.
+	// add a system that checks that they are submitted properly to the world in the correct order.
 	w.AddSystem(func(wCtx ecs.WorldContext) error {
-		if !enabled {
-			return nil
-		}
 		inFooTxs := fooTx.In(wCtx)
 		inBarTxs := barTx.In(wCtx)
-		assert.Equal(t, len(inFooTxs), len(fooTxs))
-		assert.Equal(t, len(inBarTxs), len(barTxs))
-		for i, tx := range inFooTxs {
-			assert.DeepEqual(t, tx.Msg, fooTxs[i])
+		if len(inFooTxs) == 0 && len(inBarTxs) == 0 {
+			return nil
 		}
-		for i, tx := range inBarTxs {
-			assert.DeepEqual(t, tx.Msg, barTxs[i])
+		// Make sure we're only dealing with 1 transaction
+		assert.Equal(t, 1, len(inFooTxs)+len(inBarTxs))
+
+		if len(inFooTxs) > 0 {
+			assert.Check(t, cmp.DeepEqual(inFooTxs[0].Msg, fooTxs[currFooIndex]))
+			currFooIndex++
+		} else {
+			assert.Check(t, cmp.DeepEqual(inBarTxs[0].Msg, barTxs[currBarIndex]))
+			currBarIndex++
+
+			// Make sure we process the bar transaction AFTER all the foo transactions
+			assert.Check(t, len(fooTxs) == currFooIndex, "%d is not %d", len(inFooTxs), currFooIndex)
 		}
 		return nil
 	})
@@ -81,44 +86,57 @@ func TestServer_SendMessage(t *testing.T) {
 	ecs.AuthorizePersonaAddressMsg.AddToQueue(w, ecs.AuthorizePersonaAddress{
 		Address: sender,
 	}, &sign.Transaction{PersonaTag: personaTag})
-	err := w.Tick(context.Background())
-	assert.NilError(t, err)
-
-	// now that the persona transactions are handled, we can flip enabled to true, allowing the test system to run.
-	enabled = true
+	tickStartCh := make(chan time.Time)
+	tickDoneCh := make(chan uint64)
+	w.StartGameLoop(context.Background(), tickStartCh, tickDoneCh)
+	// Process an initial tick so the CreatePersona transaction will be processed
+	tickStartCh <- time.Now()
+	<-tickDoneCh
 
 	server, err := NewServer(w)
 	assert.NilError(t, err)
 
-	// marshal out the bytes to send from each list of transactions.
-	for _, tx := range fooTxs {
-		var fooTxBz []byte
-		fooTxBz, err = fooTx.ABIEncode(tx)
-		assert.NilError(t, err)
-		_, err = server.SendMessage(context.Background(), &routerv1.SendMessageRequest{
-			Sender:    sender,
-			Message:   fooTxBz,
-			MessageId: fooTx.Name(),
-		})
-		assert.NilError(t, err)
-	}
-	for _, tx := range barTxs {
-		var barTxBz []byte
-		barTxBz, err = barTx.ABIEncode(tx)
-		assert.NilError(t, err)
-		_, err = server.SendMessage(context.Background(), &routerv1.SendMessageRequest{
-			Sender:    sender,
-			Message:   barTxBz,
-			MessageId: barTx.Name(),
-		})
-		assert.NilError(t, err)
-	}
+	txSequenceDone := make(chan struct{})
+	// Send in each transaction one at a time
+	go func() {
+		// marshal out the bytes to send from each list of transactions.
+		for _, tx := range fooTxs {
+			var fooTxBz []byte
+			fooTxBz, err = fooTx.ABIEncode(tx)
+			assert.NilError(t, err)
+			_, err = server.SendMessage(context.Background(), &routerv1.SendMessageRequest{
+				Sender:    sender,
+				Message:   fooTxBz,
+				MessageId: fooTx.Name(),
+			})
+			assert.NilError(t, err)
+		}
+		for _, tx := range barTxs {
+			var barTxBz []byte
+			barTxBz, err = barTx.ABIEncode(tx)
+			assert.NilError(t, err)
+			_, err = server.SendMessage(context.Background(), &routerv1.SendMessageRequest{
+				Sender:    sender,
+				Message:   barTxBz,
+				MessageId: barTx.Name(),
+			})
+			assert.NilError(t, err)
+		}
+		close(txSequenceDone)
+	}()
 
-	// we already sent the transactions through to the server, which should pipe them into the transaction queue.
-	// all we need to do now is tick so the system can run, which will check that we got the transactions we just
-	// piped through above.
-	err = w.Tick(context.Background())
-	assert.NilError(t, err)
+loop:
+	for {
+		select {
+		case tickStartCh <- time.Now():
+			<-tickDoneCh
+		case <-txSequenceDone:
+			break loop
+		}
+	}
+	// Make sure we saw the correct number of foo and bar transactions
+	assert.Equal(t, len(fooTxs), currFooIndex)
+	assert.Equal(t, len(barTxs), currBarIndex)
 }
 
 func TestServer_Query(t *testing.T) {


### PR DESCRIPTION
Closes: #WORLD-430

## What is the purpose of the change

Update the WaitForNextTick method to use channels to block until a tick has completed. Remove the timeout path.
 
The TestServer_SendMessage test has also been refactors. The SendMessage method waits until a tick has completed before returning, which means it wouldn't be possible to call SendMessage 5 times to queue up 5 messages in the same tick. The test has been refactored so the SendMessage calls happen sequentially across multiple ticks.

This is OK in production, because a separate goroutine will be handling each SendMessage call. 

## Testing and Verifying

- Added unit test that validates the WaitForNextTick will block until a tick has completed, and will NOT block if the world has been shut down.