### PR TITLE
feat(cardinal): add eris (errors with stacktraces) to eventhub

### DIFF
--- a/cardinal/events/events_test.go
+++ b/cardinal/events/events_test.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"pkg.world.dev/world-engine/cardinal"
-	"pkg.world.dev/world-engine/cardinal/testutils"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
+
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/testutils"
 
 	"gotest.tools/v3/assert"
 
@@ -21,6 +23,23 @@ import (
 	"pkg.world.dev/world-engine/cardinal/events"
 	"pkg.world.dev/world-engine/cardinal/server"
 )
+
+func TestEventError(t *testing.T) {
+	err := events.WebSocketEchoHandler(nil)
+	fmt.Println(eris.ToString(err, true))
+	mappedJson := eris.ToJSON(err, true)
+	fmt.Println(mappedJson)
+	v, ok := mappedJson["root"]
+	assert.Assert(t, ok)
+	v1, ok := v.(map[string]interface{})
+	assert.Assert(t, ok)
+	v2, ok := v1["stack"]
+	assert.Assert(t, ok)
+	v3, ok := v2.([]string)
+	assert.Assert(t, ok)
+	assert.Assert(t, len(v3) > 0)
+
+}
 
 func TestEvents(t *testing.T) {
 	// broadcast 5 messages to 5 clients means 25 messages received.

--- a/cardinal/events/events_test.go
+++ b/cardinal/events/events_test.go
@@ -26,10 +26,9 @@ import (
 
 func TestEventError(t *testing.T) {
 	err := events.WebSocketEchoHandler(nil)
-	fmt.Println(eris.ToString(err, true))
-	mappedJson := eris.ToJSON(err, true)
-	fmt.Println(mappedJson)
-	v, ok := mappedJson["root"]
+	// fmt.Println(eris.ToString(err, true))
+	mappedJSON := eris.ToJSON(err, true)
+	v, ok := mappedJSON["root"]
 	assert.Assert(t, ok)
 	v1, ok := v.(map[string]interface{})
 	assert.Assert(t, ok)
@@ -38,7 +37,6 @@ func TestEventError(t *testing.T) {
 	v3, ok := v2.([]string)
 	assert.Assert(t, ok)
 	assert.Assert(t, len(v3) > 0)
-
 }
 
 func TestEvents(t *testing.T) {

--- a/cardinal/go.mod
+++ b/cardinal/go.mod
@@ -122,6 +122,7 @@ require (
 	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.11.1 // indirect
 	github.com/rogpeppe/go-internal v1.11.0 // indirect
+	github.com/rotisserie/eris v0.5.4 // indirect
 	github.com/sasha-s/go-deadlock v0.3.1 // indirect
 	github.com/spf13/cast v1.5.1 // indirect
 	github.com/spf13/cobra v1.7.0 // indirect

--- a/cardinal/go.sum
+++ b/cardinal/go.sum
@@ -670,6 +670,8 @@ github.com/rollkit/cosmos-sdk v0.50.0-rc.0-rollkit-v0.11.0-rc2-no-fraud-proofs-p
 github.com/rollkit/cosmos-sdk v0.50.0-rc.0-rollkit-v0.11.0-rc2-no-fraud-proofs-polaris/go.mod h1:9ityGu51zyF2IIfj4CmIfK+W+iNl1cwCmKjZbpDAyS8=
 github.com/rollkit/rollkit v0.11.0-rc2 h1:a4tCmrWnUOPweEerj5bH4w4vCRPx8ACKmSWNYExRj7M=
 github.com/rollkit/rollkit v0.11.0-rc2/go.mod h1:HP99tiFSjXcaidbHTp/Pucog7sA2N9qlIV4VAgIGdHE=
+github.com/rotisserie/eris v0.5.4 h1:Il6IvLdAapsMhvuOahHWiBnl1G++Q0/L5UIkI5mARSk=
+github.com/rotisserie/eris v0.5.4/go.mod h1:Z/kgYTJiJtocxCbFfvRmO+QejApzG6zpyky9G1A4g9s=
 github.com/rs/cors v1.10.1 h1:L0uuZVXIKlI1SShY2nhFfo44TYvDPQ1w4oFkUJNfhyo=
 github.com/rs/cors v1.10.1/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
 github.com/rs/xid v1.5.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=


### PR DESCRIPTION
Closes: WORLD-536

## Overview

This is a sub issue of https://linear.app/arguslabs/issue/WORLD-451/find-a-way-to-get-all-errors-to-be-paired-with-stack-trace

Relevant conversation here: https://argus-labs.slack.com/archives/C03G859K5TQ/p1699905811770509

This is a first PR of many that will eventually convert world-engine to use errors from this package:

https://github.com/rotisserie/eris

For the first part I just chose a really tiny use case to get a feel for the library. EventHub does not really create many custom errors. 

One drawback is that errors instantiated from other libraries or packages will not have stack traces. As soon as these errors touch our ecosystem we will have to wrap the errors with `erin.Wrap(err, "")` We can add additional error messages in place of the empty string. 

New errors can simply be instantiated with `erin.New` or `erin.Errorf`

## Tests

See the test for a demonstration about how this works. 

`eris.ToJSON` will create a nested map with the stack trace in map["root"]["stack"] as a list of strings where each string is one level on the stack. 
`eris.ToString` will create a string with readable stack trace. 

