### PR TITLE
refactor(cardinal): break up /ecs/component 

### DIFF
--- a/cardinal/ecs/benchmark/benchmark_test.go
+++ b/cardinal/ecs/benchmark/benchmark_test.go
@@ -13,7 +13,6 @@ import (
 	"pkg.world.dev/world-engine/assert"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/ecb"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
@@ -60,10 +59,10 @@ func setupWorld(t testing.TB, numOfEntities int, enableHealthSystem bool) *ecs.W
 				assert.NilError(t, err)
 				err = q.Each(
 					wCtx, func(id entity.ID) bool {
-						health, err := component.GetComponent[Health](wCtx, id)
+						health, err := ecs.GetComponent[Health](wCtx, id)
 						assert.NilError(t, err)
 						health.Value++
-						assert.NilError(t, component.SetComponent[Health](wCtx, id, health))
+						assert.NilError(t, ecs.SetComponent[Health](wCtx, id, health))
 						return true
 					},
 				)
@@ -75,7 +74,7 @@ func setupWorld(t testing.TB, numOfEntities int, enableHealthSystem bool) *ecs.W
 
 	assert.NilError(t, ecs.RegisterComponent[Health](world))
 	assert.NilError(t, world.LoadGameState())
-	_, err := component.CreateMany(ecs.NewWorldContext(world), numOfEntities, Health{})
+	_, err := ecs.CreateMany(ecs.NewWorldContext(world), numOfEntities, Health{})
 	assert.NilError(t, err)
 	// Perform a game tick to ensure the newly created entities have been committed to the DB
 	ctx := context.Background()

--- a/cardinal/ecs/component/metadata/component_metadata_test.go
+++ b/cardinal/ecs/component/metadata/component_metadata_test.go
@@ -11,7 +11,6 @@ import (
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/types/archetype"
 
@@ -163,9 +162,9 @@ func TestErrorWhenAccessingComponentNotOnEntity(t *testing.T) {
 	ecs.MustRegisterComponent[notFoundComp](world)
 
 	wCtx := ecs.NewWorldContext(world)
-	id, err := component.Create(wCtx, foundComp{})
+	id, err := ecs.Create(wCtx, foundComp{})
 	assert.NilError(t, err)
-	_, err = component.GetComponent[notFoundComp](wCtx, id)
+	_, err = ecs.GetComponent[notFoundComp](wCtx, id)
 	assert.ErrorIs(t, err, storage.ErrComponentNotOnEntity)
 }
 
@@ -182,19 +181,19 @@ func TestMultipleCallsToCreateSupported(t *testing.T) {
 	assert.NilError(t, ecs.RegisterComponent[ValueComponent](world))
 
 	wCtx := ecs.NewWorldContext(world)
-	id, err := component.Create(wCtx, ValueComponent{})
+	id, err := ecs.Create(wCtx, ValueComponent{})
 	assert.NilError(t, err)
 
-	assert.NilError(t, component.SetComponent[ValueComponent](wCtx, id, &ValueComponent{99}))
+	assert.NilError(t, ecs.SetComponent[ValueComponent](wCtx, id, &ValueComponent{99}))
 
-	val, err := component.GetComponent[ValueComponent](wCtx, id)
+	val, err := ecs.GetComponent[ValueComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 99, val.Val)
 
-	_, err = component.Create(wCtx, ValueComponent{})
+	_, err = ecs.Create(wCtx, ValueComponent{})
 	assert.NilError(t, err)
 
-	val, err = component.GetComponent[ValueComponent](wCtx, id)
+	val, err = ecs.GetComponent[ValueComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 99, val.Val)
 }

--- a/cardinal/ecs/cql/cql.go
+++ b/cardinal/ecs/cql/cql.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/alecthomas/participle/v2"
 	"github.com/rotisserie/eris"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
@@ -142,7 +142,7 @@ var internalCQLParser = participle.MustBuild[cqlTerm]()
 // TODO: Msg is sum type is represented as a product type. There is a case where multiple properties are filled out.
 // Only one property may not be nil, The parser should prevent this from happening but for safety this should eventually
 // be checked.
-func valueToComponentFilter(value *cqlValue, stringToComponent func(string) (metadata.ComponentMetadata, error)) (
+func valueToComponentFilter(value *cqlValue, stringToComponent func(string) (component.ComponentMetadata, error)) (
 	filter.ComponentFilter, error,
 ) {
 	if value.Not != nil { //nolint:gocritic,nestif // its fine.
@@ -155,7 +155,7 @@ func valueToComponentFilter(value *cqlValue, stringToComponent func(string) (met
 		if len(value.Exact.Components) == 0 {
 			return nil, eris.New("EXACT cannot have zero parameters")
 		}
-		components := make([]metadata.ComponentMetadata, 0, len(value.Exact.Components))
+		components := make([]component.ComponentMetadata, 0, len(value.Exact.Components))
 		for _, componentName := range value.Exact.Components {
 			comp, err := stringToComponent(componentName.Name)
 			if err != nil {
@@ -168,7 +168,7 @@ func valueToComponentFilter(value *cqlValue, stringToComponent func(string) (met
 		if len(value.Contains.Components) == 0 {
 			return nil, eris.New("CONTAINS cannot have zero parameters")
 		}
-		components := make([]metadata.ComponentMetadata, 0, len(value.Contains.Components))
+		components := make([]component.ComponentMetadata, 0, len(value.Contains.Components))
 		for _, componentName := range value.Contains.Components {
 			comp, err := stringToComponent(componentName.Name)
 			if err != nil {
@@ -184,7 +184,7 @@ func valueToComponentFilter(value *cqlValue, stringToComponent func(string) (met
 	}
 }
 
-func factorToComponentFilter(factor *cqlFactor, stringToComponent func(string) (metadata.ComponentMetadata, error)) (
+func factorToComponentFilter(factor *cqlFactor, stringToComponent func(string) (component.ComponentMetadata, error)) (
 	filter.ComponentFilter, error,
 ) {
 	return valueToComponentFilter(factor.Base, stringToComponent)
@@ -192,7 +192,7 @@ func factorToComponentFilter(factor *cqlFactor, stringToComponent func(string) (
 
 func opFactorToComponentFilter(
 	opFactor *cqlOpFactor,
-	stringToComponent func(string) (metadata.ComponentMetadata, error),
+	stringToComponent func(string) (component.ComponentMetadata, error),
 ) (*cqlOperator, filter.ComponentFilter, error) {
 	resultFilter, err := factorToComponentFilter(opFactor.Factor, stringToComponent)
 	if err != nil {
@@ -202,7 +202,7 @@ func opFactorToComponentFilter(
 }
 
 func termToComponentFilter(
-	term *cqlTerm, stringToComponent func(string) (metadata.ComponentMetadata, error),
+	term *cqlTerm, stringToComponent func(string) (component.ComponentMetadata, error),
 ) (filter.ComponentFilter, error) {
 	if term.Left == nil {
 		return nil, eris.New("not enough values in expression")
@@ -229,7 +229,7 @@ func termToComponentFilter(
 }
 
 func Parse(
-	cqlText string, stringToComponent func(string) (metadata.ComponentMetadata, error),
+	cqlText string, stringToComponent func(string) (component.ComponentMetadata, error),
 ) (filter.ComponentFilter, error) {
 	term, err := internalCQLParser.ParseString("", cqlText)
 	if err != nil {

--- a/cardinal/ecs/cql/cql_test.go
+++ b/cardinal/ecs/cql/cql_test.go
@@ -6,8 +6,8 @@ import (
 
 	"pkg.world.dev/world-engine/assert"
 
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 )
 
 type EmptyComponent struct{}
@@ -17,52 +17,67 @@ func (EmptyComponent) Name() string { return "emptyComponent" }
 func TestParser(t *testing.T) {
 	term, err := internalCQLParser.ParseString("", "!(EXACT(a, b) & EXACT(a)) | CONTAINS(b)")
 	testTerm := cqlTerm{
-		Left: &cqlFactor{Base: &cqlValue{
-			Exact:    nil,
-			Contains: nil,
-			Not: &cqlNot{SubExpression: &cqlValue{
+		Left: &cqlFactor{
+			Base: &cqlValue{
 				Exact:    nil,
 				Contains: nil,
-				Not:      nil,
-				Subexpression: &cqlTerm{
-					Left: &cqlFactor{Base: &cqlValue{
-						Exact: &cqlExact{Components: []*cqlComponent{
-							{Name: "a"},
-							{Name: "b"}}},
-						Contains:      nil,
-						Not:           nil,
-						Subexpression: nil,
-					}},
-					Right: []*cqlOpFactor{{
-						Operator: opAnd,
-						Factor: &cqlFactor{Base: &cqlValue{
-							Exact:         &cqlExact{Components: []*cqlComponent{{Name: "a"}}},
-							Contains:      nil,
-							Not:           nil,
-							Subexpression: nil,
-						}},
-					}},
+				Not: &cqlNot{
+					SubExpression: &cqlValue{
+						Exact:    nil,
+						Contains: nil,
+						Not:      nil,
+						Subexpression: &cqlTerm{
+							Left: &cqlFactor{
+								Base: &cqlValue{
+									Exact: &cqlExact{
+										Components: []*cqlComponent{
+											{Name: "a"},
+											{Name: "b"},
+										},
+									},
+									Contains:      nil,
+									Not:           nil,
+									Subexpression: nil,
+								},
+							},
+							Right: []*cqlOpFactor{
+								{
+									Operator: opAnd,
+									Factor: &cqlFactor{
+										Base: &cqlValue{
+											Exact:         &cqlExact{Components: []*cqlComponent{{Name: "a"}}},
+											Contains:      nil,
+											Not:           nil,
+											Subexpression: nil,
+										},
+									},
+								},
+							},
+						},
+					},
 				},
-			}},
-			Subexpression: nil,
-		}},
+				Subexpression: nil,
+			},
+		},
 		Right: []*cqlOpFactor{
 			{
 				Operator: opOr,
-				Factor: &cqlFactor{Base: &cqlValue{
-					Exact:         nil,
-					Contains:      &cqlContains{Components: []*cqlComponent{{Name: "b"}}},
-					Not:           nil,
-					Subexpression: nil,
-				}},
+				Factor: &cqlFactor{
+					Base: &cqlValue{
+						Exact:         nil,
+						Contains:      &cqlContains{Components: []*cqlComponent{{Name: "b"}}},
+						Not:           nil,
+						Subexpression: nil,
+					},
+				},
 			},
 		},
 	}
 	assert.NilError(t, err)
 	assert.DeepEqual(t, *term, testTerm)
 
-	emptyComponent := metadata.NewComponentMetadata[EmptyComponent]()
-	stringToComponent := func(_ string) (metadata.ComponentMetadata, error) {
+	emptyComponent := component.NewComponentMetadata[EmptyComponent]()
+	stringToComponent := func(_ string) (component.ComponentMetadata, error) {
 		return emptyComponent, nil
 	}
 	filterResult, err := termToComponentFilter(term, stringToComponent)
@@ -88,8 +103,10 @@ func TestParser(t *testing.T) {
 			filter.And(
 				filter.And(
 					filter.Contains(emptyComponent),
-					filter.Contains(emptyComponent, emptyComponent)),
-				filter.Contains(emptyComponent, emptyComponent, emptyComponent)),
+					filter.Contains(emptyComponent, emptyComponent),
+				),
+				filter.Contains(emptyComponent, emptyComponent, emptyComponent),
+			),
 			filter.Exact(emptyComponent),
 		)
 	assert.Assert(t, reflect.DeepEqual(testResult2, result))

--- a/cardinal/ecs/ecb/component.go
+++ b/cardinal/ecs/ecb/component.go
@@ -4,20 +4,20 @@ import (
 	"sort"
 
 	"github.com/rotisserie/eris"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
 // compKey is a tuple of a component TypeID and an entity ID. It used as a map key to keep
 // track of component data in-memory.
 type compKey struct {
-	typeID   metadata.TypeID
+	typeID   component.TypeID
 	entityID entity.ID
 }
 
 // sortComponentSet re-orders the given components so their IDs are strictly increasing. If any component is duplicated
 // an error is returned.
-func sortComponentSet(components []metadata.ComponentMetadata) error {
+func sortComponentSet(components []component.ComponentMetadata) error {
 	sort.Slice(
 		components, func(i, j int) bool {
 			return components[i].ID() < components[j].ID()
@@ -32,7 +32,7 @@ func sortComponentSet(components []metadata.ComponentMetadata) error {
 	return nil
 }
 
-func isComponentSetMatch(a, b []metadata.ComponentMetadata) bool {
+func isComponentSetMatch(a, b []component.ComponentMetadata) bool {
 	if len(a) != len(b) {
 		return false
 	}

--- a/cardinal/ecs/ecb/ecb.go
+++ b/cardinal/ecs/ecb/ecb.go
@@ -248,8 +248,9 @@ func (m *Manager) GetComponentForEntity(cType component.ComponentMetadata, id en
 }
 
 // GetComponentForEntityInRawJSON returns the saved component data as JSON encoded bytes for the given entity.
-func (m *Manager) GetComponentForEntityInRawJSON(cType metadata.ComponentMetadata, id entity.ID) (
-	json.RawMessage, error) {
+func (m *Manager) GetComponentForEntityInRawJSON(cType component.ComponentMetadata, id entity.ID) (
+	json.RawMessage, error,
+) {
 	value, err := m.GetComponentForEntity(cType, id)
 	if err != nil {
 		return nil, err

--- a/cardinal/ecs/ecb/ecb.go
+++ b/cardinal/ecs/ecb/ecb.go
@@ -11,12 +11,12 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	ecslog "pkg.world.dev/world-engine/cardinal/ecs/log"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/cardinal/ecs/store"
 	"pkg.world.dev/world-engine/cardinal/types/archetype"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
@@ -27,7 +27,7 @@ type Manager struct {
 
 	compValues         map[compKey]any
 	compValuesToDelete map[compKey]bool
-	typeToComponent    map[metadata.TypeID]metadata.ComponentMetadata
+	typeToComponent    map[component.TypeID]component.ComponentMetadata
 
 	activeEntities map[archetype.ID]activeEntities
 
@@ -40,7 +40,7 @@ type Manager struct {
 	entityIDToArchID       map[entity.ID]archetype.ID
 	entityIDToOriginArchID map[entity.ID]archetype.ID
 
-	archIDToComps  map[archetype.ID][]metadata.ComponentMetadata
+	archIDToComps  map[archetype.ID][]component.ComponentMetadata
 	pendingArchIDs []archetype.ID
 
 	logger *ecslog.Logger
@@ -60,7 +60,7 @@ func NewManager(client *redis.Client) (*Manager, error) {
 		compValuesToDelete: map[compKey]bool{},
 
 		activeEntities: map[archetype.ID]activeEntities{},
-		archIDToComps:  map[archetype.ID][]metadata.ComponentMetadata{},
+		archIDToComps:  map[archetype.ID][]component.ComponentMetadata{},
 
 		entityIDToArchID:       map[entity.ID]archetype.ID{},
 		entityIDToOriginArchID: map[entity.ID]archetype.ID{},
@@ -76,8 +76,8 @@ func NewManager(client *redis.Client) (*Manager, error) {
 	return m, nil
 }
 
-func (m *Manager) RegisterComponents(comps []metadata.ComponentMetadata) error {
-	m.typeToComponent = map[metadata.TypeID]metadata.ComponentMetadata{}
+func (m *Manager) RegisterComponents(comps []component.ComponentMetadata) error {
+	m.typeToComponent = map[component.TypeID]component.ComponentMetadata{}
 	for _, comp := range comps {
 		m.typeToComponent[comp.ID()] = comp
 	}
@@ -157,7 +157,7 @@ func (m *Manager) RemoveEntity(idToRemove entity.ID) error {
 }
 
 // CreateEntity creates a single entity with the given set of components.
-func (m *Manager) CreateEntity(comps ...metadata.ComponentMetadata) (entity.ID, error) {
+func (m *Manager) CreateEntity(comps ...component.ComponentMetadata) (entity.ID, error) {
 	ids, err := m.CreateManyEntities(1, comps...)
 	if err != nil {
 		return 0, err
@@ -166,7 +166,7 @@ func (m *Manager) CreateEntity(comps ...metadata.ComponentMetadata) (entity.ID, 
 }
 
 // CreateManyEntities creates many entities with the given set of components.
-func (m *Manager) CreateManyEntities(num int, comps ...metadata.ComponentMetadata) ([]entity.ID, error) {
+func (m *Manager) CreateManyEntities(num int, comps ...component.ComponentMetadata) ([]entity.ID, error) {
 	archID, err := m.getOrMakeArchIDForComponents(comps)
 	if err != nil {
 		return nil, err
@@ -194,7 +194,7 @@ func (m *Manager) CreateManyEntities(num int, comps ...metadata.ComponentMetadat
 }
 
 // SetComponentForEntity sets the given entity's component data to the given value.
-func (m *Manager) SetComponentForEntity(cType metadata.ComponentMetadata, id entity.ID, value any) error {
+func (m *Manager) SetComponentForEntity(cType component.ComponentMetadata, id entity.ID, value any) error {
 	comps, err := m.GetComponentTypesForEntity(id)
 	if err != nil {
 		return err
@@ -209,7 +209,7 @@ func (m *Manager) SetComponentForEntity(cType metadata.ComponentMetadata, id ent
 }
 
 // GetComponentForEntity returns the saved component data for the given entity.
-func (m *Manager) GetComponentForEntity(cType metadata.ComponentMetadata, id entity.ID) (any, error) {
+func (m *Manager) GetComponentForEntity(cType component.ComponentMetadata, id entity.ID) (any, error) {
 	key := compKey{cType.ID(), id}
 	value, ok := m.compValues[key]
 	if ok {
@@ -259,7 +259,7 @@ func (m *Manager) GetComponentForEntityInRawJSON(cType metadata.ComponentMetadat
 
 // AddComponentToEntity adds the given component to the given entity. An error is returned if the entity
 // already has this component.
-func (m *Manager) AddComponentToEntity(cType metadata.ComponentMetadata, id entity.ID) error {
+func (m *Manager) AddComponentToEntity(cType component.ComponentMetadata, id entity.ID) error {
 	fromComps, err := m.GetComponentTypesForEntity(id)
 	if err != nil {
 		return err
@@ -285,12 +285,12 @@ func (m *Manager) AddComponentToEntity(cType metadata.ComponentMetadata, id enti
 
 // RemoveComponentFromEntity removes the given component from the given entity. An error is returned if the entity
 // does not have the component.
-func (m *Manager) RemoveComponentFromEntity(cType metadata.ComponentMetadata, id entity.ID) error {
+func (m *Manager) RemoveComponentFromEntity(cType component.ComponentMetadata, id entity.ID) error {
 	comps, err := m.GetComponentTypesForEntity(id)
 	if err != nil {
 		return err
 	}
-	newCompSet := make([]metadata.ComponentMetadata, 0, len(comps)-1)
+	newCompSet := make([]component.ComponentMetadata, 0, len(comps)-1)
 	found := false
 	for _, comp := range comps {
 		if comp.ID() == cType.ID() {
@@ -321,7 +321,7 @@ func (m *Manager) RemoveComponentFromEntity(cType metadata.ComponentMetadata, id
 
 // GetComponentTypesForEntity returns all the component types that are currently on the given entity. Only types
 // are returned. To get the actual component data, use GetComponentForEntity.
-func (m *Manager) GetComponentTypesForEntity(id entity.ID) ([]metadata.ComponentMetadata, error) {
+func (m *Manager) GetComponentTypesForEntity(id entity.ID) ([]component.ComponentMetadata, error) {
 	archID, err := m.getArchetypeForEntity(id)
 	if err != nil {
 		return nil, err
@@ -331,13 +331,13 @@ func (m *Manager) GetComponentTypesForEntity(id entity.ID) ([]metadata.Component
 }
 
 // GetComponentTypesForArchID returns the set of components that are associated with the given archetype id.
-func (m *Manager) GetComponentTypesForArchID(archID archetype.ID) []metadata.ComponentMetadata {
+func (m *Manager) GetComponentTypesForArchID(archID archetype.ID) []component.ComponentMetadata {
 	return m.archIDToComps[archID]
 }
 
 // GetArchIDForComponents returns the archetype ID that has been assigned to this set of components.
 // If this set of components does not have an archetype ID assigned to it, an error is returned.
-func (m *Manager) GetArchIDForComponents(components []metadata.ComponentMetadata) (archetype.ID, error) {
+func (m *Manager) GetArchIDForComponents(components []component.ComponentMetadata) (archetype.ID, error) {
 	if len(components) == 0 {
 		return 0, eris.New("must provide at least 1 component")
 	}
@@ -439,7 +439,7 @@ func (m *Manager) nextEntityID() (entity.ID, error) {
 // getOrMakeArchIDForComponents converts the given set of components into an archetype ID. If the set of components
 // has already been assigned an archetype ID, that ID is returned. If this is a new set of components, an archetype ID
 // is generated.
-func (m *Manager) getOrMakeArchIDForComponents(comps []metadata.ComponentMetadata) (archetype.ID, error) {
+func (m *Manager) getOrMakeArchIDForComponents(comps []component.ComponentMetadata) (archetype.ID, error) {
 	archID, err := m.GetArchIDForComponents(comps)
 	if err == nil {
 		return archID, nil

--- a/cardinal/ecs/ecb/ecb_test.go
+++ b/cardinal/ecs/ecb/ecb_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/ecb"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
@@ -299,11 +298,11 @@ func TestStorageCanBeUsedInQueries(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	justHealthIDs, err := component.CreateMany(wCtx, 8, Health{})
+	justHealthIDs, err := ecs.CreateMany(wCtx, 8, Health{})
 	assert.NilError(t, err)
-	justPowerIDs, err := component.CreateMany(wCtx, 9, Power{})
+	justPowerIDs, err := ecs.CreateMany(wCtx, 9, Power{})
 	assert.NilError(t, err)
-	healthAndPowerIDs, err := component.CreateMany(wCtx, 10, Health{}, Power{})
+	healthAndPowerIDs, err := ecs.CreateMany(wCtx, 10, Health{}, Power{})
 	assert.NilError(t, err)
 
 	testCases := []struct {

--- a/cardinal/ecs/ecb/ecb_test.go
+++ b/cardinal/ecs/ecb/ecb_test.go
@@ -11,9 +11,9 @@ import (
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/ecb"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
@@ -58,9 +58,9 @@ func (Bar) Name() string {
 }
 
 var (
-	fooComp       = metadata.NewComponentMetadata[Foo]()
-	barComp       = metadata.NewComponentMetadata[Bar]()
-	allComponents = []metadata.ComponentMetadata{fooComp, barComp}
+	fooComp       = component.NewComponentMetadata[Foo]()
+	barComp       = component.NewComponentMetadata[Bar]()
+	allComponents = []component.ComponentMetadata{fooComp, barComp}
 )
 
 //nolint:gochecknoinits // its for testing.
@@ -392,9 +392,9 @@ func TestMovedEntitiesCanBeFoundInNewArchetype(t *testing.T) {
 	_, err = manager.CreateManyEntities(startEntityCount, fooComp, barComp)
 	assert.NilError(t, err)
 
-	fooArchID, err := manager.GetArchIDForComponents([]metadata.ComponentMetadata{fooComp})
+	fooArchID, err := manager.GetArchIDForComponents([]component.ComponentMetadata{fooComp})
 	assert.NilError(t, err)
-	bothArchID, err := manager.GetArchIDForComponents([]metadata.ComponentMetadata{barComp, fooComp})
+	bothArchID, err := manager.GetArchIDForComponents([]component.ComponentMetadata{barComp, fooComp})
 	assert.NilError(t, err)
 
 	// Make sure there are the correct number of ids in each archetype to start

--- a/cardinal/ecs/ecb/keys.go
+++ b/cardinal/ecs/ecb/keys.go
@@ -3,13 +3,13 @@ package ecb
 import (
 	"fmt"
 
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/types/archetype"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
 // redisComponentKey is the key that maps an entity ID and a specific component ID to the value of that component.
-func redisComponentKey(typeID metadata.TypeID, id entity.ID) string {
+func redisComponentKey(typeID component.TypeID, id entity.ID) string {
 	return fmt.Sprintf("ECB:COMPONENT-VALUE:TYPE-ID-%d:ENTITY-ID-%d", typeID, id)
 }
 

--- a/cardinal/ecs/ecb/read_only.go
+++ b/cardinal/ecs/ecb/read_only.go
@@ -8,11 +8,11 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-engine/cardinal/ecs/codec"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/cardinal/ecs/store"
 	"pkg.world.dev/world-engine/cardinal/types/archetype"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
@@ -24,8 +24,8 @@ var (
 
 type readOnlyManager struct {
 	client          *redis.Client
-	typeToComponent map[metadata.TypeID]metadata.ComponentMetadata
-	archIDToComps   map[archetype.ID][]metadata.ComponentMetadata
+	typeToComponent map[component.TypeID]component.ComponentMetadata
+	archIDToComps   map[archetype.ID][]component.ComponentMetadata
 }
 
 func (m *Manager) ToReadOnly() store.Reader {
@@ -49,7 +49,8 @@ func (r *readOnlyManager) refreshArchIDToCompTypes() error {
 	return nil
 }
 
-func (r *readOnlyManager) GetComponentForEntity(cType metadata.ComponentMetadata, id entity.ID,
+func (r *readOnlyManager) GetComponentForEntity(
+	cType component.ComponentMetadata, id entity.ID,
 ) (any, error) {
 	bz, err := r.GetComponentForEntityInRawJSON(cType, id)
 	if err != nil {
@@ -58,7 +59,8 @@ func (r *readOnlyManager) GetComponentForEntity(cType metadata.ComponentMetadata
 	return cType.Decode(bz)
 }
 
-func (r *readOnlyManager) GetComponentForEntityInRawJSON(cType metadata.ComponentMetadata, id entity.ID,
+func (r *readOnlyManager) GetComponentForEntityInRawJSON(
+	cType component.ComponentMetadata, id entity.ID,
 ) (json.RawMessage, error) {
 	ctx := context.Background()
 	key := redisComponentKey(cType.ID(), id)
@@ -66,7 +68,7 @@ func (r *readOnlyManager) GetComponentForEntityInRawJSON(cType metadata.Componen
 	return res, eris.Wrap(err, "")
 }
 
-func (r *readOnlyManager) getComponentsForArchID(archID archetype.ID) ([]metadata.ComponentMetadata, error) {
+func (r *readOnlyManager) getComponentsForArchID(archID archetype.ID) ([]component.ComponentMetadata, error) {
 	if comps, ok := r.archIDToComps[archID]; ok {
 		return comps, nil
 	}
@@ -80,7 +82,7 @@ func (r *readOnlyManager) getComponentsForArchID(archID archetype.ID) ([]metadat
 	return comps, nil
 }
 
-func (r *readOnlyManager) GetComponentTypesForEntity(id entity.ID) ([]metadata.ComponentMetadata, error) {
+func (r *readOnlyManager) GetComponentTypesForEntity(id entity.ID) ([]component.ComponentMetadata, error) {
 	ctx := context.Background()
 
 	archIDKey := redisArchetypeIDForEntityID(id)
@@ -93,7 +95,7 @@ func (r *readOnlyManager) GetComponentTypesForEntity(id entity.ID) ([]metadata.C
 	return r.getComponentsForArchID(archID)
 }
 
-func (r *readOnlyManager) GetComponentTypesForArchID(archID archetype.ID) []metadata.ComponentMetadata {
+func (r *readOnlyManager) GetComponentTypesForArchID(archID archetype.ID) []component.ComponentMetadata {
 	comps, err := r.getComponentsForArchID(archID)
 	if err != nil {
 		panic(eris.ToString(err, true))
@@ -101,7 +103,8 @@ func (r *readOnlyManager) GetComponentTypesForArchID(archID archetype.ID) []meta
 	return comps
 }
 
-func (r *readOnlyManager) GetArchIDForComponents(components []metadata.ComponentMetadata,
+func (r *readOnlyManager) GetArchIDForComponents(
+	components []component.ComponentMetadata,
 ) (archetype.ID, error) {
 	if err := sortComponentSet(components); err != nil {
 		return 0, err

--- a/cardinal/ecs/ecb/read_only_test.go
+++ b/cardinal/ecs/ecb/read_only_test.go
@@ -8,7 +8,7 @@ import (
 
 	"pkg.world.dev/world-engine/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 )
 
 func TestReadOnly_CanGetComponent(t *testing.T) {
@@ -37,19 +37,19 @@ func TestReadOnly_CanGetComponentTypesForEntityAndArchID(t *testing.T) {
 
 	testCases := []struct {
 		name  string
-		comps []metadata.ComponentMetadata
+		comps []component.ComponentMetadata
 	}{
 		{
 			"just foo",
-			[]metadata.ComponentMetadata{fooComp},
+			[]component.ComponentMetadata{fooComp},
 		},
 		{
 			"just bar",
-			[]metadata.ComponentMetadata{barComp},
+			[]component.ComponentMetadata{barComp},
 		},
 		{
 			"foo and bar",
-			[]metadata.ComponentMetadata{fooComp, barComp},
+			[]component.ComponentMetadata{fooComp, barComp},
 		},
 	}
 
@@ -83,22 +83,22 @@ func TestReadOnly_GetEntitiesForArchID(t *testing.T) {
 	testCases := []struct {
 		name        string
 		idsToCreate int
-		comps       []metadata.ComponentMetadata
+		comps       []component.ComponentMetadata
 	}{
 		{
 			"only foo",
 			3,
-			[]metadata.ComponentMetadata{fooComp},
+			[]component.ComponentMetadata{fooComp},
 		},
 		{
 			"only bar",
 			4,
-			[]metadata.ComponentMetadata{barComp},
+			[]component.ComponentMetadata{barComp},
 		},
 		{
 			"foo and bar",
 			5,
-			[]metadata.ComponentMetadata{fooComp, barComp},
+			[]component.ComponentMetadata{fooComp, barComp},
 		},
 	}
 
@@ -123,7 +123,7 @@ func TestReadOnly_CanFindEntityIDAfterChangingArchetypes(t *testing.T) {
 	assert.NilError(t, err)
 	assert.NilError(t, manager.CommitPending())
 
-	fooArchID, err := manager.GetArchIDForComponents([]metadata.ComponentMetadata{fooComp})
+	fooArchID, err := manager.GetArchIDForComponents([]component.ComponentMetadata{fooComp})
 	assert.NilError(t, err)
 
 	roManager := manager.ToReadOnly()
@@ -141,7 +141,7 @@ func TestReadOnly_CanFindEntityIDAfterChangingArchetypes(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, 0, len(gotIDs))
 
-	bothArchID, err := roManager.GetArchIDForComponents([]metadata.ComponentMetadata{fooComp, barComp})
+	bothArchID, err := roManager.GetArchIDForComponents([]component.ComponentMetadata{fooComp, barComp})
 	assert.NilError(t, err)
 
 	gotIDs, err = roManager.GetEntitiesForArchID(bothArchID)

--- a/cardinal/ecs/ecb/read_only_test.go
+++ b/cardinal/ecs/ecb/read_only_test.go
@@ -8,7 +8,6 @@ import (
 
 	"pkg.world.dev/world-engine/assert"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 )
 
@@ -183,11 +182,11 @@ func TestReadOnly_SearchFrom(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	_, err := component.CreateMany(wCtx, 8, Health{})
+	_, err := ecs.CreateMany(wCtx, 8, Health{})
 	assert.NilError(t, err)
-	_, err = component.CreateMany(wCtx, 9, Power{})
+	_, err = ecs.CreateMany(wCtx, 9, Power{})
 	assert.NilError(t, err)
-	_, err = component.CreateMany(wCtx, 10, Health{}, Power{})
+	_, err = ecs.CreateMany(wCtx, 10, Health{}, Power{})
 	assert.NilError(t, err)
 
 	filter := ecs.Contains(Health{})

--- a/cardinal/ecs/ecb/redis.go
+++ b/cardinal/ecs/ecb/redis.go
@@ -182,15 +182,15 @@ func getArchIDToCompTypesFromRedis(
 		return nil, false, err
 	}
 
-	fromStorage, err := codec.Decode[map[archetype.ID][]metadata.TypeID](bz)
+	fromStorage, err := codec.Decode[map[archetype.ID][]component.TypeID](bz)
 	if err != nil {
 		return nil, false, err
 	}
 
 	// result is the mapping of Arch ID -> IComponent sets
-	result := map[archetype.ID][]metadata.ComponentMetadata{}
+	result := map[archetype.ID][]component.ComponentMetadata{}
 	for archID, compTypeIDs := range fromStorage {
-		currComps := []metadata.ComponentMetadata{}
+		var currComps []component.ComponentMetadata
 		for _, compTypeID := range compTypeIDs {
 			currComp, found := typeToComp[compTypeID]
 			if !found {

--- a/cardinal/ecs/ecb/redis.go
+++ b/cardinal/ecs/ecb/redis.go
@@ -6,9 +6,9 @@ import (
 	"github.com/redis/go-redis/v9"
 	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-engine/cardinal/ecs/codec"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/cardinal/types/archetype"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 )
 
 // pipeFlushToRedis return a pipeliner with all pending state changes to redis ready to be committed in an atomic
@@ -157,9 +157,9 @@ func (m *Manager) addActiveEntityIDsToPipe(ctx context.Context, pipe redis.Pipel
 }
 
 func (m *Manager) encodeArchIDToCompTypes() ([]byte, error) {
-	forStorage := map[archetype.ID][]metadata.TypeID{}
+	forStorage := map[archetype.ID][]component.TypeID{}
 	for archID, comps := range m.archIDToComps {
-		typeIDs := []metadata.TypeID{}
+		typeIDs := []component.TypeID{}
 		for _, comp := range comps {
 			typeIDs = append(typeIDs, comp.ID())
 		}
@@ -168,9 +168,10 @@ func (m *Manager) encodeArchIDToCompTypes() ([]byte, error) {
 	return codec.Encode(forStorage)
 }
 
-func getArchIDToCompTypesFromRedis(client *redis.Client,
-	typeToComp map[metadata.TypeID]metadata.ComponentMetadata,
-) (m map[archetype.ID][]metadata.ComponentMetadata, ok bool, err error) {
+func getArchIDToCompTypesFromRedis(
+	client *redis.Client,
+	typeToComp map[component.TypeID]component.ComponentMetadata,
+) (m map[archetype.ID][]component.ComponentMetadata, ok bool, err error) {
 	ctx := context.Background()
 	key := redisArchIDsToCompTypesKey()
 	bz, err := client.Get(ctx, key).Bytes()

--- a/cardinal/ecs/ecb/redis_test.go
+++ b/cardinal/ecs/ecb/redis_test.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/redis/go-redis/v9"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 )
 
 func TestComponentValuesAreDeletedFromRedis(t *testing.T) {
@@ -34,7 +34,7 @@ func TestComponentValuesAreDeletedFromRedis(t *testing.T) {
 
 	manager, err := NewManager(client)
 	assert.NilError(t, err)
-	err = manager.RegisterComponents([]metadata.ComponentMetadata{alphaComp, betaComp})
+	err = manager.RegisterComponents([]component.ComponentMetadata{alphaComp, betaComp})
 	assert.NilError(t, err)
 
 	id, err := manager.CreateEntity(alphaComp, betaComp)

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -10,7 +10,6 @@ import (
 	"pkg.world.dev/world-engine/assert"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/cardinal/types/archetype"
@@ -40,12 +39,12 @@ func UpdateEnergySystem(wCtx ecs.WorldContext) error {
 	errs = append(errs, err)
 	err = q.Each(
 		wCtx, func(ent entity.ID) bool {
-			energyPlanet, err := component.GetComponent[EnergyComponent](wCtx, ent)
+			energyPlanet, err := ecs.GetComponent[EnergyComponent](wCtx, ent)
 			if err != nil {
 				errs = append(errs, err)
 			}
 			energyPlanet.Amt += 10 // bs whatever
-			err = component.SetComponent[EnergyComponent](wCtx, ent, energyPlanet)
+			err = ecs.SetComponent[EnergyComponent](wCtx, ent, energyPlanet)
 			if err != nil {
 				errs = append(errs, err)
 			}
@@ -78,9 +77,9 @@ func TestECS(t *testing.T) {
 	world.RegisterSystem(UpdateEnergySystem)
 	assert.NilError(t, world.LoadGameState())
 	numEnergyOnly := 10
-	_, err := component.CreateMany(wCtx, numEnergyOnly, EnergyComponent{})
+	_, err := ecs.CreateMany(wCtx, numEnergyOnly, EnergyComponent{})
 	assert.NilError(t, err)
-	_, err = component.CreateMany(wCtx, numPlanets, EnergyComponent{}, OwnableComponent{})
+	_, err = ecs.CreateMany(wCtx, numPlanets, EnergyComponent{}, OwnableComponent{})
 	assert.NilError(t, err)
 
 	assert.NilError(t, world.Tick(context.Background()))
@@ -88,7 +87,7 @@ func TestECS(t *testing.T) {
 	assert.NilError(t, err)
 	err = query.Each(
 		wCtx, func(id entity.ID) bool {
-			energyPlanet, err := component.GetComponent[EnergyComponent](wCtx, id)
+			energyPlanet, err := ecs.GetComponent[EnergyComponent](wCtx, id)
 			assert.NilError(t, err)
 			assert.Equal(t, int64(10), energyPlanet.Amt)
 			return true
@@ -130,28 +129,28 @@ func TestVelocitySimulation(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	shipID, err := component.Create(wCtx, Pos{}, Vel{})
+	shipID, err := ecs.Create(wCtx, Pos{}, Vel{})
 	assert.NilError(t, err)
-	assert.NilError(t, component.SetComponent[Pos](wCtx, shipID, &Pos{1, 2}))
-	assert.NilError(t, component.SetComponent[Vel](wCtx, shipID, &Vel{3, 4}))
+	assert.NilError(t, ecs.SetComponent[Pos](wCtx, shipID, &Pos{1, 2}))
+	assert.NilError(t, ecs.SetComponent[Vel](wCtx, shipID, &Vel{3, 4}))
 	wantPos := Pos{4, 6}
 
 	velocityQuery, err := world.NewSearch(ecs.Contains(&Vel{}))
 	assert.NilError(t, err)
 	err = velocityQuery.Each(
 		wCtx, func(id entity.ID) bool {
-			vel, err := component.GetComponent[Vel](wCtx, id)
+			vel, err := ecs.GetComponent[Vel](wCtx, id)
 			assert.NilError(t, err)
-			pos, err := component.GetComponent[Pos](wCtx, id)
+			pos, err := ecs.GetComponent[Pos](wCtx, id)
 			assert.NilError(t, err)
 			newPos := Pos{pos.X + vel.DX, pos.Y + vel.DY}
-			assert.NilError(t, component.SetComponent[Pos](wCtx, id, &newPos))
+			assert.NilError(t, ecs.SetComponent[Pos](wCtx, id, &newPos))
 			return true
 		},
 	)
 	assert.NilError(t, err)
 
-	finalPos, err := component.GetComponent[Pos](wCtx, shipID)
+	finalPos, err := ecs.GetComponent[Pos](wCtx, shipID)
 	assert.NilError(t, err)
 	assert.Equal(t, wantPos, *finalPos)
 }
@@ -174,17 +173,17 @@ func TestCanSetDefaultValue(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	alphaEntity, err := component.Create(wCtx, wantOwner)
+	alphaEntity, err := ecs.Create(wCtx, wantOwner)
 	assert.NilError(t, err)
 
-	alphaOwner, err := component.GetComponent[Owner](wCtx, alphaEntity)
+	alphaOwner, err := ecs.GetComponent[Owner](wCtx, alphaEntity)
 	assert.NilError(t, err)
 	assert.Equal(t, *alphaOwner, wantOwner)
 
 	alphaOwner.MyName = "Bob"
-	assert.NilError(t, component.SetComponent[Owner](wCtx, alphaEntity, alphaOwner))
+	assert.NilError(t, ecs.SetComponent[Owner](wCtx, alphaEntity, alphaOwner))
 
-	newOwner, err := component.GetComponent[Owner](wCtx, alphaEntity)
+	newOwner, err := ecs.GetComponent[Owner](wCtx, alphaEntity)
 	assert.NilError(t, err)
 	assert.Equal(t, newOwner.MyName, "Bob")
 }
@@ -204,7 +203,7 @@ func TestCanRemoveEntity(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	entities, err := component.CreateMany(wCtx, 2, Tuple{})
+	entities, err := ecs.CreateMany(wCtx, 2, Tuple{})
 	assert.NilError(t, err)
 
 	// Make sure we find exactly 2 entries
@@ -214,7 +213,7 @@ func TestCanRemoveEntity(t *testing.T) {
 	assert.NilError(
 		t, q.Each(
 			wCtx, func(id entity.ID) bool {
-				_, err = component.GetComponent[Tuple](wCtx, id)
+				_, err = ecs.GetComponent[Tuple](wCtx, id)
 				assert.NilError(t, err)
 				count++
 				return true
@@ -231,7 +230,7 @@ func TestCanRemoveEntity(t *testing.T) {
 	assert.NilError(
 		t, q.Each(
 			wCtx, func(id entity.ID) bool {
-				_, err = component.GetComponent[Tuple](wCtx, id)
+				_, err = ecs.GetComponent[Tuple](wCtx, id)
 				assert.NilError(t, err)
 				count++
 				return true
@@ -251,7 +250,7 @@ func TestCanRemoveEntity(t *testing.T) {
 	assert.NilError(
 		t, q.Each(
 			wCtx, func(id entity.ID) bool {
-				_, err = component.GetComponent[Tuple](wCtx, id)
+				_, err = ecs.GetComponent[Tuple](wCtx, id)
 				assert.NilError(t, err)
 				count++
 				return true
@@ -280,7 +279,7 @@ func TestCanRemoveEntriesDuringCallToEach(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	_, err := component.CreateMany(wCtx, 10, CountComponent{})
+	_, err := ecs.CreateMany(wCtx, 10, CountComponent{})
 	assert.NilError(t, err)
 
 	// Pre-populate all the entities with their own IDs. This will help
@@ -291,7 +290,7 @@ func TestCanRemoveEntriesDuringCallToEach(t *testing.T) {
 	assert.NilError(
 		t, q.Each(
 			wCtx, func(id entity.ID) bool {
-				assert.NilError(t, component.SetComponent[CountComponent](wCtx, id, &CountComponent{int(id)}))
+				assert.NilError(t, ecs.SetComponent[CountComponent](wCtx, id, &CountComponent{int(id)}))
 				return true
 			},
 		),
@@ -317,7 +316,7 @@ func TestCanRemoveEntriesDuringCallToEach(t *testing.T) {
 	assert.NilError(
 		t, q.Each(
 			wCtx, func(id entity.ID) bool {
-				c, err := component.GetComponent[CountComponent](wCtx, id)
+				c, err := ecs.GetComponent[CountComponent](wCtx, id)
 				assert.NilError(t, err)
 				seen[c.Val]++
 				return true
@@ -338,9 +337,9 @@ func TestAddingAComponentThatAlreadyExistsIsError(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	ent, err := component.Create(wCtx, EnergyComponent{})
+	ent, err := ecs.Create(wCtx, EnergyComponent{})
 	assert.NilError(t, err)
-	assert.ErrorIs(t, component.AddComponentTo[EnergyComponent](wCtx, ent), storage.ErrComponentAlreadyOnEntity)
+	assert.ErrorIs(t, ecs.AddComponentTo[EnergyComponent](wCtx, ent), storage.ErrComponentAlreadyOnEntity)
 }
 
 type ReactorEnergy struct {
@@ -367,10 +366,10 @@ func TestRemovingAMissingComponentIsError(t *testing.T) {
 	assert.NilError(t, ecs.RegisterComponent[WeaponEnergy](world))
 	assert.NilError(t, world.LoadGameState())
 	wCtx := ecs.NewWorldContext(world)
-	ent, err := component.Create(wCtx, ReactorEnergy{})
+	ent, err := ecs.Create(wCtx, ReactorEnergy{})
 	assert.NilError(t, err)
 
-	assert.ErrorIs(t, component.RemoveComponentFrom[WeaponEnergy](wCtx, ent), storage.ErrComponentNotOnEntity)
+	assert.ErrorIs(t, ecs.RemoveComponentFrom[WeaponEnergy](wCtx, ent), storage.ErrComponentNotOnEntity)
 }
 
 type Foo struct{}
@@ -400,13 +399,13 @@ func TestVerifyAutomaticCreationOfArchetypesWorks(t *testing.T) {
 		return archID
 	}
 	wCtx := ecs.NewWorldContext(world)
-	entity, err := component.Create(wCtx, Foo{}, Bar{})
+	entity, err := ecs.Create(wCtx, Foo{}, Bar{})
 	assert.NilError(t, err)
 
 	archIDBefore := getArchIDForEntityID(entity)
 
 	// The entity should now be in a different archetype
-	assert.NilError(t, component.RemoveComponentFrom[Foo](wCtx, entity))
+	assert.NilError(t, ecs.RemoveComponentFrom[Foo](wCtx, entity))
 
 	archIDAfter := getArchIDForEntityID(entity)
 	assert.Check(t, archIDBefore != archIDAfter)
@@ -443,7 +442,7 @@ func TestEntriesCanChangeTheirArchetype(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	entIDs, err := component.CreateMany(wCtx, 3, Alpha{}, Beta{})
+	entIDs, err := ecs.CreateMany(wCtx, 3, Alpha{}, Beta{})
 	assert.NilError(t, err)
 
 	// count and countAgain are helpers that simplify the counting of how many
@@ -470,7 +469,7 @@ func TestEntriesCanChangeTheirArchetype(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, 0, count)
 
-	assert.NilError(t, component.RemoveComponentFrom[Alpha](wCtx, entIDs[0]))
+	assert.NilError(t, ecs.RemoveComponentFrom[Alpha](wCtx, entIDs[0]))
 
 	// alpha has been removed from entity[0], so only 2 entities should now have alpha
 	err = alphaQuery.Each(wCtx, countAgain())
@@ -478,7 +477,7 @@ func TestEntriesCanChangeTheirArchetype(t *testing.T) {
 	assert.Equal(t, 2, count)
 
 	// Add gamma to an entity. Now 1 entity should have gamma.
-	assert.NilError(t, component.AddComponentTo[Gamma](wCtx, entIDs[1]))
+	assert.NilError(t, ecs.AddComponentTo[Gamma](wCtx, entIDs[1]))
 	err = gammaQuery.Each(wCtx, countAgain())
 	assert.NilError(t, err)
 	assert.Equal(t, 1, count)
@@ -519,10 +518,10 @@ func TestCannotSetComponentThatDoesNotBelongToEntity(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	id, err := component.Create(wCtx, EnergyComponentAlpha{})
+	id, err := ecs.Create(wCtx, EnergyComponentAlpha{})
 	assert.NilError(t, err)
 
-	err = component.SetComponent[EnergyComponentBeta](wCtx, id, &EnergyComponentBeta{100, 200})
+	err = ecs.SetComponent[EnergyComponentBeta](wCtx, id, &EnergyComponentBeta{100, 200})
 	assert.Check(t, err != nil)
 }
 
@@ -546,11 +545,11 @@ func TestQueriesAndFiltersWorks(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	ab, err := component.Create(wCtx, A{}, B{})
+	ab, err := ecs.Create(wCtx, A{}, B{})
 	assert.NilError(t, err)
-	cd, err := component.Create(wCtx, C{}, D{})
+	cd, err := ecs.Create(wCtx, C{}, D{})
 	assert.NilError(t, err)
-	_, err = component.Create(wCtx, B{}, D{})
+	_, err = ecs.Create(wCtx, B{}, D{})
 	assert.NilError(t, err)
 
 	// Only one entity has the components a and b
@@ -609,10 +608,10 @@ func TestUpdateWithPointerType(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	id, err := component.Create(wCtx, HealthComponent{})
+	id, err := ecs.Create(wCtx, HealthComponent{})
 	assert.NilError(t, err)
 
-	err = component.UpdateComponent[HealthComponent](
+	err = ecs.UpdateComponent[HealthComponent](
 		wCtx, id, func(h *HealthComponent) *HealthComponent {
 			if h == nil {
 				h = &HealthComponent{}
@@ -623,7 +622,7 @@ func TestUpdateWithPointerType(t *testing.T) {
 	)
 	assert.NilError(t, err)
 
-	hp, err := component.GetComponent[HealthComponent](wCtx, id)
+	hp, err := ecs.GetComponent[HealthComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 100, hp.HP)
 }
@@ -641,19 +640,19 @@ func TestCanRemoveFirstEntity(t *testing.T) {
 	assert.NilError(t, ecs.RegisterComponent[ValueComponent1](world))
 
 	wCtx := ecs.NewWorldContext(world)
-	ids, err := component.CreateMany(wCtx, 3, ValueComponent1{})
+	ids, err := ecs.CreateMany(wCtx, 3, ValueComponent1{})
 	assert.NilError(t, err)
-	assert.NilError(t, component.SetComponent[ValueComponent1](wCtx, ids[0], &ValueComponent1{99}))
-	assert.NilError(t, component.SetComponent[ValueComponent1](wCtx, ids[1], &ValueComponent1{100}))
-	assert.NilError(t, component.SetComponent[ValueComponent1](wCtx, ids[2], &ValueComponent1{101}))
+	assert.NilError(t, ecs.SetComponent[ValueComponent1](wCtx, ids[0], &ValueComponent1{99}))
+	assert.NilError(t, ecs.SetComponent[ValueComponent1](wCtx, ids[1], &ValueComponent1{100}))
+	assert.NilError(t, ecs.SetComponent[ValueComponent1](wCtx, ids[2], &ValueComponent1{101}))
 
 	assert.NilError(t, world.Remove(ids[0]))
 
-	val, err := component.GetComponent[ValueComponent1](wCtx, ids[1])
+	val, err := ecs.GetComponent[ValueComponent1](wCtx, ids[1])
 	assert.NilError(t, err)
 	assert.Equal(t, 100, val.Val)
 
-	val, err = component.GetComponent[ValueComponent1](wCtx, ids[2])
+	val, err = ecs.GetComponent[ValueComponent1](wCtx, ids[2])
 	assert.NilError(t, err)
 	assert.Equal(t, 101, val.Val)
 }
@@ -679,19 +678,19 @@ func TestCanChangeArchetypeOfFirstEntity(t *testing.T) {
 	assert.NilError(t, ecs.RegisterComponent[OtherComponent](world))
 
 	wCtx := ecs.NewWorldContext(world)
-	ids, err := component.CreateMany(wCtx, 3, ValueComponent2{})
+	ids, err := ecs.CreateMany(wCtx, 3, ValueComponent2{})
 	assert.NilError(t, err)
-	assert.NilError(t, component.SetComponent[ValueComponent2](wCtx, ids[0], &ValueComponent2{99}))
-	assert.NilError(t, component.SetComponent[ValueComponent2](wCtx, ids[1], &ValueComponent2{100}))
-	assert.NilError(t, component.SetComponent[ValueComponent2](wCtx, ids[2], &ValueComponent2{101}))
+	assert.NilError(t, ecs.SetComponent[ValueComponent2](wCtx, ids[0], &ValueComponent2{99}))
+	assert.NilError(t, ecs.SetComponent[ValueComponent2](wCtx, ids[1], &ValueComponent2{100}))
+	assert.NilError(t, ecs.SetComponent[ValueComponent2](wCtx, ids[2], &ValueComponent2{101}))
 
-	assert.NilError(t, component.AddComponentTo[OtherComponent](wCtx, ids[0]))
+	assert.NilError(t, ecs.AddComponentTo[OtherComponent](wCtx, ids[0]))
 
-	val, err := component.GetComponent[ValueComponent2](wCtx, ids[1])
+	val, err := ecs.GetComponent[ValueComponent2](wCtx, ids[1])
 	assert.NilError(t, err)
 	assert.Equal(t, 100, val.Val)
 
-	val, err = component.GetComponent[ValueComponent2](wCtx, ids[2])
+	val, err = ecs.GetComponent[ValueComponent2](wCtx, ids[2])
 	assert.NilError(t, err)
 	assert.Equal(t, 101, val.Val)
 }
@@ -702,12 +701,12 @@ func TestEntityCreationAndSetting(t *testing.T) {
 	assert.NilError(t, ecs.RegisterComponent[OtherComponent](world))
 
 	wCtx := ecs.NewWorldContext(world)
-	ids, err := component.CreateMany(wCtx, 300, ValueComponent2{999}, OtherComponent{999})
+	ids, err := ecs.CreateMany(wCtx, 300, ValueComponent2{999}, OtherComponent{999})
 	assert.NilError(t, err)
 	for _, id := range ids {
-		x, err := component.GetComponent[ValueComponent2](wCtx, id)
+		x, err := ecs.GetComponent[ValueComponent2](wCtx, id)
 		assert.NilError(t, err)
-		y, err := component.GetComponent[OtherComponent](wCtx, id)
+		y, err := ecs.GetComponent[OtherComponent](wCtx, id)
 		assert.NilError(t, err)
 		assert.Equal(t, x.Val, 999)
 		assert.Equal(t, y.Val, 999)

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -10,9 +10,9 @@ import (
 	"pkg.world.dev/world-engine/assert"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/cardinal/types/archetype"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
@@ -61,8 +61,8 @@ func UpdateEnergySystem(wCtx ecs.WorldContext) error {
 }
 
 var (
-	Energy  = metadata.NewComponentMetadata[EnergyComponent]()
-	Ownable = metadata.NewComponentMetadata[OwnableComponent]()
+	Energy  = component.NewComponentMetadata[EnergyComponent]()
+	Ownable = component.NewComponentMetadata[OwnableComponent]()
 )
 
 func TestECS(t *testing.T) {

--- a/cardinal/ecs/entity.go
+++ b/cardinal/ecs/entity.go
@@ -4,11 +4,11 @@ import (
 	"strconv"
 
 	"github.com/rotisserie/eris"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
-func Create(wCtx WorldContext, components ...metadata.Component) (entity.ID, error) {
+func Create(wCtx WorldContext, components ...component.Component) (entity.ID, error) {
 	entities, err := CreateMany(wCtx, 1, components...)
 	if err != nil {
 		return 0, err
@@ -16,12 +16,12 @@ func Create(wCtx WorldContext, components ...metadata.Component) (entity.ID, err
 	return entities[0], nil
 }
 
-func CreateMany(wCtx WorldContext, num int, components ...metadata.Component) ([]entity.ID, error) {
+func CreateMany(wCtx WorldContext, num int, components ...component.Component) ([]entity.ID, error) {
 	if wCtx.IsReadOnly() {
 		return nil, eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
 	world := wCtx.GetWorld()
-	acc := make([]metadata.ComponentMetadata, 0, len(components))
+	acc := make([]component.ComponentMetadata, 0, len(components))
 	for _, comp := range components {
 		c, err := world.GetComponentByName(comp.Name())
 		if err != nil {
@@ -35,7 +35,7 @@ func CreateMany(wCtx WorldContext, num int, components ...metadata.Component) ([
 	}
 	for _, id := range entityIds {
 		for _, comp := range components {
-			var c metadata.ComponentMetadata
+			var c component.ComponentMetadata
 			c, err = world.GetComponentByName(comp.Name())
 			if err != nil {
 				return nil, eris.Wrap(err, "must register component before creating an entity")
@@ -51,7 +51,7 @@ func CreateMany(wCtx WorldContext, num int, components ...metadata.Component) ([
 }
 
 // RemoveComponentFrom removes a component from an entity.
-func RemoveComponentFrom[T metadata.Component](wCtx WorldContext, id entity.ID) error {
+func RemoveComponentFrom[T component.Component](wCtx WorldContext, id entity.ID) error {
 	if wCtx.IsReadOnly() {
 		return eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
@@ -65,7 +65,7 @@ func RemoveComponentFrom[T metadata.Component](wCtx WorldContext, id entity.ID) 
 	return w.StoreManager().RemoveComponentFromEntity(c, id)
 }
 
-func AddComponentTo[T metadata.Component](wCtx WorldContext, id entity.ID) error {
+func AddComponentTo[T component.Component](wCtx WorldContext, id entity.ID) error {
 	if wCtx.IsReadOnly() {
 		return eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
@@ -80,7 +80,7 @@ func AddComponentTo[T metadata.Component](wCtx WorldContext, id entity.ID) error
 }
 
 // GetComponent returns component data from the entity.
-func GetComponent[T metadata.Component](wCtx WorldContext, id entity.ID) (comp *T, err error) {
+func GetComponent[T component.Component](wCtx WorldContext, id entity.ID) (comp *T, err error) {
 	var t T
 	name := t.Name()
 	c, err := wCtx.GetWorld().GetComponentByName(name)
@@ -105,7 +105,7 @@ func GetComponent[T metadata.Component](wCtx WorldContext, id entity.ID) (comp *
 }
 
 // SetComponent sets component data to the entity.
-func SetComponent[T metadata.Component](wCtx WorldContext, id entity.ID, component *T) error {
+func SetComponent[T component.Component](wCtx WorldContext, id entity.ID, component *T) error {
 	if wCtx.IsReadOnly() {
 		return eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
@@ -127,7 +127,7 @@ func SetComponent[T metadata.Component](wCtx WorldContext, id entity.ID, compone
 	return nil
 }
 
-func UpdateComponent[T metadata.Component](wCtx WorldContext, id entity.ID, fn func(*T) *T) error {
+func UpdateComponent[T component.Component](wCtx WorldContext, id entity.ID, fn func(*T) *T) error {
 	if wCtx.IsReadOnly() {
 		return eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}

--- a/cardinal/ecs/entity.go
+++ b/cardinal/ecs/entity.go
@@ -1,15 +1,14 @@
-package component
+package ecs
 
 import (
 	"strconv"
 
 	"github.com/rotisserie/eris"
-	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
-func Create(wCtx ecs.WorldContext, components ...metadata.Component) (entity.ID, error) {
+func Create(wCtx WorldContext, components ...metadata.Component) (entity.ID, error) {
 	entities, err := CreateMany(wCtx, 1, components...)
 	if err != nil {
 		return 0, err
@@ -17,9 +16,9 @@ func Create(wCtx ecs.WorldContext, components ...metadata.Component) (entity.ID,
 	return entities[0], nil
 }
 
-func CreateMany(wCtx ecs.WorldContext, num int, components ...metadata.Component) ([]entity.ID, error) {
+func CreateMany(wCtx WorldContext, num int, components ...metadata.Component) ([]entity.ID, error) {
 	if wCtx.IsReadOnly() {
-		return nil, eris.Wrap(ecs.ErrCannotModifyStateWithReadOnlyContext, "")
+		return nil, eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
 	world := wCtx.GetWorld()
 	acc := make([]metadata.ComponentMetadata, 0, len(components))
@@ -52,9 +51,9 @@ func CreateMany(wCtx ecs.WorldContext, num int, components ...metadata.Component
 }
 
 // RemoveComponentFrom removes a component from an entity.
-func RemoveComponentFrom[T metadata.Component](wCtx ecs.WorldContext, id entity.ID) error {
+func RemoveComponentFrom[T metadata.Component](wCtx WorldContext, id entity.ID) error {
 	if wCtx.IsReadOnly() {
-		return eris.Wrap(ecs.ErrCannotModifyStateWithReadOnlyContext, "")
+		return eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
 	w := wCtx.GetWorld()
 	var t T
@@ -66,9 +65,9 @@ func RemoveComponentFrom[T metadata.Component](wCtx ecs.WorldContext, id entity.
 	return w.StoreManager().RemoveComponentFromEntity(c, id)
 }
 
-func AddComponentTo[T metadata.Component](wCtx ecs.WorldContext, id entity.ID) error {
+func AddComponentTo[T metadata.Component](wCtx WorldContext, id entity.ID) error {
 	if wCtx.IsReadOnly() {
-		return eris.Wrap(ecs.ErrCannotModifyStateWithReadOnlyContext, "")
+		return eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
 	w := wCtx.GetWorld()
 	var t T
@@ -81,7 +80,7 @@ func AddComponentTo[T metadata.Component](wCtx ecs.WorldContext, id entity.ID) e
 }
 
 // GetComponent returns component data from the entity.
-func GetComponent[T metadata.Component](wCtx ecs.WorldContext, id entity.ID) (comp *T, err error) {
+func GetComponent[T metadata.Component](wCtx WorldContext, id entity.ID) (comp *T, err error) {
 	var t T
 	name := t.Name()
 	c, err := wCtx.GetWorld().GetComponentByName(name)
@@ -106,9 +105,9 @@ func GetComponent[T metadata.Component](wCtx ecs.WorldContext, id entity.ID) (co
 }
 
 // SetComponent sets component data to the entity.
-func SetComponent[T metadata.Component](wCtx ecs.WorldContext, id entity.ID, component *T) error {
+func SetComponent[T metadata.Component](wCtx WorldContext, id entity.ID, component *T) error {
 	if wCtx.IsReadOnly() {
-		return eris.Wrap(ecs.ErrCannotModifyStateWithReadOnlyContext, "")
+		return eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
 	var t T
 	name := t.Name()
@@ -128,9 +127,9 @@ func SetComponent[T metadata.Component](wCtx ecs.WorldContext, id entity.ID, com
 	return nil
 }
 
-func UpdateComponent[T metadata.Component](wCtx ecs.WorldContext, id entity.ID, fn func(*T) *T) error {
+func UpdateComponent[T metadata.Component](wCtx WorldContext, id entity.ID, fn func(*T) *T) error {
 	if wCtx.IsReadOnly() {
-		return eris.Wrap(ecs.ErrCannotModifyStateWithReadOnlyContext, "")
+		return eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
 	val, err := GetComponent[T](wCtx, id)
 	if err != nil {

--- a/cardinal/ecs/filter.go
+++ b/cardinal/ecs/filter.go
@@ -1,8 +1,8 @@
 package ecs
 
 import (
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 )
 
 type Filterable interface {
@@ -25,11 +25,11 @@ type not struct {
 }
 
 type contains struct {
-	components []metadata.Component
+	components []component.Component
 }
 
 type exact struct {
-	components []metadata.Component
+	components []component.Component
 }
 
 func All() Filterable {
@@ -48,11 +48,11 @@ func Not(filter Filterable) Filterable {
 	return &not{filter: filter}
 }
 
-func Contains(components ...metadata.Component) Filterable {
+func Contains(components ...component.Component) Filterable {
 	return &contains{components: components}
 }
 
-func Exact(components ...metadata.Component) Filterable {
+func Exact(components ...component.Component) Filterable {
 	return &exact{components: components}
 }
 
@@ -89,7 +89,7 @@ func (s not) ConvertToComponentFilter(world *World) (filter.ComponentFilter, err
 }
 
 func (s contains) ConvertToComponentFilter(world *World) (filter.ComponentFilter, error) {
-	acc := make([]metadata.ComponentMetadata, 0, len(s.components))
+	acc := make([]component.ComponentMetadata, 0, len(s.components))
 	for _, internalComponent := range s.components {
 		c, err := world.GetComponentByName(internalComponent.Name())
 		if err != nil {
@@ -101,7 +101,7 @@ func (s contains) ConvertToComponentFilter(world *World) (filter.ComponentFilter
 }
 
 func (s exact) ConvertToComponentFilter(world *World) (filter.ComponentFilter, error) {
-	acc := make([]metadata.ComponentMetadata, 0, len(s.components))
+	acc := make([]component.ComponentMetadata, 0, len(s.components))
 	for _, internalComponent := range s.components {
 		c, err := world.GetComponentByName(internalComponent.Name())
 		if err != nil {

--- a/cardinal/ecs/filter/all.go
+++ b/cardinal/ecs/filter/all.go
@@ -1,6 +1,6 @@
 package filter
 
-import "pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+import "pkg.world.dev/world-engine/cardinal/types/component"
 
 type all struct {
 }
@@ -9,6 +9,6 @@ func All() ComponentFilter {
 	return &all{}
 }
 
-func (f *all) MatchesComponents(_ []metadata.ComponentMetadata) bool {
+func (f *all) MatchesComponents(_ []component.ComponentMetadata) bool {
 	return true
 }

--- a/cardinal/ecs/filter/and.go
+++ b/cardinal/ecs/filter/and.go
@@ -1,6 +1,6 @@
 package filter
 
-import "pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+import "pkg.world.dev/world-engine/cardinal/types/component"
 
 type and struct {
 	filters []ComponentFilter
@@ -10,7 +10,7 @@ func And(filters ...ComponentFilter) ComponentFilter {
 	return &and{filters: filters}
 }
 
-func (f *and) MatchesComponents(components []metadata.ComponentMetadata) bool {
+func (f *and) MatchesComponents(components []component.ComponentMetadata) bool {
 	for _, filter := range f.filters {
 		if !filter.MatchesComponents(components) {
 			return false

--- a/cardinal/ecs/filter/contains.go
+++ b/cardinal/ecs/filter/contains.go
@@ -1,17 +1,17 @@
 package filter
 
-import "pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+import "pkg.world.dev/world-engine/cardinal/types/component"
 
 type contains struct {
-	components []metadata.ComponentMetadata
+	components []component.ComponentMetadata
 }
 
 // Contains matches archetypes that contain all the components specified.
-func Contains(components ...metadata.ComponentMetadata) ComponentFilter {
+func Contains(components ...component.ComponentMetadata) ComponentFilter {
 	return &contains{components: components}
 }
 
-func (f *contains) MatchesComponents(components []metadata.ComponentMetadata) bool {
+func (f *contains) MatchesComponents(components []component.ComponentMetadata) bool {
 	for _, componentType := range f.components {
 		if !MatchComponentMetaData(components, componentType) {
 			return false

--- a/cardinal/ecs/filter/exact.go
+++ b/cardinal/ecs/filter/exact.go
@@ -1,19 +1,19 @@
 package filter
 
-import "pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+import "pkg.world.dev/world-engine/cardinal/types/component"
 
 type exact struct {
-	components []metadata.ComponentMetadata
+	components []component.ComponentMetadata
 }
 
 // Exact matches archetypes that contain exactly the same components specified.
-func Exact(components ...metadata.ComponentMetadata) ComponentFilter {
+func Exact(components ...component.ComponentMetadata) ComponentFilter {
 	return exact{
 		components: components,
 	}
 }
 
-func (f exact) MatchesComponents(components []metadata.ComponentMetadata) bool {
+func (f exact) MatchesComponents(components []component.ComponentMetadata) bool {
 	if len(components) != len(f.components) {
 		return false
 	}

--- a/cardinal/ecs/filter/filter.go
+++ b/cardinal/ecs/filter/filter.go
@@ -1,9 +1,9 @@
 package filter
 
-import "pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+import "pkg.world.dev/world-engine/cardinal/types/component"
 
 // ComponentFilter is a filter that filters entities based on their components.
 type ComponentFilter interface {
 	// MatchesComponents returns true if the entity matches the filter.
-	MatchesComponents(components []metadata.ComponentMetadata) bool
+	MatchesComponents(components []component.ComponentMetadata) bool
 }

--- a/cardinal/ecs/filter/filter_test.go
+++ b/cardinal/ecs/filter/filter_test.go
@@ -10,7 +10,6 @@ import (
 	"pkg.world.dev/world-engine/assert"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/cql"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
@@ -34,10 +33,10 @@ func TestGetEverythingFilter(t *testing.T) {
 
 	subsetCount := 50
 	wCtx := ecs.NewWorldContext(world)
-	_, err := component.CreateMany(wCtx, subsetCount, Alpha{}, Beta{})
+	_, err := ecs.CreateMany(wCtx, subsetCount, Alpha{}, Beta{})
 	assert.NilError(t, err)
 	// Make some entities that have all 3 component.
-	_, err = component.CreateMany(wCtx, 20, Alpha{}, Beta{}, Gamma{})
+	_, err = ecs.CreateMany(wCtx, 20, Alpha{}, Beta{}, Gamma{})
 	assert.NilError(t, err)
 
 	count := 0
@@ -66,10 +65,10 @@ func TestCanFilterByArchetype(t *testing.T) {
 
 	subsetCount := 50
 	wCtx := ecs.NewWorldContext(world)
-	_, err := component.CreateMany(wCtx, subsetCount, Alpha{}, Beta{})
+	_, err := ecs.CreateMany(wCtx, subsetCount, Alpha{}, Beta{})
 	assert.NilError(t, err)
 	// Make some entities that have all 3 component.
-	_, err = component.CreateMany(wCtx, 20, Alpha{}, Beta{}, Gamma{})
+	_, err = ecs.CreateMany(wCtx, 20, Alpha{}, Beta{}, Gamma{})
 	assert.NilError(t, err)
 
 	count := 0
@@ -81,7 +80,7 @@ func TestCanFilterByArchetype(t *testing.T) {
 		wCtx, func(id entity.ID) bool {
 			count++
 			// Make sure the gamma component is not on this entity
-			_, err = component.GetComponent[gammaComponent](wCtx, id)
+			_, err = ecs.GetComponent[gammaComponent](wCtx, id)
 			assert.ErrorIs(t, err, storage.ErrComponentNotOnEntity)
 			return true
 		},
@@ -109,10 +108,10 @@ func TestExactVsContains(t *testing.T) {
 
 	alphaCount := 75
 	wCtx := ecs.NewWorldContext(world)
-	_, err := component.CreateMany(wCtx, alphaCount, Alpha{})
+	_, err := ecs.CreateMany(wCtx, alphaCount, Alpha{})
 	assert.NilError(t, err)
 	bothCount := 100
-	_, err = component.CreateMany(wCtx, bothCount, Alpha{}, Beta{})
+	_, err = ecs.CreateMany(wCtx, bothCount, Alpha{}, Beta{})
 	assert.NilError(t, err)
 	count := 0
 	// Contains(alpha) should return all entities
@@ -246,11 +245,11 @@ func TestCanGetArchetypeFromEntity(t *testing.T) {
 
 	wantCount := 50
 	wCtx := ecs.NewWorldContext(world)
-	ids, err := component.CreateMany(wCtx, wantCount, Alpha{}, Beta{})
+	ids, err := ecs.CreateMany(wCtx, wantCount, Alpha{}, Beta{})
 	assert.NilError(t, err)
 	// Make some extra entities that will be ignored. Our query later
 	// should NOT contain these entities
-	_, err = component.CreateMany(wCtx, 20, Alpha{})
+	_, err = ecs.CreateMany(wCtx, 20, Alpha{})
 	assert.NilError(t, err)
 	id := ids[0]
 	comps, err := world.StoreManager().GetComponentTypesForEntity(id)
@@ -296,7 +295,7 @@ func BenchmarkEntityCreation(b *testing.B) {
 		assert.NilError(b, ecs.RegisterComponent[Alpha](world))
 		assert.NilError(b, world.LoadGameState())
 		wCtx := ecs.NewWorldContext(world)
-		_, err := component.CreateMany(wCtx, 100000, Alpha{})
+		_, err := ecs.CreateMany(wCtx, 100000, Alpha{})
 		assert.NilError(b, err)
 	}
 }
@@ -324,9 +323,9 @@ func helperArchetypeFilter(b *testing.B, relevantCount, ignoreCount int) {
 	assert.NilError(b, ecs.RegisterComponent[Beta](world))
 	assert.NilError(b, world.LoadGameState())
 	wCtx := ecs.NewWorldContext(world)
-	_, err := component.CreateMany(wCtx, relevantCount, Alpha{}, Beta{})
+	_, err := ecs.CreateMany(wCtx, relevantCount, Alpha{}, Beta{})
 	assert.NilError(b, err)
-	_, err = component.CreateMany(wCtx, ignoreCount, Alpha{})
+	_, err = ecs.CreateMany(wCtx, ignoreCount, Alpha{})
 	assert.NilError(b, err)
 	b.StartTimer()
 	for i := 0; i < b.N; i++ {

--- a/cardinal/ecs/filter/helper.go
+++ b/cardinal/ecs/filter/helper.go
@@ -1,12 +1,12 @@
 package filter
 
-import "pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+import "pkg.world.dev/world-engine/cardinal/types/component"
 
 // MatchComponentMetaData returns true if the given slice of components contains the given component. Components are the
 // same if they have the same ID.
 func MatchComponentMetaData(
-	components []metadata.ComponentMetadata,
-	cType metadata.ComponentMetadata,
+	components []component.ComponentMetadata,
+	cType component.ComponentMetadata,
 ) bool {
 	for _, c := range components {
 		if cType.ID() == c.ID() {

--- a/cardinal/ecs/filter/not.go
+++ b/cardinal/ecs/filter/not.go
@@ -1,6 +1,6 @@
 package filter
 
-import "pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+import "pkg.world.dev/world-engine/cardinal/types/component"
 
 func Not(filter ComponentFilter) ComponentFilter {
 	return &not{filter: filter}
@@ -10,6 +10,6 @@ type not struct {
 	filter ComponentFilter
 }
 
-func (f *not) MatchesComponents(components []metadata.ComponentMetadata) bool {
+func (f *not) MatchesComponents(components []component.ComponentMetadata) bool {
 	return !f.filter.MatchesComponents(components)
 }

--- a/cardinal/ecs/filter/or.go
+++ b/cardinal/ecs/filter/or.go
@@ -1,6 +1,6 @@
 package filter
 
-import "pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+import "pkg.world.dev/world-engine/cardinal/types/component"
 
 type or struct {
 	filters []ComponentFilter
@@ -10,7 +10,7 @@ func Or(filters ...ComponentFilter) ComponentFilter {
 	return &or{filters: filters}
 }
 
-func (f *or) MatchesComponents(components []metadata.ComponentMetadata) bool {
+func (f *or) MatchesComponents(components []component.ComponentMetadata) bool {
 	for _, filter := range f.filters {
 		if filter.MatchesComponents(components) {
 			return true

--- a/cardinal/ecs/log/log.go
+++ b/cardinal/ecs/log/log.go
@@ -2,13 +2,13 @@ package log
 
 import (
 	"github.com/rs/zerolog"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/types/archetype"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
 type Loggable interface {
-	GetComponents() []metadata.ComponentMetadata
+	GetComponents() []component.ComponentMetadata
 	GetSystemNames() []string
 }
 
@@ -17,7 +17,7 @@ type Logger struct {
 }
 
 func (*Logger) loadComponentIntoArrayLogger(
-	component metadata.ComponentMetadata,
+	component component.ComponentMetadata,
 	arrayLogger *zerolog.Array,
 ) *zerolog.Array {
 	dictLogger := zerolog.Dict()
@@ -50,7 +50,7 @@ func (l *Logger) loadSystemIntoEvent(zeroLoggerEvent *zerolog.Event, target Logg
 
 func (l *Logger) loadEntityIntoEvent(
 	zeroLoggerEvent *zerolog.Event, entityID entity.ID, archID archetype.ID,
-	components []metadata.ComponentMetadata,
+	components []component.ComponentMetadata,
 ) *zerolog.Event {
 	arrayLogger := zerolog.Arr()
 	for _, _component := range components {
@@ -78,7 +78,7 @@ func (l *Logger) LogSystem(target Loggable, level zerolog.Level) {
 // LogEntity logs entity info given an entityID.
 func (l *Logger) LogEntity(
 	level zerolog.Level, entityID entity.ID, archID archetype.ID,
-	components []metadata.ComponentMetadata,
+	components []component.ComponentMetadata,
 ) {
 	zeroLoggerEvent := l.WithLevel(level)
 	l.loadEntityIntoEvent(zeroLoggerEvent, entityID, archID, components).Send()

--- a/cardinal/ecs/log/log_test.go
+++ b/cardinal/ecs/log/log_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/log"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
@@ -44,12 +43,12 @@ func testSystem(wCtx ecs.WorldContext) error {
 	}
 	err = q.Each(
 		wCtx, func(entityId entity.ID) bool {
-			energyPlanet, err := component.GetComponent[EnergyComp](wCtx, entityId)
+			energyPlanet, err := ecs.GetComponent[EnergyComp](wCtx, entityId)
 			if err != nil {
 				return false
 			}
 			energyPlanet.value += 10
-			err = component.SetComponent[EnergyComp](wCtx, entityId, energyPlanet)
+			err = ecs.SetComponent[EnergyComp](wCtx, entityId, energyPlanet)
 			return err == nil
 		},
 	)
@@ -129,7 +128,7 @@ func TestWorldLogger(t *testing.T) {
 	w.RegisterSystem(testSystemWarningTrigger)
 	err = w.LoadGameState()
 	assert.NilError(t, err)
-	entityID, err := component.Create(wCtx, EnergyComp{})
+	entityID, err := ecs.Create(wCtx, EnergyComp{})
 	assert.NilError(t, err)
 	logStrings := strings.Split(buf.String(), "\n")[:2]
 	require.JSONEq(
@@ -249,7 +248,7 @@ func TestWorldLogger(t *testing.T) {
 
 	// testing log output for the creation of two entities.
 	buf.Reset()
-	_, err = component.CreateMany(wCtx, 2, EnergyComp{})
+	_, err = ecs.CreateMany(wCtx, 2, EnergyComp{})
 	assert.NilError(t, err)
 	entityCreationStrings := strings.Split(buf.String(), "\n")[:2]
 	require.JSONEq(

--- a/cardinal/ecs/log/log_test.go
+++ b/cardinal/ecs/log/log_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/rs/zerolog"
 	"github.com/stretchr/testify/require"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/log"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
@@ -123,7 +123,7 @@ func TestWorldLogger(t *testing.T) {
 	buf.Reset()
 	energy, err := w.GetComponentByName(EnergyComp{}.Name())
 	assert.NilError(t, err)
-	components := []metadata.ComponentMetadata{energy}
+	components := []component.ComponentMetadata{energy}
 	wCtx := ecs.NewWorldContext(w)
 	w.RegisterSystem(testSystemWarningTrigger)
 	err = w.LoadGameState()

--- a/cardinal/ecs/message/message_test.go
+++ b/cardinal/ecs/message/message_test.go
@@ -11,7 +11,6 @@ import (
 	"pkg.world.dev/world-engine/assert"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/message"
 	"pkg.world.dev/world-engine/cardinal/testutils"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
@@ -66,7 +65,7 @@ func TestCanQueueTransactions(t *testing.T) {
 			modifyScore := modifyScoreMsg.In(wCtx)
 			for _, txData := range modifyScore {
 				ms := txData.Msg
-				err := component.UpdateComponent[ScoreComponent](
+				err := ecs.UpdateComponent[ScoreComponent](
 					wCtx, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
 						s.Score += ms.Amount
 						return s
@@ -80,15 +79,15 @@ func TestCanQueueTransactions(t *testing.T) {
 		},
 	)
 	assert.NilError(t, world.LoadGameState())
-	id, err := component.Create(wCtx, ScoreComponent{})
+	id, err := ecs.Create(wCtx, ScoreComponent{})
 	assert.NilError(t, err)
 
 	modifyScoreMsg.AddToQueue(world, &ModifyScoreMsg{id, 100})
 
-	assert.NilError(t, component.SetComponent[ScoreComponent](wCtx, id, &ScoreComponent{}))
+	assert.NilError(t, ecs.SetComponent[ScoreComponent](wCtx, id, &ScoreComponent{}))
 
 	// Verify the score is 0
-	s, err := component.GetComponent[ScoreComponent](wCtx, id)
+	s, err := ecs.GetComponent[ScoreComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 0, s.Score)
 
@@ -96,7 +95,7 @@ func TestCanQueueTransactions(t *testing.T) {
 	assert.NilError(t, world.Tick(context.Background()))
 
 	// Verify the score was updated
-	s, err = component.GetComponent[ScoreComponent](wCtx, id)
+	s, err = ecs.GetComponent[ScoreComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 100, s.Score)
 
@@ -104,7 +103,7 @@ func TestCanQueueTransactions(t *testing.T) {
 	assert.NilError(t, world.Tick(context.Background()))
 
 	// Verify the score hasn't changed
-	s, err = component.GetComponent[ScoreComponent](wCtx, id)
+	s, err = ecs.GetComponent[ScoreComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 100, s.Score)
 }
@@ -129,7 +128,7 @@ func TestSystemsAreExecutedDuringGameTick(t *testing.T) {
 			search, err := wCtx.NewSearch(ecs.Exact(CounterComponent{}))
 			assert.NilError(t, err)
 			id := search.MustFirst(wCtx)
-			return component.UpdateComponent[CounterComponent](
+			return ecs.UpdateComponent[CounterComponent](
 				wCtx, id, func(c *CounterComponent) *CounterComponent {
 					c.Count++
 					return c
@@ -138,14 +137,14 @@ func TestSystemsAreExecutedDuringGameTick(t *testing.T) {
 		},
 	)
 	assert.NilError(t, world.LoadGameState())
-	id, err := component.Create(wCtx, CounterComponent{})
+	id, err := ecs.Create(wCtx, CounterComponent{})
 	assert.NilError(t, err)
 
 	for i := 0; i < 10; i++ {
 		assert.NilError(t, world.Tick(context.Background()))
 	}
 
-	c, err := component.GetComponent[CounterComponent](wCtx, id)
+	c, err := ecs.GetComponent[CounterComponent](wCtx, id)
 	assert.NilError(t, err)
 	assert.Equal(t, 10, c.Count)
 }
@@ -162,7 +161,7 @@ func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 			modifyScores := modifyScoreMsg.In(wCtx)
 			for _, msData := range modifyScores {
 				ms := msData.Msg
-				err := component.UpdateComponent[ScoreComponent](
+				err := ecs.UpdateComponent[ScoreComponent](
 					wCtx, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
 						s.Score += ms.Amount
 						return s
@@ -176,7 +175,7 @@ func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 
 	wCtx := ecs.NewWorldContext(world)
-	ids, err := component.CreateMany(wCtx, 100, ScoreComponent{})
+	ids, err := ecs.CreateMany(wCtx, 100, ScoreComponent{})
 	assert.NilError(t, err)
 	// Entities at index 5, 10 and 50 will be updated with some values
 	modifyScoreMsg.AddToQueue(
@@ -210,7 +209,7 @@ func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 		case 50:
 			wantScore = 150
 		}
-		s, err := component.GetComponent[ScoreComponent](wCtx, id)
+		s, err := ecs.GetComponent[ScoreComponent](wCtx, id)
 		assert.NilError(t, err)
 		assert.Equal(t, wantScore, s.Score)
 	}

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -5,7 +5,7 @@ import (
 	"strconv"
 
 	"github.com/rotisserie/eris"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
@@ -210,7 +210,7 @@ func (w *World) GetSignerForPersonaTag(personaTag string, tick uint64) (addr str
 // plugins.
 // Get returns component data from the entity.
 // GetComponent returns component data from the entity.
-func getComponent[T metadata.Component](wCtx WorldContext, id entity.ID) (comp *T, err error) {
+func getComponent[T component.Component](wCtx WorldContext, id entity.ID) (comp *T, err error) {
 	var t T
 	name := t.Name()
 	c, err := wCtx.GetWorld().GetComponentByName(name)
@@ -239,7 +239,7 @@ func getComponent[T metadata.Component](wCtx WorldContext, id entity.ID) (comp *
 // TODO private component function used to temporarily remove circular dependency until we replace components.
 // TODO this function is intended only for use with persona.go and is to be removed with persona when we replace with
 // plugins.
-func setComponent[T metadata.Component](wCtx WorldContext, id entity.ID, component *T) error {
+func setComponent[T component.Component](wCtx WorldContext, id entity.ID, component *T) error {
 	if wCtx.IsReadOnly() {
 		return eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
@@ -265,7 +265,7 @@ func setComponent[T metadata.Component](wCtx WorldContext, id entity.ID, compone
 // TODO this function is intended only for use with persona.go and is to be removed with persona when we replace with
 // plugins.
 // https://linear.app/arguslabs/issue/WORLD-423/ecs-plugin-feature
-func updateComponent[T metadata.Component](wCtx WorldContext, id entity.ID, fn func(*T) *T) error {
+func updateComponent[T component.Component](wCtx WorldContext, id entity.ID, fn func(*T) *T) error {
 	if wCtx.IsReadOnly() {
 		return eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
@@ -281,12 +281,12 @@ func updateComponent[T metadata.Component](wCtx WorldContext, id entity.ID, fn f
 // TODO this function is intended only for use with persona.go and is to be removed with persona when we replace with
 // plugins.
 // https://linear.app/arguslabs/issue/WORLD-423/ecs-plugin-feature
-func createMany(wCtx WorldContext, num int, components ...metadata.Component) ([]entity.ID, error) {
+func createMany(wCtx WorldContext, num int, components ...component.Component) ([]entity.ID, error) {
 	if wCtx.IsReadOnly() {
 		return nil, eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
 	world := wCtx.GetWorld()
-	acc := make([]metadata.ComponentMetadata, 0, len(components))
+	acc := make([]component.ComponentMetadata, 0, len(components))
 	for _, comp := range components {
 		c, err := world.GetComponentByName(comp.Name())
 		if err != nil {
@@ -317,7 +317,7 @@ func createMany(wCtx WorldContext, num int, components ...metadata.Component) ([
 // TODO this function is intended only for use with persona.go and is to be removed with persona when we replace with
 // plugins.
 // https://linear.app/arguslabs/issue/WORLD-423/ecs-plugin-feature
-func create(wCtx WorldContext, components ...metadata.Component) (entity.ID, error) {
+func create(wCtx WorldContext, components ...component.Component) (entity.ID, error) {
 	entities, err := createMany(wCtx, 1, components...)
 	if err != nil {
 		return 0, err

--- a/cardinal/ecs/persona_test.go
+++ b/cardinal/ecs/persona_test.go
@@ -7,7 +7,6 @@ import (
 
 	"pkg.world.dev/world-engine/cardinal/testutils"
 
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 	"pkg.world.dev/world-engine/sign"
 
@@ -48,7 +47,7 @@ func TestCreatePersonaTransactionAutomaticallyCreated(t *testing.T) {
 	err = q.Each(
 		wCtx, func(id entity.ID) bool {
 			count++
-			sc, err := component.GetComponent[ecs.SignerComponent](wCtx, id)
+			sc, err := ecs.GetComponent[ecs.SignerComponent](wCtx, id)
 			assert.NilError(t, err)
 			assert.Equal(t, sc.PersonaTag, wantTag)
 			assert.Equal(t, sc.SignerAddress, wantAddress)
@@ -165,7 +164,7 @@ func TestCanAuthorizeAddress(t *testing.T) {
 	err = q.Each(
 		wCtx, func(id entity.ID) bool {
 			count++
-			sc, err := component.GetComponent[ecs.SignerComponent](wCtx, id)
+			sc, err := ecs.GetComponent[ecs.SignerComponent](wCtx, id)
 			assert.NilError(t, err)
 			assert.Equal(t, sc.PersonaTag, wantTag)
 			assert.Equal(t, sc.SignerAddress, wantSigner)

--- a/cardinal/ecs/search_test.go
+++ b/cardinal/ecs/search_test.go
@@ -8,7 +8,6 @@ import (
 	"pkg.world.dev/world-engine/assert"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
@@ -28,7 +27,7 @@ func TestSearchEarlyTermination(t *testing.T) {
 	count := 0
 	stop := 5
 	wCtx := ecs.NewWorldContext(world)
-	_, err := component.CreateMany(wCtx, total, FooComponent{})
+	_, err := ecs.CreateMany(wCtx, total, FooComponent{})
 	assert.NilError(t, err)
 	q, err := world.NewSearch(ecs.Exact(FooComponent{}))
 	assert.NilError(t, err)

--- a/cardinal/ecs/state_test.go
+++ b/cardinal/ecs/state_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
@@ -63,7 +62,7 @@ func TestErrorWhenSavedArchetypesDoNotMatchComponentTypes(t *testing.T) {
 	assert.NilError(t, ecs.RegisterComponent[OneAlphaNum](oneWorld))
 	assert.NilError(t, oneWorld.LoadGameState())
 
-	_, err := component.Create(ecs.NewWorldContext(oneWorld), OneAlphaNum{})
+	_, err := ecs.Create(ecs.NewWorldContext(oneWorld), OneAlphaNum{})
 	assert.NilError(t, err)
 
 	assert.NilError(t, oneWorld.Tick(context.Background()))
@@ -91,7 +90,7 @@ func TestArchetypeIDIsConsistentAfterSaveAndLoad(t *testing.T) {
 	assert.NilError(t, ecs.RegisterComponent[NumberComponent](oneWorld))
 	assert.NilError(t, oneWorld.LoadGameState())
 
-	_, err := component.Create(ecs.NewWorldContext(oneWorld), NumberComponent{})
+	_, err := ecs.Create(ecs.NewWorldContext(oneWorld), NumberComponent{})
 	assert.NilError(t, err)
 	oneNum, err := oneWorld.GetComponentByName(NumberComponent{}.Name())
 	assert.NilError(t, err)
@@ -128,11 +127,11 @@ func TestCanRecoverArchetypeInformationAfterLoad(t *testing.T) {
 	assert.NilError(t, oneWorld.LoadGameState())
 
 	oneWorldCtx := ecs.NewWorldContext(oneWorld)
-	_, err := component.Create(oneWorldCtx, OneAlphaNum{})
+	_, err := ecs.Create(oneWorldCtx, OneAlphaNum{})
 	assert.NilError(t, err)
-	_, err = component.Create(oneWorldCtx, OneBetaNum{})
+	_, err = ecs.Create(oneWorldCtx, OneBetaNum{})
 	assert.NilError(t, err)
-	_, err = component.Create(oneWorldCtx, OneAlphaNum{}, OneBetaNum{})
+	_, err = ecs.Create(oneWorldCtx, OneAlphaNum{}, OneBetaNum{})
 	assert.NilError(t, err)
 	oneAlphaNum, err := oneWorld.GetComponentByName(OneAlphaNum{}.Name())
 	assert.NilError(t, err)
@@ -228,7 +227,7 @@ func TestCanReloadState(t *testing.T) {
 			assert.NilError(
 				t, q.Each(
 					wCtx, func(id entity.ID) bool {
-						err = component.SetComponent[oneAlphaNumComp](wCtx, id, &oneAlphaNumComp{int(id)})
+						err = ecs.SetComponent[oneAlphaNumComp](wCtx, id, &oneAlphaNumComp{int(id)})
 						assert.Check(t, err == nil)
 						return true
 					},
@@ -238,7 +237,7 @@ func TestCanReloadState(t *testing.T) {
 		},
 	)
 	assert.NilError(t, alphaWorld.LoadGameState())
-	_, err = component.CreateMany(ecs.NewWorldContext(alphaWorld), 10, oneAlphaNumComp{})
+	_, err = ecs.CreateMany(ecs.NewWorldContext(alphaWorld), 10, oneAlphaNumComp{})
 	assert.NilError(t, err)
 
 	// Start a tick with executes the above system which initializes the number components.
@@ -257,7 +256,7 @@ func TestCanReloadState(t *testing.T) {
 		t, q.Each(
 			betaWorldCtx, func(id entity.ID) bool {
 				count++
-				num, err := component.GetComponent[OneBetaNum](betaWorldCtx, id)
+				num, err := ecs.GetComponent[OneBetaNum](betaWorldCtx, id)
 				assert.NilError(t, err)
 				assert.Equal(t, int(id), num.Num)
 				return true

--- a/cardinal/ecs/state_test.go
+++ b/cardinal/ecs/state_test.go
@@ -8,17 +8,17 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	"pkg.world.dev/world-engine/cardinal/ecs/internal/testutil"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
 // comps reduces the typing needed to create a slice of IComponentTypes
 // []component.ComponentMetadata{a, b, c} becomes:
 // comps(a, b, c).
-func comps(cs ...metadata.ComponentMetadata) []metadata.ComponentMetadata {
+func comps(cs ...component.ComponentMetadata) []component.ComponentMetadata {
 	return cs
 }
 

--- a/cardinal/ecs/storage/mock.go
+++ b/cardinal/ecs/storage/mock.go
@@ -2,17 +2,17 @@ package storage
 
 import (
 	"fmt"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/codec"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"reflect"
 )
 
 var (
-	nextMockComponentTypeID metadata.TypeID = 1
+	nextMockComponentTypeID component.TypeID = 1
 )
 
 type MockComponentType[T any] struct {
-	id         metadata.TypeID
+	id         component.TypeID
 	typ        reflect.Type
 	defaultVal interface{}
 }
@@ -27,12 +27,12 @@ func NewMockComponentType[T any](t T, defaultVal interface{}) *MockComponentType
 	return m
 }
 
-func (m *MockComponentType[T]) SetID(id metadata.TypeID) error {
+func (m *MockComponentType[T]) SetID(id component.TypeID) error {
 	m.id = id
 	return nil
 }
 
-func (m *MockComponentType[T]) ID() metadata.TypeID {
+func (m *MockComponentType[T]) ID() component.TypeID {
 	return m.id
 }
 
@@ -48,7 +48,7 @@ func (m *MockComponentType[T]) Name() string {
 	return fmt.Sprintf("%s[%s]", reflect.TypeOf(m).Name(), m.typ.Name())
 }
 
-var _ metadata.ComponentMetadata = &MockComponentType[int]{}
+var _ component.ComponentMetadata = &MockComponentType[int]{}
 
 func (m *MockComponentType[T]) Decode(bytes []byte) (any, error) {
 	return codec.Decode[T](bytes)

--- a/cardinal/ecs/store/iface.go
+++ b/cardinal/ecs/store/iface.go
@@ -4,25 +4,25 @@ import (
 	"encoding/json"
 	"pkg.world.dev/world-engine/cardinal/ecs/message"
 
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
 	ecslog "pkg.world.dev/world-engine/cardinal/ecs/log"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/cardinal/types/archetype"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
 type Reader interface {
 	// One Component One Entity
-	GetComponentForEntity(cType metadata.ComponentMetadata, id entity.ID) (any, error)
-	GetComponentForEntityInRawJSON(cType metadata.ComponentMetadata, id entity.ID) (json.RawMessage, error)
+	GetComponentForEntity(cType component.ComponentMetadata, id entity.ID) (any, error)
+	GetComponentForEntityInRawJSON(cType component.ComponentMetadata, id entity.ID) (json.RawMessage, error)
 
 	// Many Components One Entity
-	GetComponentTypesForEntity(id entity.ID) ([]metadata.ComponentMetadata, error)
+	GetComponentTypesForEntity(id entity.ID) ([]component.ComponentMetadata, error)
 
 	// One Archetype Many Components
-	GetComponentTypesForArchID(archID archetype.ID) []metadata.ComponentMetadata
-	GetArchIDForComponents(components []metadata.ComponentMetadata) (archetype.ID, error)
+	GetComponentTypesForArchID(archID archetype.ID) []component.ComponentMetadata
+	GetArchIDForComponents(components []component.ComponentMetadata) (archetype.ID, error)
 
 	// One Archetype Many Entities
 	GetEntitiesForArchID(archID archetype.ID) ([]entity.ID, error)
@@ -37,18 +37,18 @@ type Writer interface {
 	RemoveEntity(id entity.ID) error
 
 	// Many Components
-	CreateEntity(comps ...metadata.ComponentMetadata) (entity.ID, error)
-	CreateManyEntities(num int, comps ...metadata.ComponentMetadata) ([]entity.ID, error)
+	CreateEntity(comps ...component.ComponentMetadata) (entity.ID, error)
+	CreateManyEntities(num int, comps ...component.ComponentMetadata) ([]entity.ID, error)
 
 	// One Component One Entity
-	SetComponentForEntity(cType metadata.ComponentMetadata, id entity.ID, value any) error
-	AddComponentToEntity(cType metadata.ComponentMetadata, id entity.ID) error
-	RemoveComponentFromEntity(cType metadata.ComponentMetadata, id entity.ID) error
+	SetComponentForEntity(cType component.ComponentMetadata, id entity.ID, value any) error
+	AddComponentToEntity(cType component.ComponentMetadata, id entity.ID) error
+	RemoveComponentFromEntity(cType component.ComponentMetadata, id entity.ID) error
 
 	// Misc
 	InjectLogger(logger *ecslog.Logger)
 	Close() error
-	RegisterComponents([]metadata.ComponentMetadata) error
+	RegisterComponents([]component.ComponentMetadata) error
 }
 
 type TickStorage interface {

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -21,13 +21,13 @@ import (
 
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	ecslog "pkg.world.dev/world-engine/cardinal/ecs/log"
 	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/cardinal/ecs/store"
 	"pkg.world.dev/world-engine/cardinal/events"
 	"pkg.world.dev/world-engine/cardinal/shard"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 	"pkg.world.dev/world-engine/chain/x/shard/types"
 	"pkg.world.dev/world-engine/sign"
@@ -50,9 +50,9 @@ type World struct {
 	initSystemLogger       *ecslog.Logger
 	systemNames            []string
 	tick                   *atomic.Uint64
-	nameToComponent        map[string]metadata.ComponentMetadata
+	nameToComponent        map[string]component.ComponentMetadata
 	nameToQuery            map[string]Query
-	registeredComponents   []metadata.ComponentMetadata
+	registeredComponents   []component.ComponentMetadata
 	registeredMessages     []message.Message
 	registeredQueries      []Query
 	isComponentsRegistered bool
@@ -76,7 +76,7 @@ type World struct {
 	endGameLoopCh     chan bool
 	isGameLoopRunning atomic.Bool
 
-	nextComponentID metadata.TypeID
+	nextComponentID component.TypeID
 
 	eventHub events.EventHub
 
@@ -189,7 +189,7 @@ func (w *World) AddInitSystem(system System) {
 	w.initSystem = system
 }
 
-func RegisterComponent[T metadata.Component](world *World) error {
+func RegisterComponent[T component.Component](world *World) error {
 	if world.stateIsLoaded {
 		panic("cannot register components after loading game state")
 	}
@@ -198,7 +198,7 @@ func RegisterComponent[T metadata.Component](world *World) error {
 	if err == nil {
 		return eris.Errorf("component with name '%s' is already registered", t.Name())
 	}
-	c := metadata.NewComponentMetadata[T]()
+	c := component.NewComponentMetadata[T]()
 	err = c.SetID(world.nextComponentID)
 	if err != nil {
 		return err
@@ -210,14 +210,14 @@ func RegisterComponent[T metadata.Component](world *World) error {
 	return nil
 }
 
-func MustRegisterComponent[T metadata.Component](world *World) {
+func MustRegisterComponent[T component.Component](world *World) {
 	err := RegisterComponent[T](world)
 	if err != nil {
 		panic(err)
 	}
 }
 
-func (w *World) GetComponentByName(name string) (metadata.ComponentMetadata, error) {
+func (w *World) GetComponentByName(name string) (component.ComponentMetadata, error) {
 	componentType, exists := w.nameToComponent[name]
 	if !exists {
 		return nil, eris.Errorf(
@@ -324,7 +324,7 @@ func NewWorld(
 		tick:              &atomic.Uint64{},
 		systems:           make([]System, 0),
 		initSystem:        func(_ WorldContext) error { return nil },
-		nameToComponent:   make(map[string]metadata.ComponentMetadata),
+		nameToComponent:   make(map[string]component.ComponentMetadata),
 		nameToQuery:       make(map[string]Query),
 		txQueue:           message.NewTxQueue(),
 		Logger:            logger,
@@ -827,7 +827,7 @@ func (w *World) GetTransactionReceiptsForTick(tick uint64) ([]receipt.Receipt, e
 	return w.receiptHistory.GetReceiptsForTick(tick)
 }
 
-func (w *World) GetComponents() []metadata.ComponentMetadata {
+func (w *World) GetComponents() []component.ComponentMetadata {
 	return w.registeredComponents
 }
 
@@ -848,7 +848,7 @@ func (w *World) NewSearch(filter Filterable) (*Search, error) {
 	return NewSearch(componentFilter), nil
 }
 
-func GetRawJSONOfComponent(w *World, component metadata.ComponentMetadata, id entity.ID) (
+func GetRawJSONOfComponent(w *World, component component.ComponentMetadata, id entity.ID) (
 	json.RawMessage, error,
 ) {
 	return w.StoreManager().GetComponentForEntityInRawJSON(component, id)

--- a/cardinal/ecs/world_test.go
+++ b/cardinal/ecs/world_test.go
@@ -13,7 +13,6 @@ import (
 	"pkg.world.dev/world-engine/assert"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 )
 
 func TestCanWaitForNextTick(t *testing.T) {
@@ -68,9 +67,11 @@ func TestWaitForNextTickReturnsFalseWhenWorldIsShutDown(t *testing.T) {
 	}()
 
 	// Shutdown the world at some point in the near future
-	time.AfterFunc(100*time.Millisecond, func() {
-		w.Shutdown()
-	})
+	time.AfterFunc(
+		100*time.Millisecond, func() {
+			w.Shutdown()
+		},
+	)
 	// testTimeout will cause the test to fail if we have to wait too long for a WaitForNextTick failure
 	testTimeout := time.After(5 * time.Second)
 	for {
@@ -120,12 +121,16 @@ func TestEVMTxConsume(t *testing.T) {
 	assert.NilError(t, w.RegisterMessages(fooTx))
 	var returnVal FooOut
 	var returnErr error
-	w.RegisterSystem(func(wCtx ecs.WorldContext) error {
-		fooTx.Each(wCtx, func(t ecs.TxData[FooIn]) (FooOut, error) {
-			return returnVal, returnErr
-		})
-		return nil
-	})
+	w.RegisterSystem(
+		func(wCtx ecs.WorldContext) error {
+			fooTx.Each(
+				wCtx, func(t ecs.TxData[FooIn]) (FooOut, error) {
+					return returnVal, returnErr
+				},
+			)
+			return nil
+		},
+	)
 	assert.NilError(t, w.LoadGameState())
 
 	// add tx to queue
@@ -182,16 +187,18 @@ func TestAddSystems(t *testing.T) {
 func TestSystemExecutionOrder(t *testing.T) {
 	w := testutils.NewTestWorld(t).Instance()
 	order := make([]int, 0, 3)
-	w.RegisterSystems(func(ecs.WorldContext) error {
-		order = append(order, 1)
-		return nil
-	}, func(ecs.WorldContext) error {
-		order = append(order, 2)
-		return nil
-	}, func(ecs.WorldContext) error {
-		order = append(order, 3)
-		return nil
-	})
+	w.RegisterSystems(
+		func(ecs.WorldContext) error {
+			order = append(order, 1)
+			return nil
+		}, func(ecs.WorldContext) error {
+			order = append(order, 2)
+			return nil
+		}, func(ecs.WorldContext) error {
+			order = append(order, 3)
+			return nil
+		},
+	)
 	err := w.LoadGameState()
 	assert.NilError(t, err)
 	assert.NilError(t, w.Tick(context.Background()))
@@ -211,34 +218,42 @@ func TestSetNamespace(t *testing.T) {
 func TestWithoutRegistration(t *testing.T) {
 	world := testutils.NewTestWorld(t).Instance()
 	wCtx := ecs.NewWorldContext(world)
-	id, err := component.Create(wCtx, EnergyComponent{}, OwnableComponent{})
+	id, err := ecs.Create(wCtx, EnergyComponent{}, OwnableComponent{})
 	assert.Assert(t, err != nil)
 
-	err = component.UpdateComponent[EnergyComponent](wCtx, id, func(component *EnergyComponent) *EnergyComponent {
-		component.Amt += 50
-		return component
-	})
+	err = ecs.UpdateComponent[EnergyComponent](
+		wCtx, id, func(component *EnergyComponent) *EnergyComponent {
+			component.Amt += 50
+			return component
+		},
+	)
 	assert.Assert(t, err != nil)
 
-	err = component.SetComponent[EnergyComponent](wCtx, id, &EnergyComponent{
-		Amt: 0,
-		Cap: 0,
-	})
+	err = ecs.SetComponent[EnergyComponent](
+		wCtx, id, &EnergyComponent{
+			Amt: 0,
+			Cap: 0,
+		},
+	)
 
 	assert.Assert(t, err != nil)
 
 	assert.NilError(t, ecs.RegisterComponent[EnergyComponent](world))
 	assert.NilError(t, ecs.RegisterComponent[OwnableComponent](world))
-	id, err = component.Create(wCtx, EnergyComponent{}, OwnableComponent{})
+	id, err = ecs.Create(wCtx, EnergyComponent{}, OwnableComponent{})
 	assert.NilError(t, err)
-	err = component.UpdateComponent[EnergyComponent](wCtx, id, func(component *EnergyComponent) *EnergyComponent {
-		component.Amt += 50
-		return component
-	})
+	err = ecs.UpdateComponent[EnergyComponent](
+		wCtx, id, func(component *EnergyComponent) *EnergyComponent {
+			component.Amt += 50
+			return component
+		},
+	)
 	assert.NilError(t, err)
-	err = component.SetComponent[EnergyComponent](wCtx, id, &EnergyComponent{
-		Amt: 0,
-		Cap: 0,
-	})
+	err = ecs.SetComponent[EnergyComponent](
+		wCtx, id, &EnergyComponent{
+			Amt: 0,
+			Cap: 0,
+		},
+	)
 	assert.NilError(t, err)
 }

--- a/cardinal/evm/server.go
+++ b/cardinal/evm/server.go
@@ -13,7 +13,6 @@ import (
 	"pkg.world.dev/world-engine/cardinal/ecs/message"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 	"pkg.world.dev/world-engine/sign"
 
@@ -298,7 +297,7 @@ func (s *msgServerImpl) getSignerComponentForAuthorizedAddr(
 		q.Each(
 			wCtx, func(id entity.ID) bool {
 				var signerComp *ecs.SignerComponent
-				signerComp, getComponentErr = component.GetComponent[ecs.SignerComponent](wCtx, id)
+				signerComp, getComponentErr = ecs.GetComponent[ecs.SignerComponent](wCtx, id)
 				getComponentErr = eris.Wrap(getComponentErr, "")
 				if getComponentErr != nil {
 					return false

--- a/cardinal/filter.go
+++ b/cardinal/filter.go
@@ -2,7 +2,7 @@ package cardinal
 
 import (
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 )
 
 type Filter interface {
@@ -25,11 +25,11 @@ type not struct {
 }
 
 type contains struct {
-	components []metadata.Component
+	components []component.Component
 }
 
 type exact struct {
-	components []metadata.Component
+	components []component.Component
 }
 
 func All() Filter {
@@ -48,11 +48,11 @@ func Not(filter Filter) Filter {
 	return &not{filter: filter}
 }
 
-func Contains(components ...metadata.Component) Filter {
+func Contains(components ...component.Component) Filter {
 	return &contains{components: components}
 }
 
-func Exact(components ...metadata.Component) Filter {
+func Exact(components ...component.Component) Filter {
 	return &exact{components: components}
 }
 

--- a/cardinal/server/debug.go
+++ b/cardinal/server/debug.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/go-openapi/runtime/middleware/untyped"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
@@ -29,7 +29,7 @@ func (handler *Handler) registerDebugHandlerSwagger(api *untyped.API) {
 				var eachClosureErr error
 				searchEachErr := search.Each(
 					wCtx, func(id entity.ID) bool {
-						var components []metadata.ComponentMetadata
+						var components []component.ComponentMetadata
 						components, eachClosureErr = wCtx.StoreReader().GetComponentTypesForEntity(id)
 						if eachClosureErr != nil {
 							return false

--- a/cardinal/server/debug_test.go
+++ b/cardinal/server/debug_test.go
@@ -10,7 +10,6 @@ import (
 	"gotest.tools/v3/assert"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/server"
 	"pkg.world.dev/world-engine/cardinal/testutils"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
@@ -26,19 +25,19 @@ func TestDebugEndpoint(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 	ctx := context.Background()
 	worldCtx := ecs.NewWorldContext(world)
-	_, err := component.CreateMany(worldCtx, 10, Alpha{})
+	_, err := ecs.CreateMany(worldCtx, 10, Alpha{})
 	assert.NilError(t, err)
-	_, err = component.CreateMany(worldCtx, 10, Beta{})
+	_, err = ecs.CreateMany(worldCtx, 10, Beta{})
 	assert.NilError(t, err)
-	_, err = component.CreateMany(worldCtx, 10, Gamma{})
+	_, err = ecs.CreateMany(worldCtx, 10, Gamma{})
 	assert.NilError(t, err)
-	_, err = component.CreateMany(worldCtx, 10, Alpha{}, Beta{})
+	_, err = ecs.CreateMany(worldCtx, 10, Alpha{}, Beta{})
 	assert.NilError(t, err)
-	_, err = component.CreateMany(worldCtx, 10, Alpha{}, Gamma{})
+	_, err = ecs.CreateMany(worldCtx, 10, Alpha{}, Gamma{})
 	assert.NilError(t, err)
-	_, err = component.CreateMany(worldCtx, 10, Beta{}, Gamma{})
+	_, err = ecs.CreateMany(worldCtx, 10, Beta{}, Gamma{})
 	assert.NilError(t, err)
-	_, err = component.CreateMany(worldCtx, 10, Alpha{}, Beta{}, Gamma{})
+	_, err = ecs.CreateMany(worldCtx, 10, Alpha{}, Beta{}, Gamma{})
 	assert.NilError(t, err)
 	err = world.Tick(ctx)
 	assert.NilError(t, err)
@@ -66,7 +65,7 @@ func TestDebugAndCQLEndpointMustAccessReadOnlyData(t *testing.T) {
 			// This system increments Delta.Value by 50 twice. /debug/state should see Delta.Value = 0 OR Delta.Value = 100,
 			// But never Delta.Value = 50.
 			assert.Check(
-				t, nil == component.UpdateComponent[Delta](
+				t, nil == ecs.UpdateComponent[Delta](
 					worldCtx, targetID, func(d *Delta) *Delta {
 						d.DeltaValue += 50
 						return d
@@ -76,7 +75,7 @@ func TestDebugAndCQLEndpointMustAccessReadOnlyData(t *testing.T) {
 			<-midTickCh
 			<-midTickCh
 			assert.Check(
-				t, nil == component.UpdateComponent[Delta](
+				t, nil == ecs.UpdateComponent[Delta](
 					worldCtx, targetID, func(d *Delta) *Delta {
 						d.DeltaValue += 50
 						return d
@@ -90,7 +89,7 @@ func TestDebugAndCQLEndpointMustAccessReadOnlyData(t *testing.T) {
 	assert.NilError(t, world.LoadGameState())
 	worldCtx := ecs.NewWorldContext(world)
 	var err error
-	targetID, err = component.Create(worldCtx, Delta{})
+	targetID, err = ecs.Create(worldCtx, Delta{})
 	assert.NilError(t, err)
 
 	startNextTick := make(chan struct{})

--- a/cardinal/types/component/component.go
+++ b/cardinal/types/component/component.go
@@ -1,4 +1,4 @@
-package metadata
+package component
 
 import (
 	"fmt"

--- a/cardinal/types/component/component.go
+++ b/cardinal/types/component/component.go
@@ -14,7 +14,7 @@ type (
 	TypeID int
 
 	// ComponentMetadata is a high level representation of a user defined component struct.
-	ComponentMetadata interface {
+	ComponentMetadata interface { //revive:disable-line:exported
 		// SetID sets the ID of this component. It must only be set once
 		SetID(TypeID) error
 		// ID returns the ID of the component.
@@ -128,7 +128,7 @@ func newComponentType[T any](s T, name string, defaultVal interface{}) *componen
 
 // ComponentOption is a type that can be passed to NewComponentMetadata to augment the creation
 // of the component type.
-type ComponentOption[T any] func(c *componentMetadata[T])
+type ComponentOption[T any] func(c *componentMetadata[T]) //revive:disable-line:exported
 
 // WithDefault updated the created componentMetadata with a default value.
 func WithDefault[T any](defaultVal T) ComponentOption[T] {

--- a/cardinal/types/component/component_test.go
+++ b/cardinal/types/component/component_test.go
@@ -1,4 +1,4 @@
-package metadata_test
+package component_test
 
 import (
 	"testing"
@@ -11,8 +11,8 @@ import (
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/types/archetype"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 )
@@ -33,17 +33,17 @@ type ComponentDataC struct {
 	Value int
 }
 
-func getNameOfComponent(c metadata.Component) string {
+func getNameOfComponent(c component.Component) string {
 	return c.Name()
 }
 
 func TestComponentSchemaValidation(t *testing.T) {
-	componentASchemaBytes, err := metadata.SerializeComponentSchema(ComponentDataA{Value: "test"})
+	componentASchemaBytes, err := component.SerializeComponentSchema(ComponentDataA{Value: "test"})
 	assert.NilError(t, err)
-	valid, err := metadata.IsComponentValid(ComponentDataA{Value: "anything"}, componentASchemaBytes)
+	valid, err := component.IsComponentValid(ComponentDataA{Value: "anything"}, componentASchemaBytes)
 	assert.NilError(t, err)
 	assert.Assert(t, valid)
-	valid, err = metadata.IsComponentValid(ComponentDataB{Value: "blah"}, componentASchemaBytes)
+	valid, err = component.IsComponentValid(ComponentDataB{Value: "blah"}, componentASchemaBytes)
 	assert.NilError(t, err)
 	assert.Assert(t, !valid)
 }
@@ -65,19 +65,19 @@ func TestComponents(t *testing.T) {
 	assert.NilError(t, err)
 
 	tests := []*struct {
-		comps    []metadata.ComponentMetadata
+		comps    []component.ComponentMetadata
 		archID   archetype.ID
 		entityID entity.ID
 		Value    string
 	}{
 		{
-			[]metadata.ComponentMetadata{ca},
+			[]component.ComponentMetadata{ca},
 			0,
 			0,
 			"a",
 		},
 		{
-			[]metadata.ComponentMetadata{ca, cb},
+			[]component.ComponentMetadata{ca, cb},
 			1,
 			0,
 			"b",

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -17,7 +17,6 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
 	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/ecb"
 	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
@@ -132,38 +131,38 @@ func NewMockWorld(opts ...WorldOption) (*World, error) {
 // CreateMany creates multiple entities in the world, and returns the slice of ids for the newly created
 // entities. At least 1 component must be provided.
 func CreateMany(wCtx WorldContext, num int, components ...metadata.Component) ([]EntityID, error) {
-	return component.CreateMany(wCtx.Instance(), num, components...)
+	return ecs.CreateMany(wCtx.Instance(), num, components...)
 }
 
 // Create creates a single entity in the world, and returns the id of the newly created entity.
 // At least 1 component must be provided.
 func Create(wCtx WorldContext, components ...metadata.Component) (EntityID, error) {
-	return component.Create(wCtx.Instance(), components...)
+	return ecs.Create(wCtx.Instance(), components...)
 }
 
 // SetComponent Set sets component data to the entity.
 func SetComponent[T metadata.Component](wCtx WorldContext, id entity.ID, comp *T) error {
-	return component.SetComponent[T](wCtx.Instance(), id, comp)
+	return ecs.SetComponent[T](wCtx.Instance(), id, comp)
 }
 
 // GetComponent Get returns component data from the entity.
 func GetComponent[T metadata.Component](wCtx WorldContext, id entity.ID) (*T, error) {
-	return component.GetComponent[T](wCtx.Instance(), id)
+	return ecs.GetComponent[T](wCtx.Instance(), id)
 }
 
 // UpdateComponent Updates a component on an entity.
 func UpdateComponent[T metadata.Component](wCtx WorldContext, id entity.ID, fn func(*T) *T) error {
-	return component.UpdateComponent[T](wCtx.Instance(), id, fn)
+	return ecs.UpdateComponent[T](wCtx.Instance(), id, fn)
 }
 
 // AddComponentTo Adds a component on an entity.
 func AddComponentTo[T metadata.Component](wCtx WorldContext, id entity.ID) error {
-	return component.AddComponentTo[T](wCtx.Instance(), id)
+	return ecs.AddComponentTo[T](wCtx.Instance(), id)
 }
 
 // RemoveComponentFrom Removes a component from an entity.
 func RemoveComponentFrom[T metadata.Component](wCtx WorldContext, id entity.ID) error {
-	return component.RemoveComponentFrom[T](wCtx.Instance(), id)
+	return ecs.RemoveComponentFrom[T](wCtx.Instance(), id)
 }
 
 // Remove removes the given entity id from the world.

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -17,13 +17,13 @@ import (
 
 	"github.com/rs/zerolog/log"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/ecs/component/metadata"
 	"pkg.world.dev/world-engine/cardinal/ecs/ecb"
 	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage"
 	"pkg.world.dev/world-engine/cardinal/events"
 	"pkg.world.dev/world-engine/cardinal/evm"
 	"pkg.world.dev/world-engine/cardinal/server"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 )
 
@@ -130,38 +130,38 @@ func NewMockWorld(opts ...WorldOption) (*World, error) {
 
 // CreateMany creates multiple entities in the world, and returns the slice of ids for the newly created
 // entities. At least 1 component must be provided.
-func CreateMany(wCtx WorldContext, num int, components ...metadata.Component) ([]EntityID, error) {
+func CreateMany(wCtx WorldContext, num int, components ...component.Component) ([]EntityID, error) {
 	return ecs.CreateMany(wCtx.Instance(), num, components...)
 }
 
 // Create creates a single entity in the world, and returns the id of the newly created entity.
 // At least 1 component must be provided.
-func Create(wCtx WorldContext, components ...metadata.Component) (EntityID, error) {
+func Create(wCtx WorldContext, components ...component.Component) (EntityID, error) {
 	return ecs.Create(wCtx.Instance(), components...)
 }
 
 // SetComponent Set sets component data to the entity.
-func SetComponent[T metadata.Component](wCtx WorldContext, id entity.ID, comp *T) error {
+func SetComponent[T component.Component](wCtx WorldContext, id entity.ID, comp *T) error {
 	return ecs.SetComponent[T](wCtx.Instance(), id, comp)
 }
 
 // GetComponent Get returns component data from the entity.
-func GetComponent[T metadata.Component](wCtx WorldContext, id entity.ID) (*T, error) {
+func GetComponent[T component.Component](wCtx WorldContext, id entity.ID) (*T, error) {
 	return ecs.GetComponent[T](wCtx.Instance(), id)
 }
 
 // UpdateComponent Updates a component on an entity.
-func UpdateComponent[T metadata.Component](wCtx WorldContext, id entity.ID, fn func(*T) *T) error {
+func UpdateComponent[T component.Component](wCtx WorldContext, id entity.ID, fn func(*T) *T) error {
 	return ecs.UpdateComponent[T](wCtx.Instance(), id, fn)
 }
 
 // AddComponentTo Adds a component on an entity.
-func AddComponentTo[T metadata.Component](wCtx WorldContext, id entity.ID) error {
+func AddComponentTo[T component.Component](wCtx WorldContext, id entity.ID) error {
 	return ecs.AddComponentTo[T](wCtx.Instance(), id)
 }
 
 // RemoveComponentFrom Removes a component from an entity.
-func RemoveComponentFrom[T metadata.Component](wCtx WorldContext, id entity.ID) error {
+func RemoveComponentFrom[T component.Component](wCtx WorldContext, id entity.ID) error {
 	return ecs.RemoveComponentFrom[T](wCtx.Instance(), id)
 }
 
@@ -297,7 +297,7 @@ func RegisterSystems(w *World, systems ...System) error {
 	return nil
 }
 
-func RegisterComponent[T metadata.Component](world *World) error {
+func RegisterComponent[T component.Component](world *World) error {
 	return ecs.RegisterComponent[T](world.instance)
 }
 


### PR DESCRIPTION
Closes: WORLD-606

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

This PR breaks up the /ecs/component package. As a result, this not only declutter the `/ecs` folder, it also reduces the surface area for circular dependency. This is a redo of #463 without the codec PR

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

- Move `/ecs/component/component.go` into `/ecs/entity.go` (this makes more sense anyway because having this as a separate package in circular dependency prone and why we end up with `/component/metadata` in the first place. in general, we want package to not be as encapsulated as possible. `/ecs/component/component.go` was not, it was highly dependent in its parent package `/ecs`. 

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

- This change is already covered by existing tests
