### PR TITLE
fix(relay): fill in missing errors and switch error -> debug for some

### DIFF
--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -261,7 +261,10 @@ func handleClaimPersona(ptv *personaTagVerifier, notifier *receiptNotifier) naka
 		// check if the user is verified. this requires them to input a valid beta key.
 		err = checkVerified(ctx, nk, userID)
 		if err != nil {
-			return logDebugWithMessageAndCode(logger, err, AlreadyExists, "unable to claim persona tag")
+			if eris.Is(eris.Cause(err), ErrNotAllowlisted) {
+				return logDebugWithMessageAndCode(logger, err, AlreadyExists, "unable to claim persona tag")
+			}
+			return logErrorMessageFailedPrecondition(logger, err, "unable to claim persona tag")
 		}
 
 		ptr := &personaTagStorageObj{}

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -261,7 +261,7 @@ func handleClaimPersona(ptv *personaTagVerifier, notifier *receiptNotifier) naka
 		// check if the user is verified. this requires them to input a valid beta key.
 		err = checkVerified(ctx, nk, userID)
 		if err != nil {
-			return logErrorWithMessageAndCode(logger, err, AlreadyExists, "unable to claim persona tag")
+			return logDebugWithMessageAndCode(logger, err, AlreadyExists, "unable to claim persona tag")
 		}
 
 		ptr := &personaTagStorageObj{}
@@ -460,6 +460,17 @@ func initCardinalEndpoints(logger runtime.Logger, initializer runtime.Initialize
 	return nil
 }
 
+func logDebugWithMessageAndCode(
+	logger runtime.Logger,
+	err error,
+	code int,
+	format string,
+	v ...interface{},
+) (string, error) {
+	err = eris.Wrapf(err, format, v...)
+	return logDebug(logger, err, code)
+}
+
 func logErrorWithMessageAndCode(
 	logger runtime.Logger,
 	err error,
@@ -480,6 +491,15 @@ func logErrorMessageFailedPrecondition(
 	return logErrorFailedPrecondition(logger, err)
 }
 
+func logDebug(
+	logger runtime.Logger,
+	err error,
+	code int,
+) (string, error) {
+	logger.Debug(eris.ToString(err, true))
+	return "", errToNakamaError(err, code)
+}
+
 func logError(
 	logger runtime.Logger,
 	err error,
@@ -494,13 +514,11 @@ func logErrorFailedPrecondition(
 	return logError(logger, err, FailedPrecondition)
 }
 
-func errToNakamaError(
-	err error,
-	code int) error {
+func errToNakamaError(err error, code int) error {
 	if DebugEnabled {
 		return runtime.NewError(eris.ToString(err, true), code)
 	}
-	return runtime.NewError(eris.Errorf("error: %v", err).Error(), code)
+	return runtime.NewError(err.Error(), code)
 }
 
 // setPersonaTagAssignment attempts to associate a given persona tag with the given user ID, and returns

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -518,10 +518,13 @@ func logErrorFailedPrecondition(
 }
 
 func errToNakamaError(err error, code int) error {
-	if DebugEnabled {
-		return runtime.NewError(eris.ToString(err, true), code)
+	if err != nil {
+		if DebugEnabled {
+			return runtime.NewError(eris.ToString(err, true), code)
+		}
+		return runtime.NewError(err.Error(), code)
 	}
-	return runtime.NewError(err.Error(), code)
+	return nil
 }
 
 // setPersonaTagAssignment attempts to associate a given persona tag with the given user ID, and returns

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -369,7 +369,7 @@ func handleShowPersona(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk
 // initCardinalEndpoints queries the cardinal server to find the list of existing endpoints, and attempts to
 // set up RPC wrappers around each one.
 //
-//nolint:gocognit
+//nolint:gocognit,funlen // its fine.
 func initCardinalEndpoints(logger runtime.Logger, initializer runtime.Initializer, notify *receiptNotifier) error {
 	txEndpoints, queryEndpoints, err := getCardinalEndpoints()
 	if err != nil {
@@ -439,7 +439,7 @@ func initCardinalEndpoints(logger runtime.Logger, initializer runtime.Initialize
 					}
 					return logErrorMessageFailedPrecondition(
 						logger,
-						eris.Errorf("bad status code %d", resp.Status),
+						eris.Errorf("bad status code %d", resp.StatusCode),
 						"bad status code: %s: %s", resp.Status, body,
 					)
 				}


### PR DESCRIPTION
## Overview

switches the log level to debug for ErrNotAllowListed in ClaimPersona RPC.

additionally fixes a bunch of issues where we may have been attempting to return nil errors. this should fix issues where clients were seeing the error message set to "0065nil0065" or something to that effect.


## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
