### PR TITLE
feat(cardinal): changed shard to work with eris.

### DIFF
--- a/cardinal/shard/option.go
+++ b/cardinal/shard/option.go
@@ -1,5 +1,7 @@
 package shard
 
+import "github.com/rotisserie/eris"
+
 type Option func(adapter *adapterImpl)
 
 func WithCredentials(credPath string) Option {
@@ -9,7 +11,7 @@ func WithCredentials(credPath string) Option {
 		}
 		creds, err := loadClientCredentials(credPath)
 		if err != nil {
-			panic(err)
+			panic(eris.ToString(err, true))
 		}
 		a.creds = creds
 	}


### PR DESCRIPTION
Closes: WORLD-551

Small just changes to use eris for cardinal.shard

Info:
This is a sub issue of https://linear.app/arguslabs/issue/WORLD-451/find-a-way-to-get-all-errors-to-be-paired-with-stack-trace

Relevant conversation here: https://argus-labs.slack.com/archives/C03G859K5TQ/p1699905811770509