### PR TITLE
feat(cardinal): add eris to ecs receipt

### DIFF
--- a/cardinal/ecs/receipt/receipt.go
+++ b/cardinal/ecs/receipt/receipt.go
@@ -4,8 +4,10 @@ package receipt
 
 import (
 	"errors"
-	"pkg.world.dev/world-engine/cardinal/ecs/message"
 	"sync/atomic"
+
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-engine/cardinal/ecs/message"
 )
 
 var (
@@ -97,10 +99,10 @@ func (h *History) GetReceiptsForTick(tick uint64) ([]Receipt, error) {
 	// The requested tick is either in the future, or it is currently being processed. We don't yet know
 	// what the results of this tick will be.
 	if currTick <= tick {
-		return nil, ErrTickHasNotBeenProcessed
+		return nil, eris.Wrap(ErrTickHasNotBeenProcessed, "")
 	}
 	if currTick-tick >= h.ticksToStore {
-		return nil, ErrOldTickHasBeenDiscarded
+		return nil, eris.Wrap(ErrOldTickHasBeenDiscarded, "")
 	}
 	mod := tick % h.ticksToStore
 	recs := make([]Receipt, 0, len(h.history[mod]))

--- a/cardinal/ecs/receipt/receipt_test.go
+++ b/cardinal/ecs/receipt/receipt_test.go
@@ -2,11 +2,14 @@ package receipt
 
 import (
 	"errors"
-	"pkg.world.dev/world-engine/cardinal/ecs/message"
 	"testing"
 
-	"github.com/google/uuid"
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-engine/cardinal/ecs/message"
+
 	"gotest.tools/v3/assert"
+
+	"github.com/google/uuid"
 )
 
 func txHash(t *testing.T) message.TxHash {
@@ -100,7 +103,7 @@ func TestErrorWhenGettingReceiptsInNonFinishedTick(t *testing.T) {
 	rh := NewHistory(currTick, 5)
 
 	_, err := rh.GetReceiptsForTick(currTick)
-	assert.ErrorIs(t, ErrTickHasNotBeenProcessed, err)
+	assert.ErrorIs(t, ErrTickHasNotBeenProcessed, eris.Cause(err))
 
 	rh.NextTick()
 
@@ -142,5 +145,5 @@ func TestOldTicksAreDiscarded(t *testing.T) {
 	// should no longer be stored
 	rh.NextTick()
 	_, err := rh.GetReceiptsForTick(tickToGet)
-	assert.ErrorIs(t, ErrOldTickHasBeenDiscarded, err)
+	assert.ErrorIs(t, ErrOldTickHasBeenDiscarded, eris.Cause(err))
 }


### PR DESCRIPTION
Closes: WORLD-563

Adds eris to ecs.receipt

Info:
This is a sub issue of https://linear.app/arguslabs/issue/WORLD-451/find-a-way-to-get-all-errors-to-be-paired-with-stack-trace

Relevant conversation here: https://argus-labs.slack.com/archives/C03G859K5TQ/p1699905811770509

