### PR TITLE
fix(evm): injects faucet_addr

### DIFF
--- a/evm/app/app.go
+++ b/evm/app/app.go
@@ -233,7 +233,7 @@ func (app *App) preBlocker(ctx sdk.Context, _ *types.RequestFinalizeBlock) (*sdk
 				return resPreBlock, err
 			}
 		}
-		zerolog.Debug().Msg("succesfully sequenced game shard txs")
+		zerolog.Debug().Msg("successfully sequenced game shard txs")
 	}
 	return resPreBlock, nil
 }

--- a/evm/scripts/start-sequencer.sh
+++ b/evm/scripts/start-sequencer.sh
@@ -47,7 +47,7 @@ world-evm genesis collect-gentxs
 
 cp app.toml /root/.world-evm/config/app.toml
 
-sed -i'.bak' 's#"20f33ce90a13a4b5e7697e3544c3083b8f8a51d4"#"e66d1f367870950190fA3a07D36b26c187a2E578"#g' /root/.world-evm/config/genesis.json
+sed -i'.bak' "s#'20f33ce90a13a4b5e7697e3544c3083b8f8a51d4'#'$FAUCET_ADDR'#g" /root/.world-evm/config/genesis.json
 sed -i'.bak' 's#"0x1b1ae4d6e2ef500000"#"0x3fffffffffffffff0000000000000001"#g' /root/.world-evm/config/genesis.json
 
 # start the node.


### PR DESCRIPTION
## Overview

injects faucet addr

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
