### PR TITLE
chore(db): replace Nakama PostgresDB with CockroachDB

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,24 +1,26 @@
 version: '3'
 services:
-  postgres:
-    command: postgres -c shared_preload_libraries=pg_stat_statements -c pg_stat_statements.track=all
+  cockroachdb:
+    image: cockroachdb/cockroach:latest-v23.1
+    command: start-single-node --insecure --store=attrs=ssd,path=/var/lib/cockroach/
+    restart: "no"
     environment:
-      - POSTGRES_DB=nakama
-      - POSTGRES_PASSWORD=localdb
+      - COCKROACH_DATABASE=nakama
+      - COCKROACH_USER=root
+      - COCKROACH_PASSWORD=${DB_PASSWORD:-development}
+    volumes:
+      - data:/var/lib/cockroach
     expose:
       - "8080"
-      - "5432"
-    image: postgres:12.2-alpine
+      - "26257"
     ports:
-      - "5432:5432"
+      - "26257:26257"
       - "8080:8080"
     healthcheck:
-      test: [ "CMD", "pg_isready", "-U", "postgres", "-d", "nakama" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]
       interval: 3s
       timeout: 3s
       retries: 5
-    volumes:
-      - data:/var/lib/postgresql/data
     networks:
       - world-engine
 
@@ -27,7 +29,7 @@ services:
     platform: linux/amd64
     build: ./relay/nakama
     depends_on:
-      postgres:
+      cockroachdb:
         condition: service_healthy
       game:
         condition: service_started
@@ -35,12 +37,13 @@ services:
       - CARDINAL_ADDR=game:4040
       - CARDINAL_NAMESPACE=TESTGAME
       - ENABLE_ALLOWLIST=${ENABLE_ALLOWLIST:-false}
+      - DB_PASSWORD=${DB_PASSWORD:-development}
     entrypoint:
       - "/bin/sh"
       - "-ecx"
       - >
-        /nakama/nakama migrate up --database.address postgres:localdb@postgres:5432/nakama &&
-        exec /nakama/nakama --config /nakama/data/local.yml --database.address postgres:localdb@postgres:5432/nakama
+        /nakama/nakama migrate up --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama &&
+        exec /nakama/nakama --config /nakama/data/local.yml --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama
     expose:
       - "7349"
       - "7350"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   cockroachdb:
+    # Use cockroachdb single-node clusters for non-production testing
     image: cockroachdb/cockroach:latest-v23.1
     command: start-single-node --insecure --store=attrs=ssd,path=/var/lib/cockroach/
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   cockroachdb:
-    # Use cockroachdb single-node clusters for non-production testing
+    # Only use cockroachdb single-node clusters for non-production environment
     image: cockroachdb/cockroach:latest-v23.1
     command: start-single-node --insecure --store=attrs=ssd,path=/var/lib/cockroach/,size=20%
     restart: "no"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ services:
   cockroachdb:
     # Use cockroachdb single-node clusters for non-production testing
     image: cockroachdb/cockroach:latest-v23.1
-    command: start-single-node --insecure --store=attrs=ssd,path=/var/lib/cockroach/
+    command: start-single-node --insecure --store=attrs=ssd,path=/var/lib/cockroach/,size=20%
     restart: "no"
     environment:
       - COCKROACH_DATABASE=nakama

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -8,7 +8,7 @@ rollup:
 
 game:
 	cd internal/e2e/tester/cardinal && go mod vendor
-	@docker compose up game nakama --abort-on-container-exit postgres redis
+	@docker compose up game nakama --abort-on-container-exit cockroachdb redis
 
 forge-build: |
 	@forge build --extra-output-files bin --extra-output-files abi  --root evm/precompile/contracts


### PR DESCRIPTION
Closes: #DEVOP-112 #DEVOP-113

## What is the purpose of the change

> 
- Nakama doesn't officially support Postgres (see https://heroiclabs.com/docs/nakama/getting-started/install/linux/#cockroachdb), it's for development environments only.
- We should switch it to CockroachDB which is officially supported and with queries optimized for its storage engine.

## Brief Changelog

- _Change Docker Compose setup to use CockroachDB for development (Single-node clusters)_
- _Fix makefile_
- _Use $DB_PASSWORD as env variable instead of plain text, the default value is "development"._

## Testing and Verifying

- This change is covered by existing E2E tests.
