### PR TITLE
feat(evm): namespace registration and querying precompile 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,5 @@ jobs:
       #   uses: ScribeMD/docker-cache@0.3.4
       #   with:
       #     key: docker-${{ runner.os }}-${{ hashFiles('evm/Dockerfile') }}
-      - name: Forge Build evm/contracts
-        run: make forge-build
       - name: Build Rollup
         run: make rollup-build

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -236,7 +236,6 @@ linters:
     - goconst # finds repeated strings that could be replaced by a constant
     - gocritic # provides diagnostics that check for bugs, performance and style issues
     - gocyclo # computes and checks the cyclomatic complexity of functions
-    - godot # checks if comments end in a period
     - goheader # checks is file header matches to pattern
     # - goimports # in addition to fixing imports, goimports also formats your code in the same style as gofmt
     - gomnd # detects magic numbers

--- a/evm/precompile/contracts/bindings/cosmos/precompile/namespace/INamespace.abigen.go
+++ b/evm/precompile/contracts/bindings/cosmos/precompile/namespace/INamespace.abigen.go
@@ -1,0 +1,233 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package namespace
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+// Reference imports to suppress errors if they are not otherwise used.
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+	_ = abi.ConvertType
+)
+
+// NamespaceMetaData contains all meta data concerning the Namespace contract.
+var NamespaceMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"string\",\"name\":\"namespace\",\"type\":\"string\"}],\"name\":\"addressForNamespace\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"string\",\"name\":\"namespace\",\"type\":\"string\"},{\"internalType\":\"string\",\"name\":\"gRPCAddress\",\"type\":\"string\"}],\"name\":\"register\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+}
+
+// NamespaceABI is the input ABI used to generate the binding from.
+// Deprecated: Use NamespaceMetaData.ABI instead.
+var NamespaceABI = NamespaceMetaData.ABI
+
+// Namespace is an auto generated Go binding around an Ethereum contract.
+type Namespace struct {
+	NamespaceCaller     // Read-only binding to the contract
+	NamespaceTransactor // Write-only binding to the contract
+	NamespaceFilterer   // Log filterer for contract events
+}
+
+// NamespaceCaller is an auto generated read-only Go binding around an Ethereum contract.
+type NamespaceCaller struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// NamespaceTransactor is an auto generated write-only Go binding around an Ethereum contract.
+type NamespaceTransactor struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// NamespaceFilterer is an auto generated log filtering Go binding around an Ethereum contract events.
+type NamespaceFilterer struct {
+	contract *bind.BoundContract // Generic contract wrapper for the low level calls
+}
+
+// NamespaceSession is an auto generated Go binding around an Ethereum contract,
+// with pre-set call and transact options.
+type NamespaceSession struct {
+	Contract     *Namespace        // Generic contract binding to set the session for
+	CallOpts     bind.CallOpts     // Call options to use throughout this session
+	TransactOpts bind.TransactOpts // Transaction auth options to use throughout this session
+}
+
+// NamespaceCallerSession is an auto generated read-only Go binding around an Ethereum contract,
+// with pre-set call options.
+type NamespaceCallerSession struct {
+	Contract *NamespaceCaller // Generic contract caller binding to set the session for
+	CallOpts bind.CallOpts    // Call options to use throughout this session
+}
+
+// NamespaceTransactorSession is an auto generated write-only Go binding around an Ethereum contract,
+// with pre-set transact options.
+type NamespaceTransactorSession struct {
+	Contract     *NamespaceTransactor // Generic contract transactor binding to set the session for
+	TransactOpts bind.TransactOpts    // Transaction auth options to use throughout this session
+}
+
+// NamespaceRaw is an auto generated low-level Go binding around an Ethereum contract.
+type NamespaceRaw struct {
+	Contract *Namespace // Generic contract binding to access the raw methods on
+}
+
+// NamespaceCallerRaw is an auto generated low-level read-only Go binding around an Ethereum contract.
+type NamespaceCallerRaw struct {
+	Contract *NamespaceCaller // Generic read-only contract binding to access the raw methods on
+}
+
+// NamespaceTransactorRaw is an auto generated low-level write-only Go binding around an Ethereum contract.
+type NamespaceTransactorRaw struct {
+	Contract *NamespaceTransactor // Generic write-only contract binding to access the raw methods on
+}
+
+// NewNamespace creates a new instance of Namespace, bound to a specific deployed contract.
+func NewNamespace(address common.Address, backend bind.ContractBackend) (*Namespace, error) {
+	contract, err := bindNamespace(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &Namespace{NamespaceCaller: NamespaceCaller{contract: contract}, NamespaceTransactor: NamespaceTransactor{contract: contract}, NamespaceFilterer: NamespaceFilterer{contract: contract}}, nil
+}
+
+// NewNamespaceCaller creates a new read-only instance of Namespace, bound to a specific deployed contract.
+func NewNamespaceCaller(address common.Address, caller bind.ContractCaller) (*NamespaceCaller, error) {
+	contract, err := bindNamespace(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &NamespaceCaller{contract: contract}, nil
+}
+
+// NewNamespaceTransactor creates a new write-only instance of Namespace, bound to a specific deployed contract.
+func NewNamespaceTransactor(address common.Address, transactor bind.ContractTransactor) (*NamespaceTransactor, error) {
+	contract, err := bindNamespace(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &NamespaceTransactor{contract: contract}, nil
+}
+
+// NewNamespaceFilterer creates a new log filterer instance of Namespace, bound to a specific deployed contract.
+func NewNamespaceFilterer(address common.Address, filterer bind.ContractFilterer) (*NamespaceFilterer, error) {
+	contract, err := bindNamespace(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &NamespaceFilterer{contract: contract}, nil
+}
+
+// bindNamespace binds a generic wrapper to an already deployed contract.
+func bindNamespace(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := NamespaceMetaData.GetAbi()
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, *parsed, caller, transactor, filterer), nil
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Namespace *NamespaceRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Namespace.Contract.NamespaceCaller.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Namespace *NamespaceRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Namespace.Contract.NamespaceTransactor.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Namespace *NamespaceRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Namespace.Contract.NamespaceTransactor.contract.Transact(opts, method, params...)
+}
+
+// Call invokes the (constant) contract method with params as input values and
+// sets the output to result. The result type might be a single field for simple
+// returns, a slice of interfaces for anonymous returns and a struct for named
+// returns.
+func (_Namespace *NamespaceCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _Namespace.Contract.contract.Call(opts, result, method, params...)
+}
+
+// Transfer initiates a plain transaction to move funds to the contract, calling
+// its default method if one is available.
+func (_Namespace *NamespaceTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _Namespace.Contract.contract.Transfer(opts)
+}
+
+// Transact invokes the (paid) contract method with params as input values.
+func (_Namespace *NamespaceTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _Namespace.Contract.contract.Transact(opts, method, params...)
+}
+
+// AddressForNamespace is a free data retrieval call binding the contract method 0x0fdf8ad9.
+//
+// Solidity: function addressForNamespace(string namespace) view returns(string)
+func (_Namespace *NamespaceCaller) AddressForNamespace(opts *bind.CallOpts, namespace string) (string, error) {
+	var out []interface{}
+	err := _Namespace.contract.Call(opts, &out, "addressForNamespace", namespace)
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+// AddressForNamespace is a free data retrieval call binding the contract method 0x0fdf8ad9.
+//
+// Solidity: function addressForNamespace(string namespace) view returns(string)
+func (_Namespace *NamespaceSession) AddressForNamespace(namespace string) (string, error) {
+	return _Namespace.Contract.AddressForNamespace(&_Namespace.CallOpts, namespace)
+}
+
+// AddressForNamespace is a free data retrieval call binding the contract method 0x0fdf8ad9.
+//
+// Solidity: function addressForNamespace(string namespace) view returns(string)
+func (_Namespace *NamespaceCallerSession) AddressForNamespace(namespace string) (string, error) {
+	return _Namespace.Contract.AddressForNamespace(&_Namespace.CallOpts, namespace)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x3ffbd47f.
+//
+// Solidity: function register(string namespace, string gRPCAddress) returns(bool)
+func (_Namespace *NamespaceTransactor) Register(opts *bind.TransactOpts, namespace string, gRPCAddress string) (*types.Transaction, error) {
+	return _Namespace.contract.Transact(opts, "register", namespace, gRPCAddress)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x3ffbd47f.
+//
+// Solidity: function register(string namespace, string gRPCAddress) returns(bool)
+func (_Namespace *NamespaceSession) Register(namespace string, gRPCAddress string) (*types.Transaction, error) {
+	return _Namespace.Contract.Register(&_Namespace.TransactOpts, namespace, gRPCAddress)
+}
+
+// Register is a paid mutator transaction binding the contract method 0x3ffbd47f.
+//
+// Solidity: function register(string namespace, string gRPCAddress) returns(bool)
+func (_Namespace *NamespaceTransactorSession) Register(namespace string, gRPCAddress string) (*types.Transaction, error) {
+	return _Namespace.Contract.Register(&_Namespace.TransactOpts, namespace, gRPCAddress)
+}

--- a/evm/precompile/contracts/gen.go
+++ b/evm/precompile/contracts/gen.go
@@ -26,3 +26,4 @@
 package contracts
 
 //go:generate abigen --pkg router --abi ./out/router.sol/IRouter.abi.json --bin ./out/router.sol/IRouter.bin --out ./bindings/cosmos/precompile/router/IRouter.abigen.go --type router
+//go:generate abigen --pkg namespace --abi ./out/namespace.sol/INamespace.abi.json --bin ./out/namespace.sol/INamespace.bin --out ./bindings/cosmos/precompile/namespace/INamespace.abigen.go --type namespace

--- a/evm/precompile/contracts/src/cosmos/precompile/namespace.sol
+++ b/evm/precompile/contracts/src/cosmos/precompile/namespace.sol
@@ -1,0 +1,7 @@
+pragma solidity ^0.8.4;
+
+interface INamespace {
+    function register(string memory namespace, string memory gRPCAddress) external returns (bool);
+
+    function addressForNamespace(string memory namespace) external view returns (string memory);
+}

--- a/evm/precompile/namespace/namespace.go
+++ b/evm/precompile/namespace/namespace.go
@@ -1,0 +1,53 @@
+package namespace
+
+import (
+	"context"
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/ethereum/go-ethereum/common"
+	ethprecompile "pkg.berachain.dev/polaris/eth/core/precompile"
+	"pkg.world.dev/world-engine/evm/precompile/contracts/bindings/cosmos/precompile/namespace"
+	"pkg.world.dev/world-engine/evm/x/namespace/types"
+)
+
+const name = "world_engine_namespace_registrar"
+
+type Contract struct {
+	ethprecompile.BaseContract
+	types.MsgServer
+	types.QueryServiceServer
+}
+
+func NewPrecompileContract(ms types.MsgServer, qs types.QueryServiceServer) *Contract {
+	return &Contract{
+		BaseContract: ethprecompile.NewBaseContract(
+			namespace.NamespaceMetaData.ABI,
+			common.BytesToAddress(authtypes.NewModuleAddress(name)),
+		),
+		MsgServer:          ms,
+		QueryServiceServer: qs,
+	}
+}
+
+func (c *Contract) Register(
+	ctx context.Context,
+	namespace string,
+	grpcAddress string,
+) (bool, error) {
+	_, err := c.UpdateNamespace(ctx, &types.UpdateNamespaceRequest{
+		Authority: "",
+		Namespace: &types.Namespace{
+			ShardName:    namespace,
+			ShardAddress: grpcAddress,
+		},
+	})
+	// if err == nil, this returns true, which means it succeeded.
+	return err == nil, err
+}
+
+func (c *Contract) AddressForNamespace(ctx context.Context, namespace string) (string, error) {
+	res, err := c.Address(ctx, &types.AddressRequest{Namespace: namespace})
+	if err != nil {
+		return "", err
+	}
+	return res.Address, nil
+}

--- a/evm/precompile/namespace/namespace_test.go
+++ b/evm/precompile/namespace/namespace_test.go
@@ -1,0 +1,51 @@
+package namespace
+
+import (
+	authtypes "github.com/cosmos/cosmos-sdk/x/auth/types"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/suite"
+	ethprecompile "pkg.berachain.dev/polaris/eth/core/precompile"
+	"pkg.berachain.dev/polaris/lib/utils"
+	generated "pkg.world.dev/world-engine/evm/precompile/contracts/bindings/cosmos/precompile/namespace"
+	"testing"
+)
+
+type NamespaceTestSuite struct {
+	suite.Suite
+	sf       *ethprecompile.StatefulFactory
+	contract *Contract
+}
+
+func TestNamespace(t *testing.T) {
+	suite.Run(t, &NamespaceTestSuite{})
+}
+
+func (r *NamespaceTestSuite) SetupTest() {
+	r.contract = utils.MustGetAs[*Contract](
+		NewPrecompileContract(
+			nil, nil,
+		),
+	)
+	r.sf = ethprecompile.NewStatefulFactory()
+}
+
+func (r *NamespaceTestSuite) TestStaticRegistryKey() {
+	r.Require().Equal(r.contract.RegistryKey(), common.BytesToAddress(authtypes.NewModuleAddress(name)))
+}
+
+func (r *NamespaceTestSuite) TestABIMethods() {
+	var contractABI abi.ABI
+	err := contractABI.UnmarshalJSON([]byte(generated.NamespaceMetaData.ABI))
+	r.Require().NoError(err)
+	r.Require().Equal(r.contract.ABIMethods(), contractABI.Methods)
+}
+
+func (r *NamespaceTestSuite) TestMatchPrecompileMethods() {
+	_, err := r.sf.Build(r.contract, nil)
+	r.Require().NoError(err)
+}
+
+func (r *NamespaceTestSuite) TestCustomValueDecoderIsNoop() {
+	r.Require().Nil(r.contract.CustomValueDecoders())
+}

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -17,8 +17,10 @@ game:
 	cd internal/e2e/tester/game && go mod vendor
 	@docker compose up game nakama --build --abort-on-container-exit cockroachdb redis
 
-forge-build: |
+
+contracts:
 	@forge build --extra-output-files bin --extra-output-files abi  --root evm/precompile/contracts
+	cd evm/precompile/contracts && go generate
 
 rollup-build:
 	@docker build evm


### PR DESCRIPTION
## Overview

adds namespace registration and querying as a precompile to the EVM base shard.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
