### PR TITLE
feat(cardinal): validation and error handling for register and auth persona

### DIFF
--- a/cardinal/ecs/internal/testutil/testutil.go
+++ b/cardinal/ecs/internal/testutil/testutil.go
@@ -97,7 +97,7 @@ func UniqueSignature(t *testing.T) *sign.Transaction {
 	nonce++
 	sig, err := sign.NewTransaction(
 		privateKey,
-		"some-persona-tag",
+		"some_persona_tag",
 		"namespace",
 		nonce,
 		`{"some":"data"}`,

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -148,11 +148,11 @@ func RegisterPersonaSystem(wCtx WorldContext) error {
 	}
 
 	CreatePersonaMsg.Each(wCtx, func(txData TxData[CreatePersona]) (CreatePersonaResult, error) {
-		msg, tx := txData.Msg, txData.Tx
+		msg := txData.Msg
 		result := CreatePersonaResult{Success: false}
 
 		if valid := IsAlphanumericWithUnderscore(msg.PersonaTag); !valid {
-			err = fmt.Errorf("persona tag %s is not valid, must be alphanumeric with underscores also allowed", tx.PersonaTag)
+			err = fmt.Errorf("persona tag %s is not valid, must be alphanumeric with underscores also allowed", msg.PersonaTag)
 			return result, err
 		}
 
@@ -173,7 +173,7 @@ func RegisterPersonaSystem(wCtx WorldContext) error {
 		); err != nil {
 			return result, eris.Wrap(err, "")
 		}
-		personaTagToAddress[tx.PersonaTag] = personaTagComponentData{
+		personaTagToAddress[msg.PersonaTag] = personaTagComponentData{
 			SignerAddress: msg.SignerAddress,
 			EntityID:      id,
 		}

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -151,7 +151,7 @@ func RegisterPersonaSystem(wCtx WorldContext) error {
 		result.Success = false
 
 		if !isAlphanumericWithUnderscore(msg.PersonaTag) {
-			err = eris.Errorf("persona tag %s is not valid, must be alphanumeric with underscores also allowed", msg.PersonaTag)
+			err = eris.Errorf("persona tag %s is not valid: must only contain alphanumerics and underscores", msg.PersonaTag)
 			return result, err
 		}
 

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -151,7 +151,7 @@ func RegisterPersonaSystem(wCtx WorldContext) error {
 		msg := txData.Msg
 		result := CreatePersonaResult{Success: false}
 
-		if valid := IsAlphanumericWithUnderscore(msg.PersonaTag); !valid {
+		if valid := isAlphanumericWithUnderscore(msg.PersonaTag); !valid {
 			err = fmt.Errorf("persona tag %s is not valid, must be alphanumeric with underscores also allowed", msg.PersonaTag)
 			return result, err
 		}
@@ -184,7 +184,7 @@ func RegisterPersonaSystem(wCtx WorldContext) error {
 	return nil
 }
 
-func IsAlphanumericWithUnderscore(s string) bool {
+func isAlphanumericWithUnderscore(s string) bool {
 	// Regular expression pattern for alphanumeric with underscore
 	pattern := "^[a-zA-Z0-9_]+$"
 

--- a/cardinal/ecs/persona_integration_test.go
+++ b/cardinal/ecs/persona_integration_test.go
@@ -135,13 +135,56 @@ func TestDuplicatePersonaTagsInTickAreOnlyRegisteredOnce(t *testing.T) {
 	assert.Equal(t, addr, "address_0")
 }
 
+func TestCreatePersonaFailsIfTagIsInvalid(t *testing.T) {
+	// Verify that the CreatePersona is automatically created and registered with a world.
+	world := testutils.NewTestWorld(t).Instance()
+	assert.NilError(t, world.LoadGameState())
+
+	wantTag := "INVALID PERSONA TAG WITH SPACES"
+	wantAddress := "123_456"
+	ecs.CreatePersonaMsg.AddToQueue(
+		world, ecs.CreatePersona{
+			PersonaTag:    wantTag,
+			SignerAddress: wantAddress,
+		},
+	)
+	// This CreatePersona has the same persona tag, but it shouldn't be registered because
+	// it comes second.
+	ecs.CreatePersonaMsg.AddToQueue(
+		world, ecs.CreatePersona{
+			PersonaTag:    wantTag,
+			SignerAddress: "some_other_address",
+		},
+	)
+
+	// PersonaTag registration doesn't take place until the relevant system is run during a game tick.
+	assert.NilError(t, world.Tick(context.Background()))
+
+	count := 0
+	wCtx := ecs.NewWorldContext(world)
+	q, err := wCtx.NewSearch(ecs.Exact(ecs.SignerComponent{}))
+	assert.NilError(t, err)
+	err = q.Each(
+		wCtx, func(id entity.ID) bool {
+			count++
+			sc, err := component.GetComponent[ecs.SignerComponent](wCtx, id)
+			assert.NilError(t, err)
+			assert.NotEqual(t, sc.PersonaTag, wantTag)
+			assert.NotEqual(t, sc.SignerAddress, wantAddress)
+			return true
+		},
+	)
+	assert.NilError(t, err)
+	assert.Equal(t, count, 0) // Assert that no signer components were found
+}
+
 func TestCanAuthorizeAddress(t *testing.T) {
 	// Verify that the CreatePersona is automatically created and registered with a world.
 	world := testutils.NewTestWorld(t).Instance()
 	assert.NilError(t, world.LoadGameState())
 
 	wantTag := "CoolMage"
-	wantSigner := "123-456"
+	wantSigner := "123_456"
 	ecs.CreatePersonaMsg.AddToQueue(
 		world, ecs.CreatePersona{
 			PersonaTag:    wantTag,
@@ -171,6 +214,50 @@ func TestCanAuthorizeAddress(t *testing.T) {
 			assert.Equal(t, sc.SignerAddress, wantSigner)
 			assert.Equal(t, len(sc.AuthorizedAddresses), 1)
 			assert.Equal(t, sc.AuthorizedAddresses[0], wantAddr)
+			return true
+		},
+	)
+	assert.NilError(t, err)
+	// verify that the query was even ran. if for some reason there were no SignerComponents in the state,
+	// this test would still pass (false positive).
+	assert.Equal(t, count, 1)
+}
+
+func TestCanAuthorizeAddressFailsOnInvalidAddress(t *testing.T) {
+	// Verify that the CreatePersona is automatically created and registered with a world.
+	world := testutils.NewTestWorld(t).Instance()
+	assert.NilError(t, world.LoadGameState())
+
+	wantTag := "CoolMage"
+	wantSigner := "123-456"
+	ecs.CreatePersonaMsg.AddToQueue(
+		world, ecs.CreatePersona{
+			PersonaTag:    wantTag,
+			SignerAddress: wantSigner,
+		},
+	)
+
+	wantAddr := "INVALID ADDRESS"
+	ecs.AuthorizePersonaAddressMsg.AddToQueue(
+		world, ecs.AuthorizePersonaAddress{
+			Address: wantAddr,
+		}, &sign.Transaction{PersonaTag: wantTag},
+	)
+	// PersonaTag registration doesn't take place until the relevant system is run during a game tick.
+	assert.NilError(t, world.Tick(context.Background()))
+
+	count := 0
+	q, err := world.NewSearch(ecs.Exact(ecs.SignerComponent{}))
+	assert.NilError(t, err)
+	wCtx := ecs.NewWorldContext(world)
+	err = q.Each(
+		wCtx, func(id entity.ID) bool {
+			count++
+			sc, err := component.GetComponent[ecs.SignerComponent](wCtx, id)
+			assert.NilError(t, err)
+			assert.Equal(t, sc.PersonaTag, wantTag)
+			assert.Equal(t, sc.SignerAddress, wantSigner)
+			assert.Equal(t, len(sc.AuthorizedAddresses), 0) // Assert that no authorized address was added
 			return true
 		},
 	)

--- a/cardinal/ecs/persona_integration_test.go
+++ b/cardinal/ecs/persona_integration_test.go
@@ -1,0 +1,181 @@
+package ecs_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"pkg.world.dev/world-engine/cardinal/testutils"
+
+	"pkg.world.dev/world-engine/cardinal/ecs/component"
+	"pkg.world.dev/world-engine/cardinal/types/entity"
+	"pkg.world.dev/world-engine/sign"
+
+	"pkg.world.dev/world-engine/assert"
+
+	"pkg.world.dev/world-engine/cardinal/ecs"
+)
+
+func TestCreatePersonaTransactionAutomaticallyCreated(t *testing.T) {
+	// Verify that the CreatePersona is automatically created and registered with a world.
+	world := testutils.NewTestWorld(t).Instance()
+	assert.NilError(t, world.LoadGameState())
+
+	wantTag := "CoolMage"
+	wantAddress := "123_456"
+	ecs.CreatePersonaMsg.AddToQueue(
+		world, ecs.CreatePersona{
+			PersonaTag:    wantTag,
+			SignerAddress: wantAddress,
+		},
+	)
+	// This CreatePersona has the same persona tag, but it shouldn't be registered because
+	// it comes second.
+	ecs.CreatePersonaMsg.AddToQueue(
+		world, ecs.CreatePersona{
+			PersonaTag:    wantTag,
+			SignerAddress: "some_other_address",
+		},
+	)
+
+	// PersonaTag registration doesn't take place until the relevant system is run during a game tick.
+	assert.NilError(t, world.Tick(context.Background()))
+
+	count := 0
+	wCtx := ecs.NewWorldContext(world)
+	q, err := wCtx.NewSearch(ecs.Exact(ecs.SignerComponent{}))
+	assert.NilError(t, err)
+	err = q.Each(
+		wCtx, func(id entity.ID) bool {
+			count++
+			sc, err := component.GetComponent[ecs.SignerComponent](wCtx, id)
+			assert.NilError(t, err)
+			assert.Equal(t, sc.PersonaTag, wantTag)
+			assert.Equal(t, sc.SignerAddress, wantAddress)
+			return true
+		},
+	)
+	assert.NilError(t, err)
+	assert.Equal(t, 1, count)
+}
+
+func TestGetSignerForPersonaTagReturnsErrorWhenNotRegistered(t *testing.T) {
+	world := testutils.NewTestWorld(t).Instance()
+	assert.NilError(t, world.LoadGameState())
+	ctx := context.Background()
+
+	// Tick the game forward a bit to simulate a game that has been running for a bit of time.
+	for i := 0; i < 10; i++ {
+		assert.NilError(t, world.Tick(ctx))
+	}
+
+	_, err := world.GetSignerForPersonaTag("missing_persona", 1)
+	assert.ErrorIs(t, err, ecs.ErrPersonaTagHasNoSigner)
+
+	// Queue up a CreatePersona
+	personaTag := "foobar"
+	signerAddress := "xyzzy"
+	ecs.CreatePersonaMsg.AddToQueue(
+		world, ecs.CreatePersona{
+			PersonaTag:    personaTag,
+			SignerAddress: signerAddress,
+		},
+	)
+	// This CreatePersona will not be processed until the world.CurrentTick() is greater than the tick that
+	// originally got the CreatePersona.
+	tick := world.CurrentTick()
+	_, err = world.GetSignerForPersonaTag(personaTag, tick)
+	assert.ErrorIs(t, err, ecs.ErrCreatePersonaTxsNotProcessed)
+
+	assert.NilError(t, world.Tick(ctx))
+	// The CreatePersona has now been processed
+	addr, err := world.GetSignerForPersonaTag(personaTag, tick)
+	assert.NilError(t, err)
+	assert.Equal(t, addr, signerAddress)
+}
+
+func TestDuplicatePersonaTagsInTickAreOnlyRegisteredOnce(t *testing.T) {
+	world := testutils.NewTestWorld(t).Instance()
+	assert.NilError(t, world.LoadGameState())
+
+	personaTag := "jeff"
+
+	for i := 0; i < 10; i++ {
+		// Attempt to register many different signer addresses with the same persona tag.
+		ecs.CreatePersonaMsg.AddToQueue(
+			world, ecs.CreatePersona{
+				PersonaTag:    personaTag,
+				SignerAddress: fmt.Sprintf("address_%d", i),
+			},
+		)
+	}
+	tick := world.CurrentTick()
+
+	ctx := context.Background()
+	assert.NilError(t, world.Tick(ctx))
+
+	addr, err := world.GetSignerForPersonaTag(personaTag, tick)
+	assert.NilError(t, err)
+	// Only the first address should be associated with the user
+	assert.Equal(t, addr, "address_0")
+
+	// Attempt to register this persona tag again in a different tick. We should still maintain the original
+	// signer address.
+	ecs.CreatePersonaMsg.AddToQueue(
+		world, ecs.CreatePersona{
+			PersonaTag:    personaTag,
+			SignerAddress: "some_other_address",
+		},
+	)
+
+	assert.NilError(t, world.Tick(ctx))
+	addr, err = world.GetSignerForPersonaTag(personaTag, tick)
+	assert.NilError(t, err)
+	// The saved address should be unchanged
+	assert.Equal(t, addr, "address_0")
+}
+
+func TestCanAuthorizeAddress(t *testing.T) {
+	// Verify that the CreatePersona is automatically created and registered with a world.
+	world := testutils.NewTestWorld(t).Instance()
+	assert.NilError(t, world.LoadGameState())
+
+	wantTag := "CoolMage"
+	wantSigner := "123-456"
+	ecs.CreatePersonaMsg.AddToQueue(
+		world, ecs.CreatePersona{
+			PersonaTag:    wantTag,
+			SignerAddress: wantSigner,
+		},
+	)
+
+	wantAddr := "0xd5e099c71b797516c10ed0f0d895f429c2781142"
+	ecs.AuthorizePersonaAddressMsg.AddToQueue(
+		world, ecs.AuthorizePersonaAddress{
+			Address: wantAddr,
+		}, &sign.Transaction{PersonaTag: wantTag},
+	)
+	// PersonaTag registration doesn't take place until the relevant system is run during a game tick.
+	assert.NilError(t, world.Tick(context.Background()))
+
+	count := 0
+	q, err := world.NewSearch(ecs.Exact(ecs.SignerComponent{}))
+	assert.NilError(t, err)
+	wCtx := ecs.NewWorldContext(world)
+	err = q.Each(
+		wCtx, func(id entity.ID) bool {
+			count++
+			sc, err := component.GetComponent[ecs.SignerComponent](wCtx, id)
+			assert.NilError(t, err)
+			assert.Equal(t, sc.PersonaTag, wantTag)
+			assert.Equal(t, sc.SignerAddress, wantSigner)
+			assert.Equal(t, len(sc.AuthorizedAddresses), 1)
+			assert.Equal(t, sc.AuthorizedAddresses[0], wantAddr)
+			return true
+		},
+	)
+	assert.NilError(t, err)
+	// verify that the query was even ran. if for some reason there were no SignerComponents in the state,
+	// this test would still pass (false positive).
+	assert.Equal(t, count, 1)
+}

--- a/cardinal/ecs/persona_integration_test.go
+++ b/cardinal/ecs/persona_integration_test.go
@@ -230,5 +230,6 @@ func getSigners(t *testing.T, world *ecs.World) []*ecs.SignerComponent {
 			return true
 		},
 	)
+	assert.NilError(t, err)
 	return signers
 }

--- a/cardinal/ecs/persona_test.go
+++ b/cardinal/ecs/persona_test.go
@@ -1,181 +1,29 @@
-package ecs_test
+package ecs
 
 import (
-	"context"
-	"fmt"
 	"testing"
-
-	"pkg.world.dev/world-engine/cardinal/testutils"
-
-	"pkg.world.dev/world-engine/cardinal/ecs/component"
-	"pkg.world.dev/world-engine/cardinal/types/entity"
-	"pkg.world.dev/world-engine/sign"
-
-	"pkg.world.dev/world-engine/assert"
-
-	"pkg.world.dev/world-engine/cardinal/ecs"
 )
 
-func TestCreatePersonaTransactionAutomaticallyCreated(t *testing.T) {
-	// Verify that the CreatePersona is automatically created and registered with a world.
-	world := testutils.NewTestWorld(t).Instance()
-	assert.NilError(t, world.LoadGameState())
-
-	wantTag := "CoolMage"
-	wantAddress := "123-456"
-	ecs.CreatePersonaMsg.AddToQueue(
-		world, ecs.CreatePersona{
-			PersonaTag:    wantTag,
-			SignerAddress: wantAddress,
-		},
-	)
-	// This CreatePersona has the same persona tag, but it shouldn't be registered because
-	// it comes second.
-	ecs.CreatePersonaMsg.AddToQueue(
-		world, ecs.CreatePersona{
-			PersonaTag:    wantTag,
-			SignerAddress: "some-other-address",
-		},
-	)
-
-	// PersonaTag registration doesn't take place until the relevant system is run during a game tick.
-	assert.NilError(t, world.Tick(context.Background()))
-
-	count := 0
-	wCtx := ecs.NewWorldContext(world)
-	q, err := wCtx.NewSearch(ecs.Exact(ecs.SignerComponent{}))
-	assert.NilError(t, err)
-	err = q.Each(
-		wCtx, func(id entity.ID) bool {
-			count++
-			sc, err := component.GetComponent[ecs.SignerComponent](wCtx, id)
-			assert.NilError(t, err)
-			assert.Equal(t, sc.PersonaTag, wantTag)
-			assert.Equal(t, sc.SignerAddress, wantAddress)
-			return true
-		},
-	)
-	assert.NilError(t, err)
-	assert.Equal(t, 1, count)
-}
-
-func TestGetSignerForPersonaTagReturnsErrorWhenNotRegistered(t *testing.T) {
-	world := testutils.NewTestWorld(t).Instance()
-	assert.NilError(t, world.LoadGameState())
-	ctx := context.Background()
-
-	// Tick the game forward a bit to simulate a game that has been running for a bit of time.
-	for i := 0; i < 10; i++ {
-		assert.NilError(t, world.Tick(ctx))
+func TestIsAlphanumericWithUnderscore(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"abc123", true},
+		{"ABC_123", true},
+		{"123", true},
+		{"abc 123", false}, // contains a space
+		{"abc123 ", false}, // contains a trailing space
+		{"abc@123", false}, // contains a special character
+		{"", false},        // empty string
 	}
 
-	_, err := world.GetSignerForPersonaTag("missing_persona", 1)
-	assert.ErrorIs(t, err, ecs.ErrPersonaTagHasNoSigner)
-
-	// Queue up a CreatePersona
-	personaTag := "foobar"
-	signerAddress := "xyzzy"
-	ecs.CreatePersonaMsg.AddToQueue(
-		world, ecs.CreatePersona{
-			PersonaTag:    personaTag,
-			SignerAddress: signerAddress,
-		},
-	)
-	// This CreatePersona will not be processed until the world.CurrentTick() is greater than the tick that
-	// originally got the CreatePersona.
-	tick := world.CurrentTick()
-	_, err = world.GetSignerForPersonaTag(personaTag, tick)
-	assert.ErrorIs(t, err, ecs.ErrCreatePersonaTxsNotProcessed)
-
-	assert.NilError(t, world.Tick(ctx))
-	// The CreatePersona has now been processed
-	addr, err := world.GetSignerForPersonaTag(personaTag, tick)
-	assert.NilError(t, err)
-	assert.Equal(t, addr, signerAddress)
-}
-
-func TestDuplicatePersonaTagsInTickAreOnlyRegisteredOnce(t *testing.T) {
-	world := testutils.NewTestWorld(t).Instance()
-	assert.NilError(t, world.LoadGameState())
-
-	personaTag := "jeff"
-
-	for i := 0; i < 10; i++ {
-		// Attempt to register many different signer addresses with the same persona tag.
-		ecs.CreatePersonaMsg.AddToQueue(
-			world, ecs.CreatePersona{
-				PersonaTag:    personaTag,
-				SignerAddress: fmt.Sprintf("address-%d", i),
-			},
-		)
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			result := IsAlphanumericWithUnderscore(test.input)
+			if result != test.expected {
+				t.Errorf("Expected %v, but got %v", test.expected, result)
+			}
+		})
 	}
-	tick := world.CurrentTick()
-
-	ctx := context.Background()
-	assert.NilError(t, world.Tick(ctx))
-
-	addr, err := world.GetSignerForPersonaTag(personaTag, tick)
-	assert.NilError(t, err)
-	// Only the first address should be associated with the user
-	assert.Equal(t, addr, "address-0")
-
-	// Attempt to register this persona tag again in a different tick. We should still maintain the original
-	// signer address.
-	ecs.CreatePersonaMsg.AddToQueue(
-		world, ecs.CreatePersona{
-			PersonaTag:    personaTag,
-			SignerAddress: "some-other-address",
-		},
-	)
-
-	assert.NilError(t, world.Tick(ctx))
-	addr, err = world.GetSignerForPersonaTag(personaTag, tick)
-	assert.NilError(t, err)
-	// The saved address should be unchanged
-	assert.Equal(t, addr, "address-0")
-}
-
-func TestCanAuthorizeAddress(t *testing.T) {
-	// Verify that the CreatePersona is automatically created and registered with a world.
-	world := testutils.NewTestWorld(t).Instance()
-	assert.NilError(t, world.LoadGameState())
-
-	wantTag := "CoolMage"
-	wantSigner := "123-456"
-	ecs.CreatePersonaMsg.AddToQueue(
-		world, ecs.CreatePersona{
-			PersonaTag:    wantTag,
-			SignerAddress: wantSigner,
-		},
-	)
-
-	wantAddr := "0xfoobar"
-	ecs.AuthorizePersonaAddressMsg.AddToQueue(
-		world, ecs.AuthorizePersonaAddress{
-			Address: wantAddr,
-		}, &sign.Transaction{PersonaTag: wantTag},
-	)
-	// PersonaTag registration doesn't take place until the relevant system is run during a game tick.
-	assert.NilError(t, world.Tick(context.Background()))
-
-	count := 0
-	q, err := world.NewSearch(ecs.Exact(ecs.SignerComponent{}))
-	assert.NilError(t, err)
-	wCtx := ecs.NewWorldContext(world)
-	err = q.Each(
-		wCtx, func(id entity.ID) bool {
-			count++
-			sc, err := component.GetComponent[ecs.SignerComponent](wCtx, id)
-			assert.NilError(t, err)
-			assert.Equal(t, sc.PersonaTag, wantTag)
-			assert.Equal(t, sc.SignerAddress, wantSigner)
-			assert.Equal(t, len(sc.AuthorizedAddresses), 1)
-			assert.Equal(t, sc.AuthorizedAddresses[0], wantAddr)
-			return true
-		},
-	)
-	assert.NilError(t, err)
-	// verify that the query was even ran. if for some reason there were no SignerComponents in the state,
-	// this test would still pass (false positive).
-	assert.Equal(t, count, 1)
 }

--- a/cardinal/ecs/persona_test.go
+++ b/cardinal/ecs/persona_test.go
@@ -1,6 +1,7 @@
 package ecs
 
 import (
+	"pkg.world.dev/world-engine/assert"
 	"testing"
 )
 
@@ -21,9 +22,7 @@ func TestIsAlphanumericWithUnderscore(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
 			result := isAlphanumericWithUnderscore(test.input)
-			if result != test.expected {
-				t.Errorf("Expected %v, but got %v", test.expected, result)
-			}
+			assert.Equal(t, result, test.expected)
 		})
 	}
 }

--- a/cardinal/ecs/persona_test.go
+++ b/cardinal/ecs/persona_test.go
@@ -20,7 +20,7 @@ func TestIsAlphanumericWithUnderscore(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.input, func(t *testing.T) {
-			result := IsAlphanumericWithUnderscore(test.input)
+			result := isAlphanumericWithUnderscore(test.input)
 			if result != test.expected {
 				t.Errorf("Expected %v, but got %v", test.expected, result)
 			}

--- a/cardinal/evm/server_test.go
+++ b/cardinal/evm/server_test.go
@@ -81,7 +81,7 @@ func TestServer_SendMessage(t *testing.T) {
 	})
 	assert.NilError(t, w.LoadGameState())
 
-	sender := "0xHelloThere"
+	sender := "0xd5e099c71b797516c10ed0f0d895f429c2781142"
 	personaTag := "foo"
 	// create authorized addresses for the evm transaction's msg sender.
 	ecs.CreatePersonaMsg.AddToQueue(w, ecs.CreatePersona{

--- a/cardinal/testutils/testutils.go
+++ b/cardinal/testutils/testutils.go
@@ -165,7 +165,7 @@ func UniqueSignatureWithName(name string) *sign.Transaction {
 }
 
 func UniqueSignature() *sign.Transaction {
-	return UniqueSignatureWithName("some-persona-tag")
+	return UniqueSignatureWithName("some_persona_tag")
 }
 
 func AddTransactionToWorldByAnyTransaction(

--- a/internal/nakama/testsuite_test.go
+++ b/internal/nakama/testsuite_test.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
-	"pkg.world.dev/world-engine/cardinal/ecs"
 	"strings"
 	"testing"
 	"time"
@@ -289,30 +288,6 @@ func TestPersonaTagFieldCannotBeEmpty(t *testing.T) {
 	})
 	assert.NilError(t, err)
 	assert.Equal(t, 400, resp.StatusCode, copyBody(resp))
-}
-
-func TestIsAlphanumericWithUnderscore(t *testing.T) {
-	tests := []struct {
-		input    string
-		expected bool
-	}{
-		{"abc123", true},
-		{"ABC_123", true},
-		{"123", true},
-		{"abc 123", false}, // contains a space
-		{"abc123 ", false}, // contains a trailing space
-		{"abc@123", false}, // contains a special character
-		{"", false},        // empty string
-	}
-
-	for _, test := range tests {
-		t.Run(test.input, func(t *testing.T) {
-			result := ecs.IsAlphanumericWithUnderscore(test.input)
-			if result != test.expected {
-				t.Errorf("Expected %v, but got %v", test.expected, result)
-			}
-		})
-	}
 }
 
 // waitForAcceptedPersonaTag periodically queries the show-persona endpoint until a previously claimed persona tag

--- a/internal/nakama/testsuite_test.go
+++ b/internal/nakama/testsuite_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"pkg.world.dev/world-engine/cardinal/ecs"
 	"strings"
 	"testing"
 	"time"
@@ -288,6 +289,30 @@ func TestPersonaTagFieldCannotBeEmpty(t *testing.T) {
 	})
 	assert.NilError(t, err)
 	assert.Equal(t, 400, resp.StatusCode, copyBody(resp))
+}
+
+func TestIsAlphanumericWithUnderscore(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected bool
+	}{
+		{"abc123", true},
+		{"ABC_123", true},
+		{"123", true},
+		{"abc 123", false}, // contains a space
+		{"abc123 ", false}, // contains a trailing space
+		{"abc@123", false}, // contains a special character
+		{"", false},        // empty string
+	}
+
+	for _, test := range tests {
+		t.Run(test.input, func(t *testing.T) {
+			result := ecs.IsAlphanumericWithUnderscore(test.input)
+			if result != test.expected {
+				t.Errorf("Expected %v, but got %v", test.expected, result)
+			}
+		})
+	}
 }
 
 // waitForAcceptedPersonaTag periodically queries the show-persona endpoint until a previously claimed persona tag


### PR DESCRIPTION
Closes: WORLD-613

## Overview

Add some extra validation around persona tags and eth addresses in the `RegisterPersonaSystem` and the `AuthorizePersonaSystem`

## Brief Changelog

- [x] Lowercase eth address
- [x] Trim eth address to check for spaces
- [x] Validate eth address is hex
- [x] Validate persona tag is alphanumeric
- [x] Validate persona tag against lowercase map of persona tags: user can submit case sensitive tag while checks happen in a case insensitive manner

## Testing and Verifying

- Added two tests in `persona_integration_test.go` to test that invalid persona tags and invalid eth addresses are not accepted.

