### PR TITLE
perf: improve codec performance

### DIFF
--- a/cardinal/ecs/codec/codec.go
+++ b/cardinal/ecs/codec/codec.go
@@ -1,29 +1,22 @@
 package codec
 
 import (
-	"bytes"
-	"encoding/json"
+	"github.com/goccy/go-json"
 )
 
 func Decode[T any](bz []byte) (T, error) {
-	var buf bytes.Buffer
-	buf.Write(bz)
-	dec := json.NewDecoder(&buf)
 	comp := new(T)
-	err := dec.Decode(comp)
-	var t T
+	err := json.Unmarshal(bz, comp)
 	if err != nil {
-		return t, err
+		return *comp, err
 	}
 	return *comp, nil
 }
 
 func Encode(comp any) ([]byte, error) {
-	var buf bytes.Buffer
-	enc := json.NewEncoder(&buf)
-	err := enc.Encode(comp)
+	bz, err := json.Marshal(comp)
 	if err != nil {
 		return nil, err
 	}
-	return buf.Bytes(), nil
+	return bz, nil
 }

--- a/cardinal/ecs/codec/codec_test.go
+++ b/cardinal/ecs/codec/codec_test.go
@@ -1,0 +1,48 @@
+package codec_test
+
+import (
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
+	"testing"
+)
+
+// Define a dummy struct for benchmarking
+type ExampleStruct struct {
+	ID   int
+	Name string
+}
+
+// Benchmark the Decode function
+func BenchmarkDecode(b *testing.B) {
+	// Prepare a byte slice to decode
+	data := []byte(`{"ID": 1, "Name": "Example"}`)
+
+	b.ResetTimer() // Reset the timer
+
+	// Run the benchmark
+	for i := 0; i < b.N; i++ {
+		_, err := codec.Decode[ExampleStruct](data)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// Benchmark the Encode function
+func BenchmarkEncode(b *testing.B) {
+	// Prepare an example struct to encode
+	example := ExampleStruct{
+		ID:   1,
+		Name: "Example",
+	}
+
+	// Reset the timer
+	b.ResetTimer()
+
+	// Run the benchmark
+	for i := 0; i < b.N; i++ {
+		_, err := codec.Encode(example)
+		if err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/cardinal/ecs/codec/codec_test.go
+++ b/cardinal/ecs/codec/codec_test.go
@@ -1,17 +1,18 @@
 package codec_test
 
 import (
-	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 	"testing"
+
+	"pkg.world.dev/world-engine/cardinal/ecs/codec"
 )
 
-// Define a dummy struct for benchmarking
+// Define a dummy struct for benchmarking.
 type ExampleStruct struct {
 	ID   int
 	Name string
 }
 
-// Benchmark the Decode function
+// Benchmark the Decode function.
 func BenchmarkDecode(b *testing.B) {
 	// Prepare a byte slice to decode
 	data := []byte(`{"ID": 1, "Name": "Example"}`)
@@ -27,7 +28,7 @@ func BenchmarkDecode(b *testing.B) {
 	}
 }
 
-// Benchmark the Encode function
+// Benchmark the Encode function.
 func BenchmarkEncode(b *testing.B) {
 	// Prepare an example struct to encode
 	example := ExampleStruct{

--- a/cardinal/go.mod
+++ b/cardinal/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/go-openapi/loads v0.21.2
 	github.com/go-openapi/runtime v0.26.0
+	github.com/goccy/go-json v0.10.2
 	github.com/google/uuid v1.3.1
 	github.com/gorilla/websocket v1.5.0
 	github.com/invopop/jsonschema v0.7.0

--- a/cardinal/go.sum
+++ b/cardinal/go.sum
@@ -290,6 +290,8 @@ github.com/gobuffalo/packd v0.1.0/go.mod h1:M2Juc+hhDXf/PnmBANFCqx4DM3wRbgDvnVWe
 github.com/gobuffalo/packr/v2 v2.0.9/go.mod h1:emmyGweYTm6Kdper+iywB6YK5YzuKchGtJQZ0Odn4pQ=
 github.com/gobuffalo/packr/v2 v2.2.0/go.mod h1:CaAwI0GPIAv+5wKLtv8Afwl+Cm78K/I/VCm/3ptBN+0=
 github.com/gobuffalo/syncx v0.0.0-20190224160051-33c29581e754/go.mod h1:HhnNqWY95UYwwW3uSASeV7vtgYkT2t16hJgV3AEPUpw=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2 h1:ZpnhV/YsD2/4cESfV5+Hoeu/iUR3ruzNvZ+yQfO03a0=
 github.com/godbus/dbus v0.0.0-20190726142602-4481cbc300e2/go.mod h1:bBOAhwG1umN6/6ZUMtDFBMQR8jRg9O75tm9K00oMsK4=
 github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5xrFpKfA=


### PR DESCRIPTION
Closes: #XXX

## What is the purpose of the change

> Add a description of the overall background and high-level changes that this PR introduces

![image](https://github.com/Argus-Labs/world-engine/assets/4402697/bcd166bc-f23a-4a16-8347-60ae757c46be)

Our current codec is unoptimized. It uses the stdlib json that have low hanging performance improvement. We also used an encoder unnecessarily when we could just use marshal/unmarshal, leading to an additional object allocation.

By doing this, we are able to significantly speed up the codec while reducing memory foot print. See benchmark results below 

**Before**
```
goos: darwin
goarch: arm64
pkg: pkg.world.dev/world-engine/cardinal/ecs/codec
BenchmarkDecode
BenchmarkDecode       	 1786486	       710.6 ns/op	    1056 B/op	      10 allocs/op
BenchmarkDecode-5     	 1998490	       597.9 ns/op	    1056 B/op	      10 allocs/op
BenchmarkDecode-10    	 2008329	       592.2 ns/op	    1056 B/op	      10 allocs/op
BenchmarkEncode
BenchmarkEncode       	 7187788	       164.3 ns/op	     136 B/op	       3 allocs/op
BenchmarkEncode-5     	 7717502	       155.8 ns/op	     136 B/op	       3 allocs/op
BenchmarkEncode-10    	 7776729	       155.2 ns/op	     136 B/op	       3 allocs/op
```

**After**
```
goos: darwin
goarch: arm64
pkg: pkg.world.dev/world-engine/cardinal/ecs/codec
BenchmarkDecode
BenchmarkDecode       	10113783	       105.2 ns/op	      56 B/op	       2 allocs/op
BenchmarkDecode-5     	12597741	        94.95 ns/op	      56 B/op	       2 allocs/op
BenchmarkDecode-10    	12556930	        96.06 ns/op	      56 B/op	       2 allocs/op
BenchmarkEncode
BenchmarkEncode       	13534896	        90.63 ns/op	      56 B/op	       2 allocs/op
BenchmarkEncode-5     	15366384	        76.47 ns/op	      56 B/op	       2 allocs/op
BenchmarkEncode-10    	15823453	        81.75 ns/op	      56 B/op	       2 allocs/op
PASS
```

## Brief Changelog

- Use https://github.com/goccy/go-json which is a drop-in replacement of stdlib json
- Switch to marshal/unmarshal instead of encoder/decoder
- Add benchmarks

## Testing and Verifying

- Added benchmark