### PR TITLE
docs(cardinal): Add persona tag section to docs

### DIFF
--- a/docs/pages/Cardinal/_meta.json
+++ b/docs/pages/Cardinal/_meta.json
@@ -13,5 +13,8 @@
   },
   "Cross_Shard_Communication": {
     "title": "Cross Shard Communication"
+  },
+  "persona-tags": {
+    "title": "Persona Tags"
   }
 }

--- a/docs/pages/Cardinal/persona-tags.mdx
+++ b/docs/pages/Cardinal/persona-tags.mdx
@@ -1,0 +1,52 @@
+# Persona Tags
+
+Persona Tags represents authorized actors that can manipulate your games state. State manipulation must be done via [Messages](/Cardinal/API-Reference/Messages). While a single Message represents an intention to manipulate the game state, the Message will only be processed by a System if the Message is signed. Signed messages are called "Transactions" and can be processed in your custom Systems. See [Getting Transactions](/Cardinal/API-Reference/Systems#getting-transactions) for more details on how to use Transactions.
+
+Your Cardinal instance will only process Transactions that have been signed by a Persona Tag that has been previously registered with your Cardinal instance. Registering a Persona Tag ensures other people or smart contracts cannot act on your behalf when interacting with the Cardinal backend.
+
+## ECS Integration
+
+Persona Tag management is automatically included with Cardinal games. A system (called AuthorizePersonaAddressSystem) is registered with your world on startup, and a MessageType (called AuthorizePersonaAddressMsg) is used to track new Persona Tag creation requests. This registration happens automatically so nothing extra needs to be done to start processing Persona Tag creation requests.
+
+While custom [MessageTypes](/Cardinal/API-Reference/Messages#newmessagetype) create Cardinal endpoints with the pattern `/tx/game/<message-name>`, the Persona Tag message creates a Cardinal endpoint of `/tx/persona/create-persona`. This endpoint is used to initially register Persona Tags with a Cardinal game.
+
+
+## Persona Tags in Systems
+
+Within a System, you can loop over transactions of a particular type (See [Getting Transactions](/Cardinal/API-Reference/Systems#getting-transactions)). These transactions (called [TxData](https://world.dev/Cardinal/API-Reference/Systems#txdata)) contain some fields.
+
+The `Msg` field is custom message data that you set up when you initially called NewMessageType.
+
+The `Tx` field contains signature information, including the Persona Tag that was used to sign the transaction.
+
+In this sample code, an "attack" message type is created, as well as a System that simply logs the Persona Tag of each incoming Attack message.
+
+```go
+type AttackInput struct {
+	// game specific field
+}
+
+type AttackOutput struct {
+	// game specific fields
+}
+
+var AttackMessage = cardinal.NewMessageType[AttackInput, AttackOutput]("attack")
+
+func AttackSystem(worldCtx cardinal.WorldContext) {
+	AttackMessage.Each(worldCtx, func(attack cardinal.TxData[AttackInput]) (AttackOutput, error) {
+		personaTag := attack.Tx().PersonaTag
+		worldCtx.Logger().Debug().Msgf("The persona tag is %q", personaTag)
+		return AttackOutput{}, nil
+	})
+}
+```
+
+## Nakama
+
+The easiest way to set up a Persona Tag with your cardinal game it to use Nakama. The `/nakama/claim-persona` RPC endpoint takes a request with a body of:
+
+```json
+{"personaTag": "the-persona-tag-you-want-to-claim"}
+```
+
+and registers that persona with your Cardinal backend. For more details about what Nakama is specifically doing under the hood, see the [Persona Tag](/Nakama/plugin#local-userid-to-personatag) section of the Nakama plugin documentation.

--- a/docs/pages/Cardinal/persona-tags.mdx
+++ b/docs/pages/Cardinal/persona-tags.mdx
@@ -42,7 +42,7 @@ func AttackSystem(worldCtx cardinal.WorldContext) {
 
 ## Nakama
 
-The easiest way to set up a Persona Tag with your cardinal game it to use the [Cardinal plugin for Nakama](Nakama/plugin). The `/nakama/claim-persona` RPC endpoint takes a request with a body of:
+The easiest way to set up a Persona Tag with your cardinal game it to use the [Cardinal plugin for Nakama](/Nakama/plugin). The `/nakama/claim-persona` RPC endpoint takes a request with a body of:
 
 ```json
 {"personaTag": "the-persona-tag-you-want-to-claim"}

--- a/docs/pages/Cardinal/persona-tags.mdx
+++ b/docs/pages/Cardinal/persona-tags.mdx
@@ -6,14 +6,13 @@ Your Cardinal instance will only process Transactions that have been signed by a
 
 ## ECS Integration
 
-Persona Tag management is automatically included with Cardinal games. A system (called AuthorizePersonaAddressSystem) is registered with your world on startup, and a MessageType (called AuthorizePersonaAddressMsg) is used to track new Persona Tag creation requests. This registration happens automatically so nothing extra needs to be done to start processing Persona Tag creation requests.
+Persona Tag management is automatically included with Cardinal games. A system (called RegisterPersonaSystem) is registered with your world on startup, and a MessageType (called CreatePersonaMsg) is used to track new Persona Tag creation requests. This registration happens automatically so nothing extra needs to be done to start processing Persona Tag creation requests.
 
 While custom [MessageTypes](/Cardinal/API-Reference/Messages#newmessagetype) create Cardinal endpoints with the pattern `/tx/game/<message-name>`, the Persona Tag message creates a Cardinal endpoint of `/tx/persona/create-persona`. This endpoint is used to initially register Persona Tags with a Cardinal game.
 
-
 ## Persona Tags in Systems
 
-Within a System, you can loop over transactions of a particular type (See [Getting Transactions](/Cardinal/API-Reference/Systems#getting-transactions)). These transactions (called [TxData](https://world.dev/Cardinal/API-Reference/Systems#txdata)) contain some fields.
+Within a System, you can loop over transactions of a particular type (See [Getting Transactions](/Cardinal/API-Reference/Systems#getting-transactions)). These transactions (called [TxData](/Cardinal/API-Reference/Systems#txdata)) contain some fields.
 
 The `Msg` field is custom message data that you set up when you initially called NewMessageType.
 
@@ -43,7 +42,7 @@ func AttackSystem(worldCtx cardinal.WorldContext) {
 
 ## Nakama
 
-The easiest way to set up a Persona Tag with your cardinal game it to use Nakama. The `/nakama/claim-persona` RPC endpoint takes a request with a body of:
+The easiest way to set up a Persona Tag with your cardinal game it to use the [Cardinal plugin for Nakama](Nakama/plugin). The `/nakama/claim-persona` RPC endpoint takes a request with a body of:
 
 ```json
 {"personaTag": "the-persona-tag-you-want-to-claim"}


### PR DESCRIPTION
Closes: WORLD-625
<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

Add a section to the Cardinal docs covering Persona Tag. 

There's also a section in the Nakama docs about Persona Tags, however that section focuses on how Nakama sends Persona Tag requests to Cardinal.


## Testing and Verifying

Doc changes only; no tests.