### PR TITLE
fix(relay): make allowlist force requests to upper, and pass case where a persona tag was rejected when claiming (WORLD-556)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,3 +18,8 @@ include makefiles/build.mk
 
 kill:
 	docker kill $$(docker ps -q)
+
+clear:
+	docker compose down
+	docker volume rm $$(docker volume ls -q)
+	docker rm -f $$(docker ps -a -q)

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -8,7 +8,7 @@ rollup:
 
 game:
 	cd internal/e2e/tester/cardinal && go mod vendor
-	@docker compose up game nakama --abort-on-container-exit cockroachdb redis
+	@docker compose up game nakama --build --abort-on-container-exit cockroachdb redis
 
 forge-build: |
 	@forge build --extra-output-files bin --extra-output-files abi  --root evm/precompile/contracts

--- a/relay/nakama/allowlist.go
+++ b/relay/nakama/allowlist.go
@@ -153,6 +153,7 @@ func claimKeyRPC(ctx context.Context, _ runtime.Logger, _ *sql.DB, nk runtime.Na
 	if ck.Key == "" {
 		return "", fmt.Errorf("no beta key specified in request")
 	}
+	ck.Key = strings.ToUpper(ck.Key)
 	err = claimKey(ctx, nk, ck.Key, userID)
 	if err != nil {
 		return "", err

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -267,6 +267,8 @@ func handleClaimPersona(ptv *personaTagVerifier, notifier *receiptNotifier) naka
 				return logCode(logger, AlreadyExists, "persona tag %q is pending for this account", tag.PersonaTag)
 			case personaTagStatusAccepted:
 				return logCode(logger, AlreadyExists, "persona tag %q already associated with this account", tag.PersonaTag)
+			case personaTagStatusRejected:
+				// if the tag was rejected, don't do anything. let the user try to claim another tag.
 			}
 		}
 


### PR DESCRIPTION
## Overview

makes requests to claim-key all uppercase, so the casing no longer matters when claiming a key.

fixes an issue where you couldn't claim a tag after sending a request that was marked as rejected.

## Brief Changelog


## Testing and Verifying

manually
