### PR TITLE
feat(cardinal): change entire nakama package to use eris.

### DIFF
--- a/relay/nakama/allowlist.go
+++ b/relay/nakama/allowlist.go
@@ -8,10 +8,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/heroiclabs/nakama-common/runtime"
 	"os"
 	"strconv"
 	"strings"
+
+	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/rotisserie/eris"
 )
 
 var (
@@ -34,8 +36,7 @@ func initAllowlist(_ runtime.Logger, initializer runtime.Initializer) error {
 	var err error
 	allowlistEnabled, err = strconv.ParseBool(enabledStr)
 	if err != nil {
-		return fmt.Errorf("the ENABLE_ALLOWLIST flag was set, however the variable %q was an invalid "+
-			"boolean: %w", enabledStr, err)
+		return eris.Wrapf(err, "the ENABLE_ALLOWLIST flag was set, however the variable %q was an invalid ", enabledStr)
 	}
 
 	if !allowlistEnabled {
@@ -43,12 +44,12 @@ func initAllowlist(_ runtime.Logger, initializer runtime.Initializer) error {
 	}
 	err = initializer.RegisterRpc("generate-beta-keys", allowListRPC)
 	if err != nil {
-		return err
+		return eris.Wrap(err, "failed to register rpc")
 	}
 
 	err = initializer.RegisterRpc("claim-key", claimKeyRPC)
 	if err != nil {
-		return err
+		return eris.Wrap(err, "failed to register rpc")
 	}
 	return nil
 }
@@ -75,18 +76,18 @@ func allowListRPC(ctx context.Context, _ runtime.Logger, _ *sql.DB, nk runtime.N
 		return "", err
 	}
 	if id != adminAccountID {
-		return "", fmt.Errorf("unauthorized: only admin may call this RPC")
+		return "", eris.Errorf("unauthorized: only admin may call this RPC")
 	}
 
 	var msg GenKeysMsg
 	err = json.Unmarshal([]byte(payload), &msg)
 	if err != nil {
-		return "", fmt.Errorf(`error unmarshaling payload: expected form {"amount": <int>}: %w`, err)
+		return "", eris.Wrap(err, `error unmarshaling payload: expected form {"amount": <int>}`)
 	}
 
 	keys, err := generateBetaKeys(msg.Amount)
 	if err != nil {
-		return "", fmt.Errorf("error generating beta keys: %w", err)
+		return "", eris.Wrap(err, "error generating beta keys")
 	}
 
 	writes := make([]*runtime.StorageWrite, 0, len(keys))
@@ -98,7 +99,7 @@ func allowListRPC(ctx context.Context, _ runtime.Logger, _ *sql.DB, nk runtime.N
 		}
 		bz, err := json.Marshal(obj)
 		if err != nil {
-			return "", err
+			return "", eris.Wrap(err, "")
 		}
 		writes = append(writes, &runtime.StorageWrite{
 			Collection:      allowlistKeyCollection,
@@ -113,12 +114,12 @@ func allowListRPC(ctx context.Context, _ runtime.Logger, _ *sql.DB, nk runtime.N
 
 	_, err = nk.StorageWrite(ctx, writes)
 	if err != nil {
-		return "", fmt.Errorf("error writing keys to storage: %w", err)
+		return "", eris.Wrap(err, "error writing keys to storage")
 	}
 
 	response, err := json.Marshal(GenKeysResponse{Keys: keys})
 	if err != nil {
-		return "", err
+		return "", eris.Wrap(err, "")
 	}
 	return string(response), nil
 }
@@ -142,16 +143,16 @@ func claimKeyRPC(ctx context.Context, _ runtime.Logger, _ *sql.DB, nk runtime.Na
 	// if this user is already verified,
 	err = checkVerified(ctx, nk, userID)
 	if err == nil {
-		return "", ErrAlreadyVerified
+		return "", eris.Wrap(errors.Join(ErrAlreadyVerified, err), "")
 	}
 
 	var ck ClaimKeyMsg
 	err = json.Unmarshal([]byte(payload), &ck)
 	if err != nil {
-		return "", err
+		return "", eris.Wrap(err, "")
 	}
 	if ck.Key == "" {
-		return "", fmt.Errorf("no beta key specified in request")
+		return "", eris.Errorf("no beta key specified in request")
 	}
 	err = claimKey(ctx, nk, ck.Key, userID)
 	if err != nil {
@@ -164,7 +165,7 @@ func claimKeyRPC(ctx context.Context, _ runtime.Logger, _ *sql.DB, nk runtime.Na
 
 	bz, err := json.Marshal(ClaimKeyRes{Success: true})
 	if err != nil {
-		return "", err
+		return "", eris.Wrap(err, "")
 	}
 	return string(bz), nil
 }
@@ -174,7 +175,7 @@ func writeVerified(ctx context.Context, nk runtime.NakamaModule, userID string) 
 	}
 	bz, err := json.Marshal(verified{})
 	if err != nil {
-		return err
+		return eris.Wrap(err, "")
 	}
 	_, err = nk.StorageWrite(ctx, []*runtime.StorageWrite{
 		{
@@ -202,10 +203,10 @@ func checkVerified(ctx context.Context, nk runtime.NakamaModule, userID string) 
 		},
 	})
 	if err != nil {
-		return err
+		return eris.Wrap(err, "")
 	}
 	if len(objs) == 0 {
-		return ErrNotAllowlisted
+		return eris.Wrap(ErrNotAllowlisted, "")
 	}
 	return nil
 }
@@ -219,17 +220,17 @@ func readKey(ctx context.Context, nk runtime.NakamaModule, key string) (*KeyStor
 		},
 	})
 	if err != nil {
-		return nil, fmt.Errorf("error reading storage object for key: %w", err)
+		return nil, eris.Wrap(err, "error reading storage object for key")
 	}
 	if len(objs) == 0 {
-		return nil, ErrInvalidBetaKey
+		return nil, eris.Wrap(ErrInvalidBetaKey, "")
 	}
 
 	obj := objs[0]
 	var ks KeyStorage
 	err = json.Unmarshal([]byte(obj.Value), &ks)
 	if err != nil {
-		return nil, fmt.Errorf("could not unmarshal storage object into %T: %w", ks, err)
+		return nil, eris.Wrapf(err, "could not unmarshal storage object into %T", ks)
 	}
 	return &ks, nil
 }
@@ -237,7 +238,7 @@ func readKey(ctx context.Context, nk runtime.NakamaModule, key string) (*KeyStor
 func writeKey(ctx context.Context, nk runtime.NakamaModule, ks *KeyStorage) error {
 	bz, err := json.Marshal(ks)
 	if err != nil {
-		return fmt.Errorf("could not marshal KeyStorage object: %w", err)
+		return eris.Wrapf(err, "could not marshal KeyStorage object")
 	}
 	_, err = nk.StorageWrite(ctx, []*runtime.StorageWrite{
 		{
@@ -251,7 +252,7 @@ func writeKey(ctx context.Context, nk runtime.NakamaModule, ks *KeyStorage) erro
 		},
 	})
 	if err != nil {
-		return fmt.Errorf("could not write KeyObject back to storage: %w", err)
+		return eris.Wrapf(err, "could not write KeyObject back to storage")
 	}
 	return nil
 }
@@ -262,7 +263,7 @@ func claimKey(ctx context.Context, nk runtime.NakamaModule, key, userID string) 
 		return err
 	}
 	if ks.Used {
-		return ErrBetaKeyAlreadyUsed
+		return eris.Wrap(ErrBetaKeyAlreadyUsed, "")
 	}
 	ks.Used = true
 	ks.UsedBy = userID
@@ -279,7 +280,7 @@ func generateRandomBytes(n int) ([]byte, error) {
 	bytes := make([]byte, n)
 	_, err := rand.Read(bytes)
 	if err != nil {
-		return nil, err
+		return nil, eris.Wrap(err, "")
 	}
 	return bytes, nil
 }

--- a/relay/nakama/go.mod
+++ b/relay/nakama/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/ethereum/go-ethereum v1.12.0
 	github.com/gorilla/websocket v1.5.0
 	github.com/heroiclabs/nakama-common v1.27.0
+	github.com/rotisserie/eris v0.5.4
 	pkg.world.dev/world-engine/sign v0.1.11-alpha
 )
 

--- a/relay/nakama/go.sum
+++ b/relay/nakama/go.sum
@@ -22,6 +22,8 @@ github.com/holiman/uint256 v1.2.3 h1:K8UWO1HUJpRMXBxbmaY1Y8IAMZC/RsKB+ArEnnK4l5o
 github.com/holiman/uint256 v1.2.3/go.mod h1:SC8Ryt4n+UBbPbIBKaG9zbbDlp4jOru9xFZmPzLUTxw=
 github.com/mitchellh/mapstructure v1.5.0 h1:jeMsZIYE/09sWLaz43PL7Gy6RuMjD2eJVyuac5Z2hdY=
 github.com/mitchellh/mapstructure v1.5.0/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/rotisserie/eris v0.5.4 h1:Il6IvLdAapsMhvuOahHWiBnl1G++Q0/L5UIkI5mARSk=
+github.com/rotisserie/eris v0.5.4/go.mod h1:Z/kgYTJiJtocxCbFfvRmO+QejApzG6zpyky9G1A4g9s=
 golang.org/x/crypto v0.13.0 h1:mvySKfSWJ+UKUii46M40LOvyWfN0s2U+46/jDd0e6Ck=
 golang.org/x/crypto v0.13.0/go.mod h1:y6Z2r+Rw4iayiXXAIxJIDAJ1zMW4yaTpebo8fPOliYc=
 golang.org/x/sys v0.12.0 h1:CM0HF96J0hcLAwsHPJZjfdNzs0gftsLfgKt57wWHJ0o=

--- a/relay/nakama/match.go
+++ b/relay/nakama/match.go
@@ -87,7 +87,7 @@ func (m *ReceiptMatch) MatchLoop(_ context.Context, logger runtime.Logger, _ *sq
 		}
 		err = dispatcher.BroadcastMessage(receiptOpCode, buf, nil, nil, true)
 		if err != nil {
-			_, _ = logError(logger, "error broadcasting message: %w", err)
+			_, _ = logError(logger, err, "error broadcasting message")
 		}
 	}
 

--- a/relay/nakama/notifications.go
+++ b/relay/nakama/notifications.go
@@ -2,10 +2,10 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/heroiclabs/nakama-common/runtime"
+	"github.com/rotisserie/eris"
 )
 
 // targetInfo contains information about who should receive a notification. It contains a user ID as well as
@@ -92,7 +92,7 @@ func (r *receiptNotifier) handleReceipt(receipt *Receipt) error {
 	ctx := context.Background()
 	target, ok := r.txHashToTargetInfo[receipt.TxHash]
 	if !ok {
-		return fmt.Errorf("unable to find user for tx hash %q", receipt.TxHash)
+		return eris.Errorf("unable to find user for tx hash %q", receipt.TxHash)
 	}
 	delete(r.txHashToTargetInfo, receipt.TxHash)
 
@@ -103,7 +103,7 @@ func (r *receiptNotifier) handleReceipt(receipt *Receipt) error {
 	}
 
 	if err := r.nk.NotificationSend(ctx, target.userID, "subject", data, 1, "", false); err != nil {
-		return fmt.Errorf("unable to send tx hash %q to user %q: %w", receipt.TxHash, target.userID, err)
+		return eris.Wrapf(err, "unable to send tx hash %q to user %q", receipt.TxHash, target.userID)
 	}
 	return nil
 }


### PR DESCRIPTION
Closes: WORLD-552

## Overview

This adds eris to nakama. 
It's rather big. I have a bunch of other PRs that are smaller.

There are two functions that were changed. logError and logCode. Modified to take into account how errors can store stack traces. The reason is because these functions actually swallowed errors and created new ones from strings, so the new paradigm of errors with stack traces would get the stack erased. 

Info:
This is a sub issue of https://linear.app/arguslabs/issue/WORLD-451/find-a-way-to-get-all-errors-to-be-paired-with-stack-trace

Relevant conversation here: https://argus-labs.slack.com/archives/C03G859K5TQ/p1699905811770509