### PR TITLE
feat(cardinal): update code to enable saving and storing of schemas.

### DIFF
--- a/cardinal/ecs/storage/engine.go
+++ b/cardinal/ecs/storage/engine.go
@@ -4,3 +4,13 @@ type NonceStorage interface {
 	GetNonce(key string) (uint64, error)
 	SetNonce(key string, nonce uint64) error
 }
+
+type SchemaStorage interface {
+	GetSchema(componentName string) ([]byte, error)
+	SetSchema(componentName string, schemaData []byte) error
+}
+
+type SchemaAndNonceStorage interface {
+	NonceStorage
+	SchemaStorage
+}

--- a/cardinal/ecs/storage/keys.go
+++ b/cardinal/ecs/storage/keys.go
@@ -8,3 +8,7 @@ package storage
 func (r *RedisStorage) nonceKey() string {
 	return "ADDRESS_TO_NONCE"
 }
+
+func (r *RedisStorage) schemaStorageKey() string {
+	return "COMPONENT_NAME_TO_SCHEMA_DATA"
+}

--- a/cardinal/ecs/storage/redis_storage.go
+++ b/cardinal/ecs/storage/redis_storage.go
@@ -47,6 +47,28 @@ func NewRedisStorage(options Options, namespace string) RedisStorage {
 }
 
 // ---------------------------------------------------------------------------
+//
+//	Schema Storage
+//
+// ---------------------------------------------------------------------------
+var _ SchemaStorage = &RedisStorage{}
+
+func (r *RedisStorage) GetSchema(componentName string) ([]byte, error) {
+	ctx := context.Background()
+	schemaBytes, err := r.Client.HGet(ctx, r.schemaStorageKey(), componentName).Bytes()
+	err = eris.Wrap(err, "")
+	if err != nil {
+		return nil, err
+	}
+	return schemaBytes, nil
+}
+
+func (r *RedisStorage) SetSchema(componentName string, schemaData []byte) error {
+	ctx := context.Background()
+	return eris.Wrap(r.Client.HSet(ctx, r.schemaStorageKey(), componentName, schemaData).Err(), "")
+}
+
+// ---------------------------------------------------------------------------
 //							Nonce Storage
 // ---------------------------------------------------------------------------
 

--- a/cardinal/ecs/storage/schema_test.go
+++ b/cardinal/ecs/storage/schema_test.go
@@ -1,0 +1,48 @@
+package storage_test
+
+import (
+	"testing"
+
+	"pkg.world.dev/world-engine/assert"
+	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
+)
+
+type TestComponent1 struct {
+	number int
+}
+
+func (TestComponent1) Name() string {
+	return "test_component1"
+}
+
+type TestComponent struct {
+	word string
+}
+
+func (TestComponent) Name() string {
+	return "test_component"
+}
+
+func TestSetAndGetSchema(t *testing.T) {
+	testComponent1 := TestComponent1{number: 2}
+	testComponent := TestComponent{word: "hello"}
+	schema1, err := metadata.SerializeComponentSchema(testComponent1)
+	schema, err := metadata.SerializeComponentSchema(testComponent)
+	assert.NilError(t, err)
+	rs := testutil.GetRedisStorage(t)
+	err = rs.SetSchema(testComponent1.Name(), schema1)
+	assert.NilError(t, err)
+	err = rs.SetSchema(testComponent.Name(), schema)
+	assert.NilError(t, err)
+	otherSchema1, err := rs.GetSchema(testComponent1.Name())
+	assert.NilError(t, err)
+	valid, err := metadata.IsComponentValid(testComponent1, otherSchema1)
+	assert.NilError(t, err)
+	assert.Assert(t, valid)
+	otherSchema, err := rs.GetSchema(testComponent.Name())
+	assert.NilError(t, err)
+	valid, err = metadata.IsComponentValid(testComponent1, otherSchema)
+	assert.NilError(t, err)
+	assert.Assert(t, !valid)
+}


### PR DESCRIPTION
Closes: WORLD-596

allows for saving and storing of schemas in world-engine. Created a sibling interface in engine.go to facilitate this. 

Deleted `GetRawJSONOfComponent` because I noticed it wasn't being used anwhere.