### PR TITLE
fix(nakama): Reject a claim persona request when cardinal says the persona tag is …

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -47,6 +47,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+- (nakama) #WORLD-643: Reject a persona tag request if it seems like cardinal didn't actually get the corresponding transaction.
+
 ### Client Breaking
 
 ### API Breaking

--- a/internal/nakama/testsuite_test.go
+++ b/internal/nakama/testsuite_test.go
@@ -7,15 +7,13 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
 
-	"strconv"
-
-	"pkg.world.dev/world-engine/assert"
-
 	"github.com/ethereum/go-ethereum/crypto"
+	"pkg.world.dev/world-engine/assert"
 )
 
 func TestEvents(t *testing.T) {
@@ -288,6 +286,40 @@ func TestPersonaTagFieldCannotBeEmpty(t *testing.T) {
 	})
 	assert.NilError(t, err)
 	assert.Equal(t, 400, resp.StatusCode, copyBody(resp))
+}
+
+func TestPersonaTagsShouldBeCaseInsensitive(t *testing.T) {
+	clientA, clientB := newClient(t), newClient(t)
+	userA, userB := randomString(), randomString()
+
+	assert.NilError(t, clientA.registerDevice(userA, userA))
+	assert.NilError(t, clientB.registerDevice(userB, userB))
+
+	lowerCase := "bbbb"
+	upperCase := "BBBB"
+	_, err := clientA.rpc("nakama/claim-persona", map[string]any{
+		"personaTag": lowerCase,
+	})
+	assert.NilError(t, err)
+	_, err = clientB.rpc("nakama/claim-persona", map[string]any{
+		"personaTag": upperCase,
+	})
+	assert.NilError(t, err)
+
+	waitForAcceptedPersonaTag(clientA)
+
+	respA, err := clientA.rpc("nakama/show-persona", nil)
+	assert.NilError(t, err)
+	respB, err := clientB.rpc("nakama/show-persona", nil)
+	assert.NilError(t, err)
+
+	showA := map[string]any{}
+	showB := map[string]any{}
+	assert.NilError(t, json.NewDecoder(respA.Body).Decode(&showA))
+	assert.NilError(t, json.NewDecoder(respB.Body).Decode(&showB))
+
+	assert.Equal(t, showA["status"], "accepted")
+	assert.Equal(t, showB["status"], "rejected")
 }
 
 // waitForAcceptedPersonaTag periodically queries the show-persona endpoint until a previously claimed persona tag

--- a/internal/nakama/testsuite_test.go
+++ b/internal/nakama/testsuite_test.go
@@ -306,7 +306,7 @@ func TestPersonaTagsShouldBeCaseInsensitive(t *testing.T) {
 	})
 	assert.NilError(t, err)
 
-	waitForAcceptedPersonaTag(clientA)
+	assert.NilError(t, waitForAcceptedPersonaTag(clientA))
 
 	respA, err := clientA.rpc("nakama/show-persona", nil)
 	assert.NilError(t, err)

--- a/relay/nakama/persona_tag_storage.go
+++ b/relay/nakama/persona_tag_storage.go
@@ -81,13 +81,19 @@ func (p *personaTagStorageObj) attemptToUpdatePending(ctx context.Context, nk ru
 	if eris.Is(eris.Cause(err), ErrPersonaSignerUnknown) {
 		// Leave the Status as pending.
 		return p, nil
-	} else if err != nil {
-		return nil, err
-	}
-	if verified {
-		p.Status = personaTagStatusAccepted
-	} else {
+	} else if eris.Is(eris.Cause(err), ErrPersonaSignerAvailable) {
+		// Somehow Nakama thinks this persona tag belongs to this user, but Cardinal doesn't think the persona tag
+		// belongs to anyone. Just reject this on Nakama's end so the user can try a different persona tag.
+		// Incidentally, trying the same persona tag might work.
 		p.Status = personaTagStatusRejected
+	} else if err != nil {
+		return nil, eris.Wrap(err, "error when verifying persona tag; user may be stuck in pending")
+	} else {
+		if verified {
+			p.Status = personaTagStatusAccepted
+		} else {
+			p.Status = personaTagStatusRejected
+		}
 	}
 	// Attempt to save the updated Status to Nakama. One reason this can fail is that the underlying record was
 	// updated while this processing was going on. Whatever the reason, re-fetch this record from Nakama's storage.

--- a/relay/nakama/persona_tag_storage.go
+++ b/relay/nakama/persona_tag_storage.go
@@ -78,17 +78,18 @@ func (p *personaTagStorageObj) attemptToUpdatePending(ctx context.Context, nk ru
 	}
 
 	verified, err := p.verifyPersonaTag(ctx)
-	if eris.Is(eris.Cause(err), ErrPersonaSignerUnknown) {
+	switch {
+	case eris.Is(eris.Cause(err), ErrPersonaSignerUnknown):
 		// Leave the Status as pending.
 		return p, nil
-	} else if eris.Is(eris.Cause(err), ErrPersonaSignerAvailable) {
+	case eris.Is(eris.Cause(err), ErrPersonaSignerAvailable):
 		// Somehow Nakama thinks this persona tag belongs to this user, but Cardinal doesn't think the persona tag
 		// belongs to anyone. Just reject this on Nakama's end so the user can try a different persona tag.
 		// Incidentally, trying the same persona tag might work.
 		p.Status = personaTagStatusRejected
-	} else if err != nil {
+	case err != nil:
 		return nil, eris.Wrap(err, "error when verifying persona tag; user may be stuck in pending")
-	} else {
+	default:
 		if verified {
 			p.Status = personaTagStatusAccepted
 		} else {


### PR DESCRIPTION
…"available"

Related to: WORLD-643

## Overview

If nakama has a user's claim persona request in a pending state, but cardinal (somehow) never got the transaction to claim the persona, cardinal will report that the given persona tag is "available".

In the CURRENT state of the code, Nakama only check to see if the call to cardinal is "unknown", meaning cardinal has not yet had a chance to process the claim persona tag transactions. If cardinal responds with "available", Nakama treats that as an error, and does not update the status on the Nakama side. Cardinal will forever report "available" and Nakama will forever leave the persona tag as "pending".

This PR changes the Nakama code to treat "available" as a persona tag rejection. Somehow, cardinal never got the persona tag request. By moving the claim to "rejected" on Nakama's end, this will allow the user to pick a new persona tag. The flow should be similar to when a user picks a persona tag that has already been claimed by someone else.

The bad news is: I don't know why Nakama would have a persona tag in the state of "pending" without cardinal also getting the create persona tag request (and either accepting or rejecting it).

At the very least, this PR will 1) give is more information when someone locked in a "pending" state,  2) unlock any account that is still stuck in a pending state 3) prevent future accounts from getting locked in this pending state.

1 way I KNOW a user can get locked into this state is by trying to claim a persona tag that is an upper/lower cased version of some other claimed persona tag. I don't think this is what's goin on in prod though because the client forces everyone's persona tags to be upper cased. 

## Testing and Verifying

Added a unit test to test the claiming of differently-cased persona tags.

