### PR TITLE
fix(evm): switch from cosmos logger to zerolog

### DIFF
--- a/evm/app/app.go
+++ b/evm/app/app.go
@@ -22,6 +22,7 @@ package app
 
 import (
 	"github.com/cometbft/cometbft/abci/types"
+	zerolog "github.com/rs/zerolog/log"
 	signinglib "pkg.berachain.dev/polaris/cosmos/lib/signing"
 	"pkg.berachain.dev/polaris/cosmos/runtime/miner"
 
@@ -219,23 +220,20 @@ func NewApp(
 func (app *App) preBlocker(ctx sdk.Context, _ *types.RequestFinalizeBlock) (*sdk.ResponsePreBlock, error) {
 	txs := app.ShardSequencer.FlushMessages()
 	numTxs := len(txs)
-	app.Logger().Debug("flushing game shard sequencer txs", "len_txs", numTxs)
+	zerolog.Debug().Msgf("flushed %d messages in PreBlocker", numTxs)
 	resPreBlock := &sdk.ResponsePreBlock{}
 	if numTxs > 0 {
-		app.Logger().Info("sequencing game shard txs")
+		zerolog.Debug().Msg("sequencing messages")
 		handler := app.MsgServiceRouter().Handler(txs[0])
 		for _, tx := range txs {
-			app.Logger().Debug("sequencing tx", "tx", tx.String())
+			zerolog.Debug().Msgf("sequencing tx %s", tx.String())
 			_, err := handler(ctx, tx)
 			if err != nil {
-				app.Logger().Error("error handling game shard tx",
-					"error", err.Error(),
-					"tx", tx.String(),
-				)
+				zerolog.Error().Err(err).Msgf("error sequencing game shard tx")
 				return resPreBlock, err
 			}
 		}
-		app.Logger().Debug("successfully sequenced game shard txs", "len_txs", numTxs)
+		zerolog.Debug().Msg("succesfully sequenced game shard txs")
 	}
 	return resPreBlock, nil
 }


### PR DESCRIPTION
## Overview

appication logger seemed to stop working.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
