### PR TITLE
feat(cardinal): accept empty namespace and signature when signature verification is d…

### DIFF
--- a/sign/sign.go
+++ b/sign/sign.go
@@ -229,6 +229,9 @@ func (s *Transaction) Verify(hexAddress string) error {
 	}
 
 	sig := common.Hex2Bytes(s.Signature)
+	if len(sig) < crypto.RecoveryIDOffset {
+		return eris.Wrap(ErrSignatureValidationFailed, "hex to bytes failed")
+	}
 	if sig[crypto.RecoveryIDOffset] == 27 || sig[crypto.RecoveryIDOffset] == 28 {
 		sig[crypto.RecoveryIDOffset] -= 27 // Transform yellow paper V from 27/28 to 0/1
 	}


### PR DESCRIPTION
…isabled

Closes: WORLD-553


## Overview

- When signature verification is disabled, accept empty namespace and signature fields. 
- Add additional testing so that we get a 401 instead of a 500 when namespace or signature fields are missing.

## Testing and Verifying

Unit tests added/updated.