### PR TITLE
feat(cardinal): add eris to codec.go

### DIFF
--- a/cardinal/ecs/codec/codec.go
+++ b/cardinal/ecs/codec/codec.go
@@ -2,13 +2,14 @@ package codec
 
 import (
 	"github.com/goccy/go-json"
+	"github.com/rotisserie/eris"
 )
 
 func Decode[T any](bz []byte) (T, error) {
 	comp := new(T)
 	err := json.Unmarshal(bz, comp)
 	if err != nil {
-		return *comp, err
+		return *comp, eris.Wrap(err, "")
 	}
 	return *comp, nil
 }
@@ -16,7 +17,7 @@ func Decode[T any](bz []byte) (T, error) {
 func Encode(comp any) ([]byte, error) {
 	bz, err := json.Marshal(comp)
 	if err != nil {
-		return nil, err
+		return nil, eris.Wrap(err, "")
 	}
 	return bz, nil
 }


### PR DESCRIPTION
Closes: WORLD-558

Adds eris to codec.go

Info:
This is a sub issue of https://linear.app/arguslabs/issue/WORLD-451/find-a-way-to-get-all-errors-to-be-paired-with-stack-trace

Relevant conversation here: https://argus-labs.slack.com/archives/C03G859K5TQ/p1699905811770509