### PR TITLE
chore(cardinal): Remove SetResult and AddError in favor of ForEach in the cardinal pac…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,10 @@
 Closes: WORLD-XXX
 
+<!---
+Add a prefix to indicate what kind of release this pull request corresponds to:
+  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
+--->
+
 ## Overview
 
 > Description of the overall background and high-level changes that this PR introduces

--- a/cardinal/message.go
+++ b/cardinal/message.go
@@ -44,18 +44,6 @@ func (t *MessageType[Input, Result]) AddToQueue(world *World, data Input, sigs .
 	return txHash
 }
 
-// AddError adds the given error to the transaction identified by the given hash. Multiple errors can be
-// added to the same message hash.
-func (t *MessageType[Input, Result]) AddError(wCtx WorldContext, hash TxHash, err error) {
-	t.impl.AddError(wCtx.Instance(), hash, err)
-}
-
-// SetResult sets the result of the message identified by the given hash. Only one result may be associated
-// with a message hash, so calling this multiple times will clobber previously set results.
-func (t *MessageType[Input, Result]) SetResult(wCtx WorldContext, hash TxHash, result Result) {
-	t.impl.SetResult(wCtx.Instance(), hash, result)
-}
-
 // GetReceipt returns the result (if any) and errors (if any) associated with the given hash. If false is returned,
 // the hash is not recognized, so the returned result and errors will be empty.
 func (t *MessageType[Input, Result]) GetReceipt(wCtx WorldContext, hash TxHash) (Result, []error, bool) {

--- a/cardinal/message_test.go
+++ b/cardinal/message_test.go
@@ -54,13 +54,7 @@ func TestTransactionExample(t *testing.T) {
 				return h
 			})
 			assert.Check(t, err == nil)
-			addHealthToEntity.AddError(worldCtx, tx.Hash(), errors.New("test error"))
-			// redundant but for testing purposes
-			addHealthToEntity.SetResult(worldCtx, tx.Hash(), AddHealthToEntityResult{})
-			_, errs, ok := addHealthToEntity.GetReceipt(worldCtx, tx.Hash()) // check if receipts are working.
-			assert.Assert(t, ok)
-			assert.Equal(t, len(errs), 1)
-			return AddHealthToEntityResult{}, nil
+			return AddHealthToEntityResult{}, errors.New("fake tx error")
 		})
 
 		addHealthToEntity.Convert() // Check for compilation error
@@ -97,4 +91,10 @@ func TestTransactionExample(t *testing.T) {
 			assert.Equal(t, 0, health.Value)
 		}
 	}
+	// Make sure transaction errors are recorded in the receipt
+	ecsWorld := cardinal.TestingWorldContextToECSWorld(testWorldCtx)
+	receipts, err := ecsWorld.GetTransactionReceiptsForTick(ecsWorld.CurrentTick() - 1)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, len(receipts))
+	assert.Equal(t, 1, len(receipts[0].Errs))
 }


### PR DESCRIPTION
…kage

Closes: WORLD-532

## Overview

- Remove the SetResult and AddError helpers in the cardinal package, and instead only expose the ForEach helper that allows user to loop over transaction.
- Update the PR template to include a list of valid PR prefixes to help some forgetful developers (like me).

## Testing and Verifying

Updated unit test to not sue SetResult and AddError.