### PR TITLE
fix(cardinal): startup and shutdown race conditions

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -84,7 +84,7 @@ func TestShutdownViaSignal(t *testing.T) {
 	}()
 	for !world.IsGameRunning() {
 		// wait until game loop is running
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 	}
 	wCtx := cardinal.TestingWorldToWorldContext(world)
 	_, err := cardinal.CreateMany(wCtx, wantNumOfEntities/2, Foo{})
@@ -115,7 +115,7 @@ func TestShutdownViaSignal(t *testing.T) {
 
 	for world.IsGameRunning() {
 		// wait until game loop is not running
-		time.Sleep(500 * time.Millisecond)
+		time.Sleep(50 * time.Millisecond)
 	}
 	wg.Wait()
 }

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -165,7 +165,7 @@ var (
 // given tick. If the world's tick is less than or equal to the given tick, ErrorCreatePersonaTXsNotProcessed is
 // returned. If the given personaTag has no signer address, ErrPersonaTagHasNoSigner is returned.
 func (w *World) GetSignerForPersonaTag(personaTag string, tick uint64) (addr string, err error) {
-	if tick >= w.tick {
+	if tick >= w.CurrentTick() {
 		return "", ErrCreatePersonaTxsNotProcessed
 	}
 	var errs []error

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -561,7 +561,7 @@ func (w *World) drainChannelsWaitingForNextTick() {
 
 func (w *World) drainEndLoopChannels() {
 	go func() {
-		for range w.endGameLoopCh {
+		for range w.endGameLoopCh { //nolint:revive // This pattern drains the channel until closed
 		}
 	}()
 }

--- a/cardinal/events/events.go
+++ b/cardinal/events/events.go
@@ -208,6 +208,11 @@ Loop:
 			waitGroup.Wait()
 			eh.eventQueue = eh.eventQueue[:0]
 		case <-eh.shutdown:
+			// Toss out any future signals to shut down
+			go func() {
+				for range eh.shutdown {
+				}
+			}()
 			for conn := range eh.websocketConnections {
 				unregisterConnection(conn)
 			}

--- a/cardinal/events/events.go
+++ b/cardinal/events/events.go
@@ -208,9 +208,8 @@ Loop:
 			waitGroup.Wait()
 			eh.eventQueue = eh.eventQueue[:0]
 		case <-eh.shutdown:
-			// Toss out any future signals to shut down
 			go func() {
-				for range eh.shutdown {
+				for range eh.shutdown { //nolint:revive // This pattern drains the channel until closed
 				}
 			}()
 			for conn := range eh.websocketConnections {

--- a/cardinal/gamestage/gamestage.go
+++ b/cardinal/gamestage/gamestage.go
@@ -5,10 +5,10 @@ import "sync/atomic"
 type Stage int32
 
 type Atomic interface {
-	CompareAndSwap(old, new Stage) (swapped bool)
+	CompareAndSwap(oldStage, newStage Stage) (swapped bool)
 	Load() Stage
 	Store(val Stage)
-	Swap(new Stage) (old Stage)
+	Swap(newStage Stage) (oldStage Stage)
 }
 
 const (
@@ -31,8 +31,8 @@ func NewAtomic() Atomic {
 	return a
 }
 
-func (a *atomicStage) CompareAndSwap(old, new Stage) (swapped bool) {
-	return a.value.CompareAndSwap(old, new)
+func (a *atomicStage) CompareAndSwap(oldStage, newStage Stage) (swapped bool) {
+	return a.value.CompareAndSwap(oldStage, newStage)
 }
 
 func (a *atomicStage) Load() Stage {
@@ -43,6 +43,6 @@ func (a *atomicStage) Store(val Stage) {
 	a.value.Store(val)
 }
 
-func (a *atomicStage) Swap(new Stage) (old Stage) {
-	return a.value.Swap(new).(Stage)
+func (a *atomicStage) Swap(newStage Stage) (oldStage Stage) {
+	return a.value.Swap(newStage).(Stage)
 }

--- a/cardinal/gamestage/gamestage.go
+++ b/cardinal/gamestage/gamestage.go
@@ -1,0 +1,48 @@
+package gamestage
+
+import "sync/atomic"
+
+type Stage int32
+
+type Atomic interface {
+	CompareAndSwap(old, new Stage) (swapped bool)
+	Load() Stage
+	Store(val Stage)
+	Swap(new Stage) (old Stage)
+}
+
+const (
+	StagePreStart Stage = iota
+	StageStarting
+	StageRunning
+	StageShuttingDown
+	StageShutDown
+)
+
+type atomicStage struct {
+	value *atomic.Value
+}
+
+func NewAtomic() Atomic {
+	a := &atomicStage{
+		value: &atomic.Value{},
+	}
+	a.Store(StagePreStart)
+	return a
+}
+
+func (a *atomicStage) CompareAndSwap(old, new Stage) (swapped bool) {
+	return a.value.CompareAndSwap(old, new)
+}
+
+func (a *atomicStage) Load() Stage {
+	return a.value.Load().(Stage)
+}
+
+func (a *atomicStage) Store(val Stage) {
+	a.value.Store(val)
+}
+
+func (a *atomicStage) Swap(new Stage) (old Stage) {
+	return a.value.Swap(new).(Stage)
+}

--- a/cardinal/gamestage/gamestage_test.go
+++ b/cardinal/gamestage/gamestage_test.go
@@ -1,0 +1,51 @@
+package gamestage
+
+import (
+	"testing"
+
+	"gotest.tools/v3/assert"
+)
+
+func TestCanOperateOnZeroValue(t *testing.T) {
+	atomicGameStage := NewAtomic()
+	gotStage := atomicGameStage.Load()
+	assert.Equal(t, StagePreStart, gotStage)
+
+	gotStage = atomicGameStage.Swap(StageShutDown)
+	assert.Equal(t, StagePreStart, gotStage)
+}
+
+func TestCanCompareAndSwapOnZeroValue(t *testing.T) {
+	atomicGameStage := NewAtomic()
+	ok := atomicGameStage.CompareAndSwap(StageShutDown, StageShutDown)
+	assert.Check(t, !ok, "zero value should be StagePreStart")
+
+	ok = atomicGameStage.CompareAndSwap(StagePreStart, StageShutDown)
+	assert.Check(t, ok, "compare and swap should succeed with correct old value")
+
+	assert.Equal(t, StageShutDown, atomicGameStage.Load())
+}
+
+func TestOnlyOneCompareAndSwapSuccess(t *testing.T) {
+	successCh := make(chan bool)
+	atomicGameStage := NewAtomic()
+
+	for i := 0; i < 10; i++ {
+		go func() {
+			ok := atomicGameStage.CompareAndSwap(StagePreStart, StageShutDown)
+			successCh <- ok
+		}()
+	}
+
+	successCount := 0
+	failureCount := 0
+	for i := 0; i < 10; i++ {
+		if <-successCh {
+			successCount++
+		} else {
+			failureCount++
+		}
+	}
+	assert.Equal(t, 1, successCount)
+	assert.Equal(t, 9, failureCount)
+}


### PR DESCRIPTION
Closes: WORLD-546

## Overview

Fix some race conditions and shutdown sequencing.

## Brief Changelog

- Shorten the sleep duration while waiting for the World to shut down
- Change the ecs.World tick into an atomic unit64
- Add the concept of a game sequence to cardinal to help with the starting and stopping of the game

## Testing and Verifying

Run `go test --count=10 --race` from the cardinal package and the ecs package to verify there are no race conditions. 

The server and events packages still have race conditions.