### PR TITLE
fix(cardinal): Use a redis set to keep track of which nonces were used

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -41,7 +41,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
-- Instead of making sure nonce values are strictly increasing, use a Redis set to track every used nonce.
+- (cardinal) #WORLD-643: Instead of making sure nonce values are strictly increasing, use a Redis set to track every used nonce.
 
 ### Deprecated
 

--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -41,6 +41,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+- Instead of making sure nonce values are strictly increasing, use a Redis set to track every used nonce.
+
 ### Deprecated
 
 ### Bug Fixes

--- a/cardinal/ecs/storage/redis/keys.go
+++ b/cardinal/ecs/storage/redis/keys.go
@@ -1,12 +1,14 @@
 package redis
 
+import "fmt"
+
 /*
 	NONCE STORAGE:      ADDRESS_TO_NONCE -> Nonce used for verifying signatures.
 	Hash set of signature address to uint64 nonce
 */
 
-func (r *NonceStorage) nonceKey() string {
-	return "ADDRESS_TO_NONCE"
+func (r *NonceStorage) nonceSetKey(str string) string {
+	return fmt.Sprintf("USED_NONCES_%s", str)
 }
 
 func (r *SchemaStorage) schemaStorageKey() string {

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -838,12 +838,8 @@ func (w *World) getMessage(id message.TypeID) message.Message {
 	return nil
 }
 
-func (w *World) GetNonce(signerAddress string) (uint64, error) {
-	return w.redisStorage.Nonce.GetNonce(signerAddress)
-}
-
-func (w *World) SetNonce(signerAddress string, nonce uint64) error {
-	return w.redisStorage.Nonce.SetNonce(signerAddress, nonce)
+func (w *World) UseNonce(signerAddress string, nonce uint64) error {
+	return w.redisStorage.Nonce.UseNonce(signerAddress, nonce)
 }
 
 func (w *World) AddMessageError(id message.TxHash, err error) {


### PR DESCRIPTION

## Overview

Nakama can send in a series of correctly-signed transactions, but still have some of them fail. Cardinal verifies that nonce values are used at most once by making sure each nonce value is strictly bigger than the last accepted nonce. If network hiccups cause the transaction requests to come in out of order, Cardinal will reject a transaction because the nonce is too small.

This fix uses a redis set to keep track of every seen nonce. This has storage implications; every transactions that will come in  will take up some memory in redis.

Since we launched we've processed about 151134 transactions (that's the current nonce value). If we call that 160,000 transactions, and we want DF to run for 2 weeks, that's approximately 2,240,000 nonces.

**Caveats**
[This redis FAQ](https://redis.io/docs/get-started/faq/) says 1 million small keys takes up about 85 Mb of space, so 2 million keys will take up 170 Mb.

Later in the FAQ we see "Redis can handle up to 2^32 keys, and was tested in practice to handle at least 250 million keys per instance.".

In addition, this change effectively wipes out all nonce memory, so previously submitted transactions can be re-submitted, and Cardinal would accept them.

## Testing and Verifying

Unit tests added.