### PR TITLE
fix(nakama): Return an non-nil error when a given beta key is empty

### DIFF
--- a/relay/nakama/allowlist.go
+++ b/relay/nakama/allowlist.go
@@ -156,7 +156,7 @@ func claimKeyRPC(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk runti
 		return logErrorWithMessageAndCode(logger, err, InvalidArgument, "unable to unmarshal payload: %v", err)
 	}
 	if ck.Key == "" {
-		return logErrorWithMessageAndCode(logger, err, InvalidArgument, "no key provided in request")
+		return logErrorWithMessageAndCode(logger, ErrInvalidBetaKey, InvalidArgument, "no key provided in request")
 	}
 	ck.Key = strings.ToUpper(ck.Key)
 	err = claimKey(ctx, nk, ck.Key, userID)


### PR DESCRIPTION
Closes: WORLD-656

## Overview

When an empty beta key is used, return an error (instead of a nil error).

## Testing and Verifying

Trivial change
