### PR TITLE
fix(relay): remove panic condition

### DIFF
--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -318,7 +318,7 @@ func handleClaimPersona(ptv *personaTagVerifier, notifier *receiptNotifier) naka
 			}
 			return logErrorWithMessageAndCode(
 				logger,
-				err,
+				eris.New("could not set personaTag assignment"),
 				AlreadyExists,
 				"persona tag %q is not available",
 				ptr.PersonaTag)
@@ -467,7 +467,8 @@ func logErrorWithMessageAndCode(
 	err error,
 	code int,
 	format string,
-	v ...interface{}) (string, error) {
+	v ...interface{},
+) (string, error) {
 	err = eris.Wrapf(err, format, v...)
 	return logError(logger, err, code)
 }

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -502,7 +502,7 @@ func errToNakamaError(
 	if DebugEnabled {
 		return runtime.NewError(eris.ToString(err, true), code)
 	}
-	return runtime.NewError(err.Error(), code)
+	return runtime.NewError(eris.Errorf("error: %w", err).Error(), code)
 }
 
 // setPersonaTagAssignment attempts to associate a given persona tag with the given user ID, and returns

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -502,7 +502,7 @@ func errToNakamaError(
 	if DebugEnabled {
 		return runtime.NewError(eris.ToString(err, true), code)
 	}
-	return runtime.NewError(eris.Errorf("error: %w", err).Error(), code)
+	return runtime.NewError(eris.Errorf("error: %v", err).Error(), code)
 }
 
 // setPersonaTagAssignment attempts to associate a given persona tag with the given user ID, and returns


### PR DESCRIPTION
## Overview

fixes an issue of trying to log a nil error, which in turn calls `err.Error()`
## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
