### PR TITLE
refactor(nakama): Remove the info logs when a receipt is not delivered to a client

### DIFF
--- a/relay/nakama/dispatcher.go
+++ b/relay/nakama/dispatcher.go
@@ -46,7 +46,7 @@ func (r *receiptsDispatcher) subscribe(session string, ch receiptChan) {
 
 // dispatch continually drains r.ch (receipts from cardinal) and sends copies to all subscribed channels.
 // This function is meant to be called in a goroutine. Pushed receipts will not block when sending.
-func (r *receiptsDispatcher) dispatch(log runtime.Logger) {
+func (r *receiptsDispatcher) dispatch(_ runtime.Logger) {
 	for receipt := range r.ch {
 		r.m.Range(func(key, value any) bool {
 			ch, _ := value.(receiptChan)

--- a/relay/nakama/dispatcher.go
+++ b/relay/nakama/dispatcher.go
@@ -54,7 +54,6 @@ func (r *receiptsDispatcher) dispatch(log runtime.Logger) {
 			select {
 			case ch <- receipt:
 			default:
-				log.Info("failed to deliver a receipt to session %q", key)
 			}
 			return true
 		})


### PR DESCRIPTION

## Overview

Remove the spammy logs that report when a receipt is not delivered to a client.

Note: This could instead be made into a debug log instead of removing the log entirely.

## Testing and Verifying

Trivial change
