### PR TITLE
perf(cardinal): Log tick timing information into a single log line

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -43,6 +43,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Improvements
 
+- (cardinal) #WORLD-668: Log tick timing information into a single log line.
 - (cardinal) #WORLD-643: Instead of making sure nonce values are strictly increasing, use a Redis set to track every used nonce.
 
 ### Deprecated

--- a/cardinal/ecs/ecb/tick.go
+++ b/cardinal/ecs/ecb/tick.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/rotisserie/eris"
+	"github.com/rs/zerolog"
 	"pkg.world.dev/world-engine/cardinal/txpool"
 	"pkg.world.dev/world-engine/cardinal/types/message"
 
@@ -60,19 +61,20 @@ func (m *Manager) StartNextTick(txs []message.Message, queue *txpool.TxQueue) er
 
 // FinalizeTick combines all pending state changes into a single multi/exec redis transactions and commits them
 // to the DB.
-func (m *Manager) FinalizeTick() error {
+func (m *Manager) FinalizeTick(event *zerolog.Event) error {
 	ctx := context.Background()
+	startRedisPipe := time.Now()
 	pipe, err := m.makePipeOfRedisCommands(ctx)
 	if err != nil {
 		return err
 	}
+	event.Int("make_pipe_time_ms", int(time.Since(startRedisPipe).Milliseconds()))
 	if err = pipe.Incr(context.Background(), redisEndTickKey()).Err(); err != nil {
 		return eris.Wrap(err, "")
 	}
 	flushStartTime := time.Now()
 	_, err = pipe.Exec(ctx)
-	elapsedTime := time.Since(flushStartTime)
-	m.logger.Logger.Debug().Int("flush_time_ms", int(elapsedTime.Milliseconds())).Msg("redis_flush")
+	event.Int("exec_pipe_time_ms", int(time.Since(flushStartTime).Milliseconds()))
 	return eris.Wrap(err, "")
 }
 

--- a/cardinal/ecs/ecb/tick_test.go
+++ b/cardinal/ecs/ecb/tick_test.go
@@ -41,7 +41,7 @@ func TestCanSaveAndRecoverTransactions(t *testing.T) {
 
 	// Make sure we can finalize the tick
 	assert.NilError(t, manager.StartNextTick(msgs, gotQueue))
-	assert.NilError(t, manager.FinalizeTick())
+	assert.NilError(t, manager.FinalizeTick(nil))
 }
 
 func TestErrorWhenRecoveringNoTransactions(t *testing.T) {

--- a/cardinal/ecs/log/log_test.go
+++ b/cardinal/ecs/log/log_test.go
@@ -220,17 +220,19 @@ func TestWorldLogger(t *testing.T) {
 	json1 := []byte(`{
 				 "level":"info",
 				 "tick":"0",
-				 "tick_execution_time_ms": 0, 
-				 "message":"tick ended"
+				 "tick_execution_time_ms": 0,
+                 "make_pipe_time_ms": 0,
+				 "exec_pipe_time_ms": 0,
+				 "message":"tick_ended"
 			 }`)
 	json1 = sanitizedJSON(json1)
 	if err = json.Unmarshal(json1, &expectedMap); err != nil {
 		t.Fatalf("Error unmarshalling json1: %v", err)
 	}
-	if err = json.Unmarshal([]byte(logStrings[5]), &map2); err != nil {
+	if err = json.Unmarshal([]byte(logStrings[4]), &map2); err != nil {
 		t.Fatalf("Error unmarshalling buf: %v", err)
 	}
-	names := []string{"level", "tick", "tick_execution_time_ms", "message"}
+	names := []string{"level", "tick", "tick_execution_time_ms", "message", "make_pipe_time_ms", "exec_pipe_time_ms"}
 	for _, name := range names {
 		v1, ok := expectedMap[name]
 		if !ok {

--- a/cardinal/ecs/store/iface.go
+++ b/cardinal/ecs/store/iface.go
@@ -3,6 +3,7 @@ package store
 import (
 	"encoding/json"
 
+	"github.com/rs/zerolog"
 	"pkg.world.dev/world-engine/cardinal/txpool"
 	"pkg.world.dev/world-engine/cardinal/types/message"
 
@@ -56,7 +57,7 @@ type Writer interface {
 type TickStorage interface {
 	GetTickNumbers() (start, end uint64, err error)
 	StartNextTick(txs []message.Message, queues *txpool.TxQueue) error
-	FinalizeTick() error
+	FinalizeTick(event *zerolog.Event) error
 	Recover(txs []message.Message) (*txpool.TxQueue, error)
 }
 

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -481,8 +481,9 @@ func (w *World) Tick(_ context.Context) error {
 		// world can be optionally loaded with or without an eventHub. If there is one, on every tick it must flush events.
 		w.eventHub.FlushEvents()
 	}
+	event := w.Logger.Info()
 	finalizeTickStartTime := time.Now()
-	if err := w.TickStore().FinalizeTick(); err != nil {
+	if err := w.TickStore().FinalizeTick(event); err != nil {
 		return err
 	}
 	finalizeTickElapsedTime := time.Since(finalizeTickStartTime)
@@ -495,15 +496,14 @@ func (w *World) Tick(_ context.Context) error {
 	if elapsedTime > warningThreshold {
 		w.Logger.Warn().Msg(fmt.Sprintf(", (warning: tick exceeded %dms)", warningThreshold.Milliseconds()))
 	}
-	event := w.Logger.Info().
-		Int("finalize_tick_time_ms", int(finalizeTickElapsedTime.Milliseconds())).
+	event.Int("finalize_tick_time_ms", int(finalizeTickElapsedTime.Milliseconds())).
 		Int("tick_execution_time_ms", int(elapsedTime.Milliseconds())).
 		Str("tick", tickAsString)
 	for systemName, milliseconds := range systemTiming {
 		event.Int("ms_execution_time_of_"+systemName, milliseconds)
 	}
 	event.Int("txs_amount", txQueue.GetAmountOfTxs())
-	event.Msg("tick ended")
+	event.Msg("tick_ended")
 	return nil
 }
 


### PR DESCRIPTION
Closes: WORLD-668

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

Use a zerolog.Event to log tick timing information into a single log line.

Really, this timing information should be exported using a statsd metric, and not a log line, but custom metrics aren't yet set up for cardinal. See: See WORLD-669 and WORLD-671.

## Testing and Verifying

Updated unit tests
