### PR TITLE
ci: improvement - golangci-lint cache & release image only when there are relevant file changes

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -24,12 +24,5 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: "**/*.sum"
-      - name: Find go path
-        id: go-dir
-        run: echo "path=$(go list -f '{{.Dir}}/...' -m | xargs)" >> $GITHUB_OUTPUT
-        ## Equivalent to 'make lint' arguments
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-        with:
-          version: v1.54.2
-          args: --timeout=10m --concurrency 8 -v ${{ steps.go-dir.outputs.path }}
+      - name: Make Lint
+        run: make lint

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -6,6 +6,10 @@ on:
   push:
     branches:
       - main
+
+permissions:
+  contents: read
+
 jobs:
   go-lint:
     name: Go
@@ -28,5 +32,9 @@ jobs:
           key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-golang-
-      - name: Make Lint
-        run: make lint
+      ## Equivalent to 'make lint' arguments
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: latest
+          args: --timeout=10m --concurrency 8 -v

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -30,5 +30,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: latest
+          version: v1.54.2
           args: --timeout=10m --concurrency 8 -v ${{ steps.go-dir.outputs.path }}

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -23,6 +23,7 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/*.sum"
       - name: Find go path
         id: go-dir
         run: echo "path=$(go list -f '{{.Dir}}/...' -m | xargs)" >> $GITHUB_OUTPUT

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -20,18 +20,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Cache Golang Deps
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            /home/runner/go
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golang-
       ## Equivalent to 'make lint' arguments
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -23,9 +23,12 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ env.GO_VERSION }}
-      ## Equivalent to 'make lint' arguments
+      - name: Find go path
+        id: go-dir
+        run: echo "path=$(go list -f '{{.Dir}}/...' -m | xargs)" >> $GITHUB_OUTPUT
+        ## Equivalent to 'make lint' arguments
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
           version: latest
-          args: --timeout=10m --concurrency 8 -v
+          args: --timeout=10m --concurrency 8 -v ${{ steps.go-dir.outputs.path }}

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -24,5 +24,12 @@ jobs:
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: "**/*.sum"
-      - name: Make Lint
-        run: make lint
+      - name: Find go path
+        id: go-dir
+        run: echo "path=$(go list -f '{{.Dir}}/...' -m | xargs)" >> $GITHUB_OUTPUT
+        ## Equivalent to 'make lint' arguments
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54.2
+          args: --timeout=10m --concurrency 8 -v ${{ steps.go-dir.outputs.path }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,9 +14,27 @@ env:
   REGISTRY_URL: us-docker.pkg.dev
 
 jobs:
+  dir-changes:
+    name: Check directory/path changes
+    runs-on: ubuntu-latest
+    outputs:
+      evm: ${{ steps.changes.outputs.evm }}
+      nakama: ${{ steps.changes.outputs.nakama }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - uses: dorny/paths-filter@v2
+      id: changes
+      with:
+        filters: |
+          evm:
+            - 'evm/**'
+          nakama:
+            - 'relay/nakama/**'
   evm-release:
     name: EVM Image Release
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/evm/v')
+    needs: dir-changes
+    if: (github.ref == 'refs/heads/main' && ${{ needs.dir-changes.outputs.evm == 'true' }}) || startsWith(github.ref, 'refs/tags/evm/v')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -67,7 +85,8 @@ jobs:
           docker push $IMAGE_ID_EVM:$VERSION
   nakama-release:
     name: Nakama Image Release
-    if: github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/relay/nakama/v')
+    needs: dir-changes
+    if: (github.ref == 'refs/heads/main' && ${{ needs.dir-changes.outputs.nakama == 'true' }}) || startsWith(github.ref, 'refs/tags/relay/nakama/v')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,8 @@ on:
     tags:
       - 'evm/v*.*.*'
       - 'relay/nakama/v*.*.*'
+  #test
+  pull_request:
 
 env:
   REGISTRY_URL: us-docker.pkg.dev
@@ -34,7 +36,7 @@ jobs:
   evm-release:
     name: EVM Image Release
     needs: dir-changes
-    if: (github.ref == 'refs/heads/main' && ${{ needs.dir-changes.outputs.evm == 'true' }}) || startsWith(github.ref, 'refs/tags/evm/v')
+    if: (${{ needs.dir-changes.outputs.evm == 'true' }}) || startsWith(github.ref, 'refs/tags/evm/v')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -86,7 +88,7 @@ jobs:
   nakama-release:
     name: Nakama Image Release
     needs: dir-changes
-    if: (github.ref == 'refs/heads/main' && ${{ needs.dir-changes.outputs.nakama == 'true' }}) || startsWith(github.ref, 'refs/tags/relay/nakama/v')
+    if: (${{ needs.dir-changes.outputs.nakama == 'true' }}) || startsWith(github.ref, 'refs/tags/relay/nakama/v')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,6 @@ on:
     tags:
       - 'evm/v*.*.*'
       - 'relay/nakama/v*.*.*'
-  #test
   pull_request:
 
 env:
@@ -36,7 +35,7 @@ jobs:
   evm-release:
     name: EVM Image Release
     needs: dir-changes
-    if: (needs.dir-changes.outputs.evm == 'true') || startsWith(github.ref, 'refs/tags/evm/v')
+    if: (github.ref == 'refs/heads/main' && needs.dir-changes.outputs.evm == 'true') || startsWith(github.ref, 'refs/tags/evm/v')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -88,7 +87,7 @@ jobs:
   nakama-release:
     name: Nakama Image Release
     needs: dir-changes
-    if: (needs.dir-changes.outputs.nakama == 'true') || startsWith(github.ref, 'refs/tags/relay/nakama/v')
+    if: (github.ref == 'refs/heads/main' && needs.dir-changes.outputs.nakama == 'true') || startsWith(github.ref, 'refs/tags/relay/nakama/v')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,7 +36,7 @@ jobs:
   evm-release:
     name: EVM Image Release
     needs: dir-changes
-    if: (${{ needs.dir-changes.outputs.evm == 'true' }}) || startsWith(github.ref, 'refs/tags/evm/v')
+    if: (needs.dir-changes.outputs.evm == 'true') || startsWith(github.ref, 'refs/tags/evm/v')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -88,7 +88,7 @@ jobs:
   nakama-release:
     name: Nakama Image Release
     needs: dir-changes
-    if: (${{ needs.dir-changes.outputs.nakama == 'true' }}) || startsWith(github.ref, 'refs/tags/relay/nakama/v')
+    if: (needs.dir-changes.outputs.nakama == 'true') || startsWith(github.ref, 'refs/tags/relay/nakama/v')
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
Closes: DEVOP-117 & DEVOP-137

## Overview

CI improvement.

## Brief Changelog

- Improve go lint caches dependency.
- EVM & Nakama container image release on the main branch will only be triggered if there are changes in the relevant directories.

## Testing and Verifying

- CI runs as intended

![image](https://github.com/Argus-Labs/world-engine/assets/29672212/a070ca44-f378-4df1-9c11-eb157006033b)

