### PR TITLE
chore(cardinal): Brian/add higher res logs for redis io flush

### DIFF
--- a/cardinal/ecs/ecb/tick.go
+++ b/cardinal/ecs/ecb/tick.go
@@ -72,7 +72,7 @@ func (m *Manager) FinalizeTick() error {
 	flushStartTime := time.Now()
 	_, err = pipe.Exec(ctx)
 	elapsedTime := time.Since(flushStartTime)
-	m.logger.Logger.Info().Int("flush_time", int(elapsedTime.Milliseconds()))
+	m.logger.Logger.Info().Int("flush_time", int(elapsedTime.Milliseconds())).Msg("redis_flush")
 	return eris.Wrap(err, "")
 }
 

--- a/cardinal/ecs/ecb/tick.go
+++ b/cardinal/ecs/ecb/tick.go
@@ -72,7 +72,7 @@ func (m *Manager) FinalizeTick() error {
 	flushStartTime := time.Now()
 	_, err = pipe.Exec(ctx)
 	elapsedTime := time.Since(flushStartTime)
-	m.logger.Logger.Info().Int("flush_time", int(elapsedTime.Milliseconds())).Msg("redis_flush")
+	m.logger.Logger.Debug().Int("flush_time_ms", int(elapsedTime.Milliseconds())).Msg("redis_flush")
 	return eris.Wrap(err, "")
 }
 

--- a/cardinal/ecs/ecb/tick.go
+++ b/cardinal/ecs/ecb/tick.go
@@ -2,6 +2,7 @@ package ecb
 
 import (
 	"context"
+	"time"
 
 	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-engine/cardinal/txpool"
@@ -68,7 +69,10 @@ func (m *Manager) FinalizeTick() error {
 	if err = pipe.Incr(context.Background(), redisEndTickKey()).Err(); err != nil {
 		return eris.Wrap(err, "")
 	}
+	flushStartTime := time.Now()
 	_, err = pipe.Exec(ctx)
+	elapsedTime := time.Since(flushStartTime)
+	m.logger.Logger.Info().Int("flush_time", int(elapsedTime.Milliseconds()))
 	return eris.Wrap(err, "")
 }
 

--- a/cardinal/ecs/log/log_test.go
+++ b/cardinal/ecs/log/log_test.go
@@ -220,7 +220,7 @@ func TestWorldLogger(t *testing.T) {
 	json1 := []byte(`{
 				 "level":"info",
 				 "tick":"0",
-				 "tick_execution_time": 0, 
+				 "tick_execution_time_ms": 0, 
 				 "message":"tick ended"
 			 }`)
 	json1 = sanitizedJSON(json1)
@@ -230,7 +230,7 @@ func TestWorldLogger(t *testing.T) {
 	if err = json.Unmarshal([]byte(logStrings[5]), &map2); err != nil {
 		t.Fatalf("Error unmarshalling buf: %v", err)
 	}
-	names := []string{"level", "tick", "tick_execution_time", "message"}
+	names := []string{"level", "tick", "tick_execution_time_ms", "message"}
 	for _, name := range names {
 		v1, ok := expectedMap[name]
 		if !ok {
@@ -241,7 +241,7 @@ func TestWorldLogger(t *testing.T) {
 			t.Errorf("Should be a value in %s", name)
 		}
 		// time is not deterministic in the context of unit tests, therefore it is not unit testable.
-		if name != "tick_execution_time" {
+		if name != "tick_execution_time_ms" {
 			assert.Equal(t, v1, v2)
 		}
 	}

--- a/cardinal/ecs/log/log_test.go
+++ b/cardinal/ecs/log/log_test.go
@@ -177,7 +177,7 @@ func TestWorldLogger(t *testing.T) {
 	// testing output of logging a tick. Should log the system log and tick start and end strings.
 	err = w.Tick(ctx)
 	assert.NilError(t, err)
-	logStrings = strings.Split(buf.String(), "\n")[:5]
+	logStrings = strings.Split(buf.String(), "\n")[:6]
 	// test tick start
 	require.JSONEq(
 		t, `
@@ -227,7 +227,7 @@ func TestWorldLogger(t *testing.T) {
 	if err = json.Unmarshal(json1, &expectedMap); err != nil {
 		t.Fatalf("Error unmarshalling json1: %v", err)
 	}
-	if err = json.Unmarshal([]byte(logStrings[4]), &map2); err != nil {
+	if err = json.Unmarshal([]byte(logStrings[5]), &map2); err != nil {
 		t.Fatalf("Error unmarshalling buf: %v", err)
 	}
 	names := []string{"level", "tick", "tick_execution_time", "message"}

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -481,11 +481,11 @@ func (w *World) Tick(_ context.Context) error {
 		// world can be optionally loaded with or without an eventHub. If there is one, on every tick it must flush events.
 		w.eventHub.FlushEvents()
 	}
-	flushStartTime := time.Now()
+	finalizeTickStartTime := time.Now()
 	if err := w.TickStore().FinalizeTick(); err != nil {
 		return err
 	}
-	flushElapsedTime := time.Since(flushStartTime)
+	finalizeTickElapsedTime := time.Since(finalizeTickStartTime)
 
 	w.setEvmResults(txQueue.GetEVMTxs())
 	w.tick.Add(1)
@@ -496,7 +496,7 @@ func (w *World) Tick(_ context.Context) error {
 		w.Logger.Warn().Msg(fmt.Sprintf(", (warning: tick exceeded %dms)", warningThreshold.Milliseconds()))
 	}
 	event := w.Logger.Info().
-		Int("flush_time", int(flushElapsedTime.Milliseconds())).
+		Int("finalize_tick_time", int(finalizeTickElapsedTime.Milliseconds())).
 		Int("tick_execution_time", int(elapsedTime.Milliseconds())).
 		Str("tick", tickAsString)
 	for systemName, milliseconds := range systemTiming {

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -496,11 +496,11 @@ func (w *World) Tick(_ context.Context) error {
 		w.Logger.Warn().Msg(fmt.Sprintf(", (warning: tick exceeded %dms)", warningThreshold.Milliseconds()))
 	}
 	event := w.Logger.Info().
-		Int("finalize_tick_time", int(finalizeTickElapsedTime.Milliseconds())).
-		Int("tick_execution_time", int(elapsedTime.Milliseconds())).
+		Int("finalize_tick_time_ms", int(finalizeTickElapsedTime.Milliseconds())).
+		Int("tick_execution_time_ms", int(elapsedTime.Milliseconds())).
 		Str("tick", tickAsString)
 	for systemName, milliseconds := range systemTiming {
-		event.Int("execution_time_of_"+systemName, milliseconds)
+		event.Int("ms_execution_time_of_"+systemName, milliseconds)
 	}
 	event.Int("txs_amount", txQueue.GetAmountOfTxs())
 	event.Msg("tick ended")


### PR DESCRIPTION
Doesn't close any ticket. 

Changes the logging a bit to add higher resolution timing measurement to the flush of the tick to redis. FinalizeTick does some extra stuff like json deserialization. I want to take that out of the equation. 