### PR TITLE
refactor(cardinal): Rename message ForEach to Each to match search iterator

### DIFF
--- a/cardinal/ecs/message.go
+++ b/cardinal/ecs/message.go
@@ -160,7 +160,7 @@ func (t *MessageType[In, Out]) GetReceipt(wCtx WorldContext, hash message.TxHash
 	return value, errs, true
 }
 
-func (t *MessageType[In, Out]) ForEach(wCtx WorldContext, fn func(TxData[In]) (Out, error)) {
+func (t *MessageType[In, Out]) Each(wCtx WorldContext, fn func(TxData[In]) (Out, error)) {
 	for _, txData := range t.In(wCtx) {
 		if result, err := fn(txData); err != nil {
 			err = eris.Wrap(err, "")

--- a/cardinal/ecs/message_test.go
+++ b/cardinal/ecs/message_test.go
@@ -7,11 +7,10 @@ import (
 
 	"gotest.tools/v3/assert"
 
-	"pkg.world.dev/world-engine/cardinal/testutils"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
 	"pkg.world.dev/world-engine/cardinal/ecs/message"
-
+	"pkg.world.dev/world-engine/cardinal/testutils"
 )
 
 func TestForEachTransaction(t *testing.T) {
@@ -27,7 +26,7 @@ func TestForEachTransaction(t *testing.T) {
 	assert.NilError(t, world.RegisterMessages(someMsg))
 
 	world.RegisterSystem(func(wCtx ecs.WorldContext) error {
-		someMsg.ForEach(wCtx, func(t ecs.TxData[SomeMsgRequest]) (result SomeMsgResponse, err error) {
+		someMsg.Each(wCtx, func(t ecs.TxData[SomeMsgRequest]) (result SomeMsgResponse, err error) {
 			if t.Msg.GenerateError {
 				return result, errors.New("some error")
 			}

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -45,7 +45,7 @@ func AuthorizePersonaAddressSystem(wCtx WorldContext) error {
 	if err != nil {
 		return err
 	}
-	AuthorizePersonaAddressMsg.ForEach(wCtx, func(txData TxData[AuthorizePersonaAddress],
+	AuthorizePersonaAddressMsg.Each(wCtx, func(txData TxData[AuthorizePersonaAddress],
 	) (AuthorizePersonaAddressResult, error) {
 		msg, tx := txData.Msg, txData.Tx
 		result := AuthorizePersonaAddressResult{Success: false}

--- a/cardinal/ecs/world_test.go
+++ b/cardinal/ecs/world_test.go
@@ -3,9 +3,10 @@ package ecs_test
 import (
 	"context"
 	"errors"
-	"pkg.world.dev/world-engine/cardinal/testutils"
 	"testing"
 	"time"
+
+	"pkg.world.dev/world-engine/cardinal/testutils"
 
 	"pkg.world.dev/world-engine/sign"
 
@@ -120,7 +121,7 @@ func TestEVMTxConsume(t *testing.T) {
 	var returnVal FooOut
 	var returnErr error
 	w.RegisterSystem(func(wCtx ecs.WorldContext) error {
-		fooTx.ForEach(wCtx, func(t ecs.TxData[FooIn]) (FooOut, error) {
+		fooTx.Each(wCtx, func(t ecs.TxData[FooIn]) (FooOut, error) {
 			return returnVal, returnErr
 		})
 		return nil

--- a/cardinal/example_messagetype_test.go
+++ b/cardinal/example_messagetype_test.go
@@ -32,7 +32,7 @@ func ExampleMessageType() {
 	}
 
 	err = cardinal.RegisterSystems(world, func(wCtx cardinal.WorldContext) error {
-		MoveMsg.ForEach(wCtx, func(txData cardinal.TxData[MovePlayerMsg]) (MovePlayerResult, error) {
+		MoveMsg.Each(wCtx, func(txData cardinal.TxData[MovePlayerMsg]) (MovePlayerResult, error) {
 			// handle the transaction
 			// ...
 

--- a/cardinal/message.go
+++ b/cardinal/message.go
@@ -50,12 +50,12 @@ func (t *MessageType[Input, Result]) GetReceipt(wCtx WorldContext, hash TxHash) 
 	return t.impl.GetReceipt(wCtx.Instance(), hash)
 }
 
-func (t *MessageType[Input, Result]) ForEach(wCtx WorldContext, fn func(TxData[Input]) (Result, error)) {
+func (t *MessageType[Input, Result]) Each(wCtx WorldContext, fn func(TxData[Input]) (Result, error)) {
 	adapterFn := func(ecsTxData ecs.TxData[Input]) (Result, error) {
 		adaptedTx := TxData[Input]{impl: ecsTxData}
 		return fn(adaptedTx)
 	}
-	t.impl.ForEach(wCtx.Instance(), adapterFn)
+	t.impl.Each(wCtx.Instance(), adapterFn)
 }
 
 // In returns the TxData in the given transaction queue that match this message's type.

--- a/cardinal/message_test.go
+++ b/cardinal/message_test.go
@@ -47,7 +47,7 @@ func TestTransactionExample(t *testing.T) {
 			assert.Check(t, err == nil)
 		}
 		// test same as above but with forEach
-		addHealthToEntity.ForEach(worldCtx, func(tx cardinal.TxData[AddHealthToEntityTx]) (AddHealthToEntityResult, error) {
+		addHealthToEntity.Each(worldCtx, func(tx cardinal.TxData[AddHealthToEntityTx]) (AddHealthToEntityResult, error) {
 			targetID := tx.Msg().TargetID
 			err := cardinal.UpdateComponent[Health](worldCtx, targetID, func(h *Health) *Health {
 				h.Value = tx.Msg().Amount


### PR DESCRIPTION
Closes: WORLD-542

## Overview

Rename the message iterator to Each to match the search iterator

## Testing and Verifying

No functional changes