### PR TITLE
fix(cardinal): fix panic bug in websocket test. 

### DIFF
--- a/cardinal/events/events.go
+++ b/cardinal/events/events.go
@@ -320,18 +320,17 @@ func Echo(w http.ResponseWriter, r *http.Request) {
 	}
 	err = WebSocketEchoHandler(c)
 	if err != nil {
-		err = sendError(w, err)
-		if err != nil {
-			panic(err)
+		errClose, ok :=
+			eris.Cause(err).(*websocket.CloseError) //nolint: errorlint // errorAs doesn't work. eris.Cause fixes it.
+
+		if ok && errClose.Code == websocket.CloseNormalClosure {
+			// the library creates an error here but it's actually a normal closure. It is Expected.
+			return
 		}
-		return
+		panic(eris.ToString(err, true))
 	}
 	err = eris.Wrap(c.Close(), "")
 	if err != nil {
-		err = sendError(w, err)
-		if err != nil {
-			panic(err)
-		}
-		return
+		panic(eris.ToString(err, true))
 	}
 }

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-engine/cardinal"
 
 	"pkg.world.dev/world-engine/cardinal/testutils"
@@ -1165,6 +1166,28 @@ func TestTransactionsSubmittedToChain(t *testing.T) {
 	assert.Equal(t, adapter.called, 2)
 }
 
+func TestWebSocket(t *testing.T) {
+	w := testutils.NewTestWorld(t)
+	world := w.Instance()
+	assert.NilError(t, w.Instance().LoadGameState())
+	txh := testutils.MakeTestTransactionHandler(t, world, server.DisableSignatureVerification())
+	url := txh.MakeWebSocketURL("echo")
+	dial, _, err := websocket.DefaultDialer.Dial(url, nil)
+	assert.NilError(t, err)
+	messageToSend := "test"
+	err = dial.WriteMessage(websocket.TextMessage, []byte(messageToSend))
+	assert.NilError(t, err)
+	messageType, message, err := dial.ReadMessage()
+	assert.NilError(t, err)
+	assert.Equal(t, messageType, websocket.TextMessage)
+	assert.Equal(t, string(message), messageToSend)
+	err = eris.Wrap(
+		dial.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, "")), "")
+	assert.NilError(t, err)
+	err = dial.Close()
+	assert.NilError(t, err)
+}
+
 func TestTransactionNotSubmittedWhenRecovering(t *testing.T) {
 	moveEndpoint := "tx/game/move"
 	type MoveTx struct {
@@ -1201,23 +1224,4 @@ func TestTransactionNotSubmittedWhenRecovering(t *testing.T) {
 	bz, err = io.ReadAll(resp.Body)
 	assert.NilError(t, err)
 	assert.ErrorContains(t, errors.New(string(bz)), "game world is recovering state")
-}
-
-func TestWebSocket(t *testing.T) {
-	w := testutils.NewTestWorld(t)
-	world := w.Instance()
-	assert.NilError(t, w.Instance().LoadGameState())
-	txh := testutils.MakeTestTransactionHandler(t, world, server.DisableSignatureVerification())
-	url := txh.MakeWebSocketURL("echo")
-	dial, _, err := websocket.DefaultDialer.Dial(url, nil)
-	assert.NilError(t, err)
-	messageToSend := "test"
-	err = dial.WriteMessage(websocket.TextMessage, []byte(messageToSend))
-	assert.NilError(t, err)
-	messageType, message, err := dial.ReadMessage()
-	assert.NilError(t, err)
-	assert.Equal(t, messageType, websocket.TextMessage)
-	assert.Equal(t, string(message), messageToSend)
-	err = dial.Close()
-	assert.NilError(t, err)
 }


### PR DESCRIPTION
Closes: WORLD-582

Basically to correctly close a websocket connection from the client side you must send it a close message. 

I moved the websocket test but there is a change to it. I send an additional close message before closing the dialer. 

This does not prevent an error from happening on the server side. The server still generates an error but with error code 1000 which indicates "normal closure" I check for this and swallow the error if it's normal. 