### PR TITLE
feat(cardinal): replace all assert.ErrorIs and testify.assert.Error

### DIFF
--- a/cardinal/ecs/abi/abi_test.go
+++ b/cardinal/ecs/abi/abi_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs/abi"
+	"pkg.world.dev/world-engine/cardinal/testutils"
 )
 
 // TestNoTagPanics tests that it panics when a struct field is of type *big.Int and does not have a `solidity` struct
@@ -17,14 +18,14 @@ func TestNoTagPanics(t *testing.T) {
 		Large *big.Int
 	}
 	_, err := abi.GenerateABIType(FooReadBroken{})
-	assert.Error(t, err)
+	testutils.AssertErrorWithTrace(t, err)
 
 	type FooReadBrokenSlice struct {
 		SliceBig []*big.Int
 	}
 
 	_, err = abi.GenerateABIType(FooReadBrokenSlice{})
-	assert.Error(t, err)
+	testutils.AssertErrorWithTrace(t, err)
 }
 
 func TestGenerateABIType_AllValidTypes(t *testing.T) {
@@ -115,7 +116,7 @@ func TestGenerateABIType_PanicOnImportedTypes(t *testing.T) {
 		X common.Decimal
 	}
 	_, err := abi.GenerateABIType(InvalidType{})
-	assert.Error(t, err)
+	testutils.AssertErrorWithTrace(t, err)
 }
 
 func TestGenerateABIType_NoSizeOnInt(t *testing.T) {
@@ -128,10 +129,10 @@ func TestGenerateABIType_NoSizeOnInt(t *testing.T) {
 	}
 
 	_, err := abi.GenerateABIType(InvalidUint{})
-	assert.Error(t, err)
+	testutils.AssertErrorWithTrace(t, err)
 
 	_, err = abi.GenerateABIType(InvalidInt{})
-	assert.Error(t, err)
+	testutils.AssertErrorWithTrace(t, err)
 }
 
 func TestGenerateABIType_StructInStruct(t *testing.T) {

--- a/cardinal/ecs/component/metadata/component_metadata_test.go
+++ b/cardinal/ecs/component/metadata/component_metadata_test.go
@@ -151,7 +151,7 @@ func TestErrorWhenAccessingComponentNotOnEntity(t *testing.T) {
 	id, err := component.Create(wCtx, foundComp{})
 	testutils.AssertNilErrorWithTrace(t, err)
 	_, err = component.GetComponent[notFoundComp](wCtx, id)
-	assert.ErrorIs(t, err, storage.ErrComponentNotOnEntity)
+	testutils.AssertErrorIsWithTrace(t, err, storage.ErrComponentNotOnEntity)
 }
 
 type ValueComponent struct {

--- a/cardinal/ecs/ecb/ecb_test.go
+++ b/cardinal/ecs/ecb/ecb_test.go
@@ -209,7 +209,7 @@ func TestCannotGetComponentOnEntityThatIsMissingTheComponent(t *testing.T) {
 	testutils.AssertNilErrorWithTrace(t, err)
 	// barComp has not been assigned to this entity
 	_, err = manager.GetComponentForEntity(barComp, id)
-	assert.ErrorIs(t, err, storage.ErrComponentNotOnEntity)
+	testutils.AssertErrorIsWithTrace(t, err, storage.ErrComponentNotOnEntity)
 }
 
 func TestCannotSetComponentOnEntityThatIsMissingTheComponent(t *testing.T) {
@@ -218,7 +218,7 @@ func TestCannotSetComponentOnEntityThatIsMissingTheComponent(t *testing.T) {
 	testutils.AssertNilErrorWithTrace(t, err)
 	// barComp has not been assigned to this entity
 	err = manager.SetComponentForEntity(barComp, id, Bar{100})
-	assert.ErrorIs(t, err, storage.ErrComponentNotOnEntity)
+	testutils.AssertErrorIsWithTrace(t, err, storage.ErrComponentNotOnEntity)
 }
 
 func TestCannotRemoveAComponentFromAnEntityThatDoesNotHaveThatComponent(t *testing.T) {
@@ -226,7 +226,7 @@ func TestCannotRemoveAComponentFromAnEntityThatDoesNotHaveThatComponent(t *testi
 	id, err := manager.CreateEntity(fooComp)
 	testutils.AssertNilErrorWithTrace(t, err)
 	err = manager.RemoveComponentFromEntity(barComp, id)
-	assert.ErrorIs(t, err, storage.ErrComponentNotOnEntity)
+	testutils.AssertErrorIsWithTrace(t, err, storage.ErrComponentNotOnEntity)
 }
 
 func TestCanAddAComponentToAnEntity(t *testing.T) {
@@ -272,7 +272,7 @@ func TestCannotAddComponentToEntityThatAlreadyHasTheComponent(t *testing.T) {
 	testutils.AssertNilErrorWithTrace(t, err)
 
 	err = manager.AddComponentToEntity(fooComp, id)
-	assert.ErrorIs(t, err, storage.ErrComponentAlreadyOnEntity)
+	testutils.AssertErrorIsWithTrace(t, err, storage.ErrComponentAlreadyOnEntity)
 }
 
 type Health struct {

--- a/cardinal/ecs/ecb/recovery_test.go
+++ b/cardinal/ecs/ecb/recovery_test.go
@@ -245,7 +245,7 @@ func TestRemovedComponentDataCanBeRecovered(t *testing.T) {
 
 	// Make sure we can no longer get the foo component
 	_, err = manager.GetComponentForEntity(fooComp, id)
-	assert.ErrorIs(t, err, storage.ErrComponentNotOnEntity)
+	testutils.AssertErrorIsWithTrace(t, err, storage.ErrComponentNotOnEntity)
 	// But uhoh, there was a problem. This means the removal of the Foo component
 	// will be undone, and the original value can be found
 	manager.DiscardPending()

--- a/cardinal/ecs/ecb/redis_test.go
+++ b/cardinal/ecs/ecb/redis_test.go
@@ -61,5 +61,5 @@ func TestComponentValuesAreDeletedFromRedis(t *testing.T) {
 
 	// Verify the component in question no longer exists in the DB
 	err = client.Get(ctx, key).Err()
-	assert.ErrorIs(t, err, redis.Nil)
+	testutils.AssertErrorIsWithTrace(t, err, redis.Nil)
 }

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -310,7 +310,7 @@ func TestAddingAComponentThatAlreadyExistsIsError(t *testing.T) {
 	wCtx := ecs.NewWorldContext(world)
 	ent, err := component.Create(wCtx, EnergyComponent{})
 	testutils.AssertNilErrorWithTrace(t, err)
-	assert.ErrorIs(t, component.AddComponentTo[EnergyComponent](wCtx, ent), storage.ErrComponentAlreadyOnEntity)
+	testutils.AssertErrorIsWithTrace(t, component.AddComponentTo[EnergyComponent](wCtx, ent), storage.ErrComponentAlreadyOnEntity)
 }
 
 type ReactorEnergy struct {
@@ -340,7 +340,7 @@ func TestRemovingAMissingComponentIsError(t *testing.T) {
 	ent, err := component.Create(wCtx, ReactorEnergy{})
 	testutils.AssertNilErrorWithTrace(t, err)
 
-	assert.ErrorIs(t, component.RemoveComponentFrom[WeaponEnergy](wCtx, ent), storage.ErrComponentNotOnEntity)
+	testutils.AssertErrorIsWithTrace(t, component.RemoveComponentFrom[WeaponEnergy](wCtx, ent), storage.ErrComponentNotOnEntity)
 }
 
 type Foo struct{}

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -310,7 +310,10 @@ func TestAddingAComponentThatAlreadyExistsIsError(t *testing.T) {
 	wCtx := ecs.NewWorldContext(world)
 	ent, err := component.Create(wCtx, EnergyComponent{})
 	testutils.AssertNilErrorWithTrace(t, err)
-	testutils.AssertErrorIsWithTrace(t, component.AddComponentTo[EnergyComponent](wCtx, ent), storage.ErrComponentAlreadyOnEntity)
+	testutils.AssertErrorIsWithTrace(
+		t,
+		component.AddComponentTo[EnergyComponent](wCtx, ent),
+		storage.ErrComponentAlreadyOnEntity)
 }
 
 type ReactorEnergy struct {
@@ -340,7 +343,10 @@ func TestRemovingAMissingComponentIsError(t *testing.T) {
 	ent, err := component.Create(wCtx, ReactorEnergy{})
 	testutils.AssertNilErrorWithTrace(t, err)
 
-	testutils.AssertErrorIsWithTrace(t, component.RemoveComponentFrom[WeaponEnergy](wCtx, ent), storage.ErrComponentNotOnEntity)
+	testutils.AssertErrorIsWithTrace(
+		t,
+		component.RemoveComponentFrom[WeaponEnergy](wCtx, ent),
+		storage.ErrComponentNotOnEntity)
 }
 
 type Foo struct{}

--- a/cardinal/ecs/filter/filter_test.go
+++ b/cardinal/ecs/filter/filter_test.go
@@ -81,7 +81,7 @@ func TestCanFilterByArchetype(t *testing.T) {
 		count++
 		// Make sure the gamma component is not on this entity
 		_, err = component.GetComponent[gammaComponent](wCtx, id)
-		assert.ErrorIs(t, err, storage.ErrComponentNotOnEntity)
+		testutils.AssertErrorIsWithTrace(t, err, storage.ErrComponentNotOnEntity)
 		return true
 	})
 	testutils.AssertNilErrorWithTrace(t, err)

--- a/cardinal/ecs/message/message_test.go
+++ b/cardinal/ecs/message/message_test.go
@@ -382,7 +382,7 @@ func TestCannotDecodeEVMBeforeSetEVM(t *testing.T) {
 	type foo struct{}
 	msg := ecs.NewMessageType[foo, EmptyMsgResult]("foo")
 	_, err := msg.DecodeEVMBytes([]byte{})
-	assert.ErrorIs(t, err, ecs.ErrEVMTypeNotSet)
+	testutils.AssertErrorIsWithTrace(t, err, ecs.ErrEVMTypeNotSet)
 }
 
 func TestCannotHaveDuplicateTransactionNames(t *testing.T) {
@@ -395,7 +395,7 @@ func TestCannotHaveDuplicateTransactionNames(t *testing.T) {
 	world := cardinaltestutils.NewTestWorld(t).Instance()
 	alphaMsg := ecs.NewMessageType[SomeMsg, EmptyMsgResult]("name_match")
 	betaMsg := ecs.NewMessageType[OtherMsg, EmptyMsgResult]("name_match")
-	assert.ErrorIs(t, world.RegisterMessages(alphaMsg, betaMsg), ecs.ErrDuplicateMessageName)
+	testutils.AssertErrorIsWithTrace(t, world.RegisterMessages(alphaMsg, betaMsg), ecs.ErrDuplicateMessageName)
 }
 
 func TestCanGetTransactionErrorsAndResults(t *testing.T) {
@@ -450,8 +450,8 @@ func TestCanGetTransactionErrorsAndResults(t *testing.T) {
 	assert.Equal(t, 1, len(receipts))
 	r := receipts[0]
 	assert.Equal(t, 2, len(r.Errs))
-	assert.ErrorIs(t, wantFirstError, r.Errs[0])
-	assert.ErrorIs(t, wantSecondError, r.Errs[1])
+	testutils.AssertErrorIsWithTrace(t, wantFirstError, r.Errs[0])
+	testutils.AssertErrorIsWithTrace(t, wantSecondError, r.Errs[1])
 	got, ok := r.Result.(MoveMsgResult)
 	assert.Check(t, ok)
 	assert.Equal(t, MoveMsgResult{42, 42}, got)
@@ -488,7 +488,7 @@ func TestSystemCanFindErrorsFromEarlierSystem(t *testing.T) {
 		_, errs, ok := numTx.GetReceipt(wCtx, hash)
 		assert.Check(t, ok)
 		assert.Equal(t, 1, len(errs))
-		assert.ErrorIs(t, wantErr, errs[0])
+		testutils.AssertErrorIsWithTrace(t, wantErr, errs[0])
 		return nil
 	})
 	testutils.AssertNilErrorWithTrace(t, world.LoadGameState())

--- a/cardinal/ecs/persona_test.go
+++ b/cardinal/ecs/persona_test.go
@@ -64,7 +64,7 @@ func TestGetSignerForPersonaTagReturnsErrorWhenNotRegistered(t *testing.T) {
 	}
 
 	_, err := world.GetSignerForPersonaTag("missing_persona", 1)
-	assert.ErrorIs(t, err, ecs.ErrPersonaTagHasNoSigner)
+	testutils.AssertErrorIsWithTrace(t, err, ecs.ErrPersonaTagHasNoSigner)
 
 	// Queue up a CreatePersona
 	personaTag := "foobar"
@@ -77,7 +77,7 @@ func TestGetSignerForPersonaTagReturnsErrorWhenNotRegistered(t *testing.T) {
 	// originally got the CreatePersona.
 	tick := world.CurrentTick()
 	_, err = world.GetSignerForPersonaTag(personaTag, tick)
-	assert.ErrorIs(t, err, ecs.ErrCreatePersonaTxsNotProcessed)
+	testutils.AssertErrorIsWithTrace(t, err, ecs.ErrCreatePersonaTxsNotProcessed)
 
 	testutils.AssertNilErrorWithTrace(t, world.Tick(ctx))
 	// The CreatePersona has now been processed

--- a/cardinal/ecs/receipt/receipt_test.go
+++ b/cardinal/ecs/receipt/receipt_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-engine/cardinal/ecs/message"
 	"pkg.world.dev/world-engine/cardinal/testutils"
 
@@ -104,7 +103,7 @@ func TestErrorWhenGettingReceiptsInNonFinishedTick(t *testing.T) {
 	rh := NewHistory(currTick, 5)
 
 	_, err := rh.GetReceiptsForTick(currTick)
-	testutils.AssertErrorIsWithTrace(t, ErrTickHasNotBeenProcessed, eris.Cause(err))
+	testutils.AssertErrorIsWithTrace(t, err, ErrTickHasNotBeenProcessed)
 
 	rh.NextTick()
 
@@ -146,5 +145,5 @@ func TestOldTicksAreDiscarded(t *testing.T) {
 	// should no longer be stored
 	rh.NextTick()
 	_, err := rh.GetReceiptsForTick(tickToGet)
-	testutils.AssertErrorIsWithTrace(t, ErrOldTickHasBeenDiscarded, eris.Cause(err))
+	testutils.AssertErrorIsWithTrace(t, err, ErrOldTickHasBeenDiscarded)
 }

--- a/cardinal/ecs/receipt/receipt_test.go
+++ b/cardinal/ecs/receipt/receipt_test.go
@@ -29,7 +29,7 @@ func TestCanSaveAndGetAnError(t *testing.T) {
 	rec, ok := rh.GetReceipt(hash)
 	assert.Check(t, ok)
 	assert.Equal(t, 1, len(rec.Errs))
-	assert.ErrorIs(t, wantError, rec.Errs[0])
+	testutils.AssertErrorIsWithTrace(t, wantError, rec.Errs[0])
 	assert.Equal(t, nil, rec.Result)
 }
 
@@ -42,8 +42,8 @@ func TestCanSaveAndGetManyErrors(t *testing.T) {
 	rec, ok := rh.GetReceipt(hash)
 	assert.Check(t, ok)
 	assert.Equal(t, 2, len(rec.Errs))
-	assert.ErrorIs(t, errA, rec.Errs[0])
-	assert.ErrorIs(t, errB, rec.Errs[1])
+	testutils.AssertErrorIsWithTrace(t, errA, rec.Errs[0])
+	testutils.AssertErrorIsWithTrace(t, errB, rec.Errs[1])
 	assert.Equal(t, nil, rec.Result)
 }
 
@@ -104,7 +104,7 @@ func TestErrorWhenGettingReceiptsInNonFinishedTick(t *testing.T) {
 	rh := NewHistory(currTick, 5)
 
 	_, err := rh.GetReceiptsForTick(currTick)
-	assert.ErrorIs(t, ErrTickHasNotBeenProcessed, eris.Cause(err))
+	testutils.AssertErrorIsWithTrace(t, ErrTickHasNotBeenProcessed, eris.Cause(err))
 
 	rh.NextTick()
 
@@ -136,7 +136,7 @@ func TestOldTicksAreDiscarded(t *testing.T) {
 		assert.Equal(t, 1, len(recs), "failed to get receipts in step %d", i)
 		rec := recs[0]
 		assert.Equal(t, 1, len(rec.Errs))
-		assert.ErrorIs(t, wantError, rec.Errs[0])
+		testutils.AssertErrorIsWithTrace(t, wantError, rec.Errs[0])
 		gotResult, ok := rec.Result.(MyStruct)
 		assert.Check(t, ok)
 		assert.Equal(t, wantResult, gotResult)
@@ -146,5 +146,5 @@ func TestOldTicksAreDiscarded(t *testing.T) {
 	// should no longer be stored
 	rh.NextTick()
 	_, err := rh.GetReceiptsForTick(tickToGet)
-	assert.ErrorIs(t, ErrOldTickHasBeenDiscarded, eris.Cause(err))
+	testutils.AssertErrorIsWithTrace(t, ErrOldTickHasBeenDiscarded, eris.Cause(err))
 }

--- a/cardinal/ecs/tick_test.go
+++ b/cardinal/ecs/tick_test.go
@@ -144,7 +144,7 @@ func TestCanIdentifyAndFixSystemError(t *testing.T) {
 	// Power is set to 2
 	testutils.AssertNilErrorWithTrace(t, oneWorld.Tick(context.Background()))
 	// Power is set to 3, then the System fails
-	testutils.AssertErrorIsWithTrace(t, errorSystem, eris.Cause(oneWorld.Tick(context.Background())))
+	testutils.AssertErrorIsWithTrace(t, oneWorld.Tick(context.Background())), errorSystem)
 
 	// Set up a new world using the same storage layer
 	twoWorld := ecstestutils.InitWorldWithRedis(t, rs)
@@ -299,7 +299,7 @@ func TestCanRecoverStateAfterFailedArchetypeChange(t *testing.T) {
 			testutils.AssertErrorIsWithTrace(t, storage.ErrComponentNotOnEntity, eris.Cause(err))
 
 			// Ticking again should result in an error
-			testutils.AssertErrorIsWithTrace(t, errorToggleComponent, eris.Cause(world.Tick(context.Background())))
+			testutils.AssertErrorIsWithTrace(t, world.Tick(context.Background()), errorToggleComponent)
 		} else {
 			// At this second iteration, the errorToggleComponent bug has been fixed. static.Val should be 5
 			// and toggle should have just been added to the entity.
@@ -383,7 +383,7 @@ func TestCanRecoverTransactionsFromFailedSystemRun(t *testing.T) {
 
 			// In this "buggy" iteration, the above system cannot handle a power of 666.
 			powerTx.AddToQueue(world, PowerComp{666})
-			testutils.AssertErrorIsWithTrace(t, errorBadPowerChange, eris.Cause(world.Tick(context.Background())))
+			testutils.AssertErrorIsWithTrace(t, world.Tick(context.Background()), errorBadPowerChange)
 		} else {
 			// Loading the game state above should successfully re-process that final 666 messages.
 			assert.Equal(t, float64(3666), fetchPower())

--- a/cardinal/ecs/tick_test.go
+++ b/cardinal/ecs/tick_test.go
@@ -144,7 +144,7 @@ func TestCanIdentifyAndFixSystemError(t *testing.T) {
 	// Power is set to 2
 	testutils.AssertNilErrorWithTrace(t, oneWorld.Tick(context.Background()))
 	// Power is set to 3, then the System fails
-	testutils.AssertErrorIsWithTrace(t, oneWorld.Tick(context.Background())), errorSystem)
+	testutils.AssertErrorIsWithTrace(t, oneWorld.Tick(context.Background()), errorSystem)
 
 	// Set up a new world using the same storage layer
 	twoWorld := ecstestutils.InitWorldWithRedis(t, rs)

--- a/cardinal/ecs/tick_test.go
+++ b/cardinal/ecs/tick_test.go
@@ -144,7 +144,7 @@ func TestCanIdentifyAndFixSystemError(t *testing.T) {
 	// Power is set to 2
 	testutils.AssertNilErrorWithTrace(t, oneWorld.Tick(context.Background()))
 	// Power is set to 3, then the System fails
-	assert.ErrorIs(t, errorSystem, eris.Cause(oneWorld.Tick(context.Background())))
+	testutils.AssertErrorIsWithTrace(t, errorSystem, eris.Cause(oneWorld.Tick(context.Background())))
 
 	// Set up a new world using the same storage layer
 	twoWorld := ecstestutils.InitWorldWithRedis(t, rs)
@@ -296,10 +296,10 @@ func TestCanRecoverStateAfterFailedArchetypeChange(t *testing.T) {
 			}
 			// After 4 ticks, static.Val should be 4 and toggle should have just been removed from the entity.
 			_, err = component.GetComponent[ScalarComponentToggle](wCtx, id)
-			assert.ErrorIs(t, storage.ErrComponentNotOnEntity, eris.Cause(err))
+			testutils.AssertErrorIsWithTrace(t, storage.ErrComponentNotOnEntity, eris.Cause(err))
 
 			// Ticking again should result in an error
-			assert.ErrorIs(t, errorToggleComponent, eris.Cause(world.Tick(context.Background())))
+			testutils.AssertErrorIsWithTrace(t, errorToggleComponent, eris.Cause(world.Tick(context.Background())))
 		} else {
 			// At this second iteration, the errorToggleComponent bug has been fixed. static.Val should be 5
 			// and toggle should have just been added to the entity.
@@ -383,7 +383,7 @@ func TestCanRecoverTransactionsFromFailedSystemRun(t *testing.T) {
 
 			// In this "buggy" iteration, the above system cannot handle a power of 666.
 			powerTx.AddToQueue(world, PowerComp{666})
-			assert.ErrorIs(t, errorBadPowerChange, eris.Cause(world.Tick(context.Background())))
+			testutils.AssertErrorIsWithTrace(t, errorBadPowerChange, eris.Cause(world.Tick(context.Background())))
 		} else {
 			// Loading the game state above should successfully re-process that final 666 messages.
 			assert.Equal(t, float64(3666), fetchPower())

--- a/cardinal/testutils/testutils.go
+++ b/cardinal/testutils/testutils.go
@@ -3,10 +3,22 @@ package testutils
 import (
 	"gotest.tools/v3/assert"
 
+	testify "github.com/stretchr/testify/assert"
+
 	"github.com/rotisserie/eris"
 )
 
 func AssertNilErrorWithTrace(t assert.TestingT, err error, args ...interface{}) {
 	args = append([]interface{}{eris.ToString(err, true)}, args...)
 	assert.NilError(t, err, args...)
+}
+
+func AssertErrorWithTrace(t testify.TestingT, err error, args ...interface{}) {
+	args = append([]interface{}{eris.ToString(err, true)}, args...)
+	testify.Error(t, eris.Cause(err), args...)
+}
+
+func AssertErrorIsWithTrace(t assert.TestingT, err error, expected error, args ...interface{}) {
+	args = append([]interface{}{eris.ToString(err, true)}, args...)
+	assert.ErrorIs(t, eris.Cause(err), eris.Cause(expected), args...)
 }

--- a/sign/sign_test.go
+++ b/sign/sign_test.go
@@ -45,7 +45,7 @@ func TestCanSignAndVerifyPayload(t *testing.T) {
 	// Verify signature verification can fail
 	errorWithStackTrace := toBeVerified.Verify(badAddressHex)
 	err = eris.Unwrap(errorWithStackTrace)
-	assert.ErrorIs(t, err, ErrSignatureValidationFailed)
+	testutils.AssertErrorIsWithTrace(t, err, ErrSignatureValidationFailed)
 }
 
 func TestCanParseAMappedTransaction(t *testing.T) {
@@ -162,7 +162,7 @@ func TestFailsIfFieldsMissing(t *testing.T) {
 			var payload *Transaction
 			payload, err = tc.payload()
 			if tc.expErr != nil {
-				assert.ErrorIs(t, tc.expErr, err)
+				testutils.AssertErrorIsWithTrace(t, err, tc.expErr)
 				return
 			}
 			testutils.AssertNilErrorWithTrace(t, err, "in test case %q", tc.name)
@@ -218,11 +218,11 @@ func TestRejectInvalidSignatures(t *testing.T) {
 		Value int
 	}
 	_, err = NewTransaction(key, "", "namespace", 100, Payload{100})
-	assert.ErrorIs(t, err, ErrInvalidPersonaTag)
+	testutils.AssertErrorIsWithTrace(t, err, ErrInvalidPersonaTag)
 	_, err = NewTransaction(key, "persona_tag", "", 100, Payload{100})
-	assert.ErrorIs(t, err, ErrInvalidNamespace)
+	testutils.AssertErrorIsWithTrace(t, err, ErrInvalidNamespace)
 	_, err = NewTransaction(key, "persona_tag", "", 100, nil)
-	assert.ErrorIs(t, err, ErrCannotSignEmptyBody)
+	testutils.AssertErrorIsWithTrace(t, err, ErrCannotSignEmptyBody)
 }
 
 func TestRejectInvalidJSON(t *testing.T) {


### PR DESCRIPTION
Closes: WORLD-579

Replaces ErrorIs and testify.assert.Error With versions that will display stack trace. on error. This PR is stacked on world-578, please review that one before this one. 