### PR TITLE
refactor(nakama): Better logging for beta key claiming and verification

### DIFF
--- a/relay/nakama/allowlist.go
+++ b/relay/nakama/allowlist.go
@@ -146,7 +146,7 @@ func claimKeyRPC(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk runti
 	// if this user is already verified,
 	err = checkVerified(ctx, nk, userID)
 	if err == nil {
-		msg := fmt.Sprintf("user %q already verifiedeith beta key", userID)
+		msg := fmt.Sprintf("user %q already verified with a beta key", userID)
 		return logErrorWithMessageAndCode(logger, ErrAlreadyVerified, AlreadyExists, msg)
 	}
 

--- a/relay/nakama/allowlist.go
+++ b/relay/nakama/allowlist.go
@@ -146,7 +146,8 @@ func claimKeyRPC(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk runti
 	// if this user is already verified,
 	err = checkVerified(ctx, nk, userID)
 	if err == nil {
-		return logErrorWithMessageAndCode(logger, err, AlreadyExists, "user already verified with beta key")
+		msg := fmt.Sprintf("user %q already verifiedeith beta key", userID)
+		return logErrorWithMessageAndCode(logger, ErrAlreadyVerified, AlreadyExists, msg)
 	}
 
 	var ck ClaimKeyMsg
@@ -276,7 +277,7 @@ func claimKey(ctx context.Context, nk runtime.NakamaModule, key, userID string) 
 		return err
 	}
 	if ks.Used {
-		return eris.Wrap(ErrBetaKeyAlreadyUsed, "")
+		return eris.Wrapf(ErrBetaKeyAlreadyUsed, "user %q was unable to claim %q", userID, key)
 	}
 	ks.Used = true
 	ks.UsedBy = userID


### PR DESCRIPTION


## Overview

1) When a user tries to claim a beta key that is already used, log the user and beta key
2) When a user tries to claim a beta key, but they've already claimed a beta key, include a non-nil error so the resulting logs have more details.

## Testing and Verifying

Logging changes only