### PR TITLE
feat(cardinal): changes to ecs.abi to use eris.

### DIFF
--- a/cardinal/testutils/testutils.go
+++ b/cardinal/testutils/testutils.go
@@ -5,13 +5,13 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 
 	"gotest.tools/v3/assert"
@@ -49,7 +49,7 @@ func MakeTestTransactionHandler(
 		err = txh.Serve()
 		// ErrServerClosed is returned from txh.Serve after txh.Close is called. This is
 		// normal.
-		if !errors.Is(err, http.ErrServerClosed) {
+		if !eris.Is(eris.Cause(err), http.ErrServerClosed) {
 			assert.NilError(t, err)
 		}
 	}()


### PR DESCRIPTION
Closes: WORLD-539

Changes abi.go in ecs to use eris. 

Additionally I made a change in testutils that will allow a section of code to error match with eris. It's a small irrelevant piece of logic that's piggy backing on this PR. 

Info:
This is a sub issue of https://linear.app/arguslabs/issue/WORLD-451/find-a-way-to-get-all-errors-to-be-paired-with-stack-trace

Relevant conversation here: https://argus-labs.slack.com/archives/C03G859K5TQ/p1699905811770509