### PR TITLE
chore: changelog

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -1,0 +1,52 @@
+<!--
+Guiding Principles:
+
+Changelogs are for humans, not machines.
+There should be an entry for every single version.
+The same types of changes should be grouped.
+Versions and sections should be linkable.
+The latest version comes first.
+The release date of each version is displayed.
+Mention whether you follow Semantic Versioning.
+
+Usage:
+
+Change log entries are to be added to the Unreleased section under the
+appropriate stanza (see below). Each entry is required to include a tag and
+the Github issue reference in the following format:
+
+* (<tag>) \#<issue-number> message
+
+The tag should consist of where the change is being made ex. (cardinal), (evm)
+The issue numbers will later be link-ified during the release process so you do
+not have to worry about including a link manually, but you can if you wish.
+
+Types of changes (Stanzas):
+
+"Features" for new features.
+"Improvements" for changes in existing functionality.
+"Deprecated" for soon-to-be removed features.
+"Bug Fixes" for any bug fixes.
+"Client Breaking" for breaking API routes, gRPC routes, or Cardinal SDK code.
+"API Breaking" for breaking exported APIs used by developers building on World Engine.
+"State Machine Breaking" for any changes that result in a different AppState given same genesis state and tx list.
+Ref: https://keepachangelog.com/en/1.0.0/
+-->
+
+# Changelog
+
+## [Unreleased]
+
+### Features
+
+### Improvements
+
+### Deprecated
+
+### Bug Fixes
+
+### Client Breaking
+
+### API Breaking
+
+### State Machine Breaking


### PR DESCRIPTION
## Overview

adds the changelog. @Argus-Labs/architects are expected to append to this when PR's that fall under any of the listed categories in the sections of the changelog.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
