### PR TITLE
fix(relay): make claim-key use logCode instead of returning raw errors

### DIFF
--- a/relay/nakama/allowlist.go
+++ b/relay/nakama/allowlist.go
@@ -137,7 +137,7 @@ func claimKeyRPC(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk runti
 ) {
 	userID, err := getUserID(ctx)
 	if err != nil {
-		return logCode(logger, Internal, "unable to get userID")
+		return logCode(logger, Internal, "unable to get userID: %v", err)
 	}
 
 	// if this user is already verified,
@@ -149,7 +149,7 @@ func claimKeyRPC(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk runti
 	var ck ClaimKeyMsg
 	err = json.Unmarshal([]byte(payload), &ck)
 	if err != nil {
-		return logCode(logger, Internal, "unable to unmarshal payload")
+		return logCode(logger, InvalidArgument, "unable to unmarshal payload: %v", err)
 	}
 	if ck.Key == "" {
 		return logCode(logger, InvalidArgument, "no key provided in request")
@@ -157,16 +157,16 @@ func claimKeyRPC(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk runti
 	ck.Key = strings.ToUpper(ck.Key)
 	err = claimKey(ctx, nk, ck.Key, userID)
 	if err != nil {
-		return logCode(logger, Internal, fmt.Sprintf("unable to claim key: %s", err.Error()))
+		return logCode(logger, Internal, fmt.Sprintf("unable to claim key: %v", err))
 	}
 	err = writeVerified(ctx, nk, userID)
 	if err != nil {
-		return logCode(logger, Internal, fmt.Sprintf("server could not save user verification entry. please try again: %s", err.Error()))
+		return logCode(logger, Internal, fmt.Sprintf("server could not save user verification entry. please try again: %v", err))
 	}
 
 	bz, err := json.Marshal(ClaimKeyRes{Success: true})
 	if err != nil {
-		return logCode(logger, Internal, "unable to marshal response")
+		return logCode(logger, Internal, "unable to marshal response: %v", err)
 	}
 	return string(bz), nil
 }

--- a/relay/nakama/allowlist.go
+++ b/relay/nakama/allowlist.go
@@ -161,7 +161,8 @@ func claimKeyRPC(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk runti
 	}
 	err = writeVerified(ctx, nk, userID)
 	if err != nil {
-		return logCode(logger, Internal, fmt.Sprintf("server could not save user verification entry. please try again: %v", err))
+		return logCode(logger, Internal, fmt.Sprintf("server could not save user verification entry. please "+
+			"try again: %v", err))
 	}
 
 	bz, err := json.Marshal(ClaimKeyRes{Success: true})

--- a/relay/nakama/allowlist.go
+++ b/relay/nakama/allowlist.go
@@ -132,41 +132,41 @@ type ClaimKeyRes struct {
 	Success bool `json:"success"`
 }
 
-func claimKeyRPC(ctx context.Context, _ runtime.Logger, _ *sql.DB, nk runtime.NakamaModule, payload string) (
+func claimKeyRPC(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk runtime.NakamaModule, payload string) (
 	string, error,
 ) {
 	userID, err := getUserID(ctx)
 	if err != nil {
-		return "", err
+		return logCode(logger, Internal, "unable to get userID")
 	}
 
 	// if this user is already verified,
 	err = checkVerified(ctx, nk, userID)
 	if err == nil {
-		return "", eris.Wrap(errors.Join(ErrAlreadyVerified, err), "")
+		return logCode(logger, AlreadyExists, "user already verified with beta key")
 	}
 
 	var ck ClaimKeyMsg
 	err = json.Unmarshal([]byte(payload), &ck)
 	if err != nil {
-		return "", eris.Wrap(err, "")
+		return logCode(logger, Internal, "unable to unmarshal payload")
 	}
 	if ck.Key == "" {
-		return "", eris.Errorf("no beta key specified in request")
+		return logCode(logger, InvalidArgument, "no key provided in request")
 	}
 	ck.Key = strings.ToUpper(ck.Key)
 	err = claimKey(ctx, nk, ck.Key, userID)
 	if err != nil {
-		return "", err
+		return logCode(logger, Internal, fmt.Sprintf("unable to claim key: %s", err.Error()))
 	}
 	err = writeVerified(ctx, nk, userID)
 	if err != nil {
-		return "", err
+		return logCode(logger, Internal, "server could not save user verification entry. please try again"+err.Error())
 	}
 
 	bz, err := json.Marshal(ClaimKeyRes{Success: true})
 	if err != nil {
-		return "", eris.Wrap(err, "")
+		return logCode(logger, Internal, "unable to marshal response")
 	}
 	return string(bz), nil
 }

--- a/relay/nakama/allowlist.go
+++ b/relay/nakama/allowlist.go
@@ -161,7 +161,7 @@ func claimKeyRPC(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk runti
 	}
 	err = writeVerified(ctx, nk, userID)
 	if err != nil {
-		return logCode(logger, Internal, "server could not save user verification entry. please try again"+err.Error())
+		return logCode(logger, Internal, fmt.Sprintf("server could not save user verification entry. please try again: %s", err.Error()))
 	}
 
 	bz, err := json.Marshal(ClaimKeyRes{Success: true})

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -19,23 +19,23 @@ import (
 )
 
 const (
-	OK                 = 0
-	Cancelled          = 1
-	Unknown            = 2
-	InvalidArgument    = 3
-	DeadlineExceeded   = 4
-	NotFound           = 5
-	AlreadyExists      = 6
-	PermissionDenied   = 7
-	ResourceExhausted  = 8
-	FailedPrecondition = 9
-	Aborted            = 10
-	OutOfRange         = 11
-	Unimplemented      = 12
-	Internal           = 13
-	Unavailable        = 14
-	DataLoss           = 15
-	Unauthenticated    = 16
+	OK = iota
+	Cancelled
+	Unknown
+	InvalidArgument
+	DeadlineExceeded
+	NotFound
+	AlreadyExists
+	PermissionDenied
+	ResourceExhausted
+	FailedPrecondition
+	Aborted
+	OutOfRange
+	Unimplemented
+	Internal
+	Unavailable
+	DataLoss
+	Unauthenticated
 )
 
 type receiptChan chan *Receipt
@@ -246,7 +246,7 @@ func handleClaimPersona(ptv *personaTagVerifier, notifier *receiptNotifier) naka
 		// check if the user is verified. this requires them to input a valid beta key.
 		err = checkVerified(ctx, nk, userID)
 		if err != nil {
-			return "", eris.Wrap(err, "unable to claim a persona tag")
+			return logCode(logger, AlreadyExists, "unable to claim persona tag")
 		}
 
 		ptr := &personaTagStorageObj{}

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -427,13 +427,13 @@ func initCardinalEndpoints(logger runtime.Logger, initializer runtime.Initialize
 func logCode(logger runtime.Logger, code int, format string, v ...interface{}) (string, error) {
 	err := eris.Errorf(format, v...)
 	logger.Error(eris.ToString(err, true))
-	return "", runtime.NewError(eris.ToString(err, true), code)
+	return "", runtime.NewError(err.Error(), code)
 }
 
 func logError(logger runtime.Logger, err error, format string, v ...interface{}) (string, error) {
 	err = eris.Wrapf(err, format, v...)
 	logger.Error(eris.ToString(err, true))
-	return "", runtime.NewError(eris.ToString(err, true), Internal)
+	return "", runtime.NewError(err.Error(), Internal)
 }
 
 // setPersonaTagAssignment attempts to associate a given persona tag with the given user ID, and returns


### PR DESCRIPTION
## Overview

it seems that returning raw errors, instead of using nakama's `runtime.NewError` will cause the server to reply with a 500, this in turn makes the javascript code in WebGL implode. not good!

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
