### PR TITLE
feat(cardinal): Create guid component and system

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -39,6 +39,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Features
 
+- (cardinal) #WORLD-679: Add a default GUID system and query.
+
 - (cardinal) #WORLD-627: timestamps are now accessible via WorldContext.
 
 - (nakama) #WORLD-651: Support saving game data to Nakama storage.
@@ -46,6 +48,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 - (cardinal) #WORLD-668: Log tick timing information into a single log line.
+
 - (cardinal) #WORLD-643: Instead of making sure nonce values are strictly increasing, use a Redis set to track every used nonce.
 
 ### Deprecated

--- a/cardinal/ecs/guid.go
+++ b/cardinal/ecs/guid.go
@@ -1,0 +1,81 @@
+package ecs
+
+import (
+	"errors"
+
+	"github.com/cometbft/cometbft/crypto"
+)
+
+const numOfCharactersInGUID = 24
+
+// GUIDComponent is a unique game identification string. It is generated randomly on tick 0 and
+// will never change.
+type GUIDComponent struct {
+	GUID string `json:"guid"`
+}
+
+func (GUIDComponent) Name() string {
+	return "GameUniqueIDComponent"
+}
+
+var ErrGUIDNotFound = errors.New("guid not found")
+
+func getGUID(wCtx WorldContext) (guid string, err error) {
+	search, err := wCtx.NewSearch(Exact(GUIDComponent{}))
+	if err != nil {
+		return "", err
+	}
+	count, err := search.Count(wCtx)
+	if err != nil {
+		return "", err
+	}
+	if count == 0 {
+		return "", ErrGUIDNotFound
+	}
+	id, err := search.First(wCtx)
+	if err != nil {
+		return "", err
+	}
+	guidComp, err := GetComponent[GUIDComponent](wCtx, id)
+	if err != nil {
+		return "", err
+	}
+	return guidComp.GUID, nil
+}
+
+func CreateGUIDSystem(wCtx WorldContext) error {
+	_, err := getGUID(wCtx)
+	if err == nil {
+		// The GUID has already been created
+		return nil
+	}
+	if !errors.Is(err, ErrGUIDNotFound) {
+		// There was some error when looking for the guid
+		return err
+	}
+	// The guid hasn't been created yet
+	guid := crypto.CRandHex(numOfCharactersInGUID)
+	id, err := Create(wCtx, GUIDComponent{})
+	if err != nil {
+		return err
+	}
+	return SetComponent[GUIDComponent](wCtx, id, &GUIDComponent{guid})
+}
+
+type GUIDRequest struct{}
+type GUIDReply struct {
+	GUID string `json:"guid"`
+}
+
+func setupGUIDQuery(world *World) error {
+	return RegisterQuery[GUIDRequest, GUIDReply](
+		world,
+		"guid",
+		func(wCtx WorldContext, _ *GUIDRequest) (*GUIDReply, error) {
+			guid, err := getGUID(wCtx)
+			if err != nil {
+				return nil, err
+			}
+			return &GUIDReply{guid}, nil
+		})
+}

--- a/cardinal/ecs/log/log_test.go
+++ b/cardinal/ecs/log/log_test.go
@@ -99,7 +99,7 @@ func TestWorldLogger(t *testing.T) {
 	cardinalLogger.LogWorld(w, zerolog.InfoLevel)
 	jsonWorldInfoString := `{
 					"level":"info",
-					"total_components":2,
+					"total_components":3,
 					"components":
 						[
 							{
@@ -108,14 +108,19 @@ func TestWorldLogger(t *testing.T) {
 							},
 							{
 								"component_id":2,
+								"component_name":"GameUniqueIDComponent"
+							},
+							{
+								"component_id":3,
 								"component_name":"EnergyComp"
 							}
 						],
-					"total_systems":2,
+					"total_systems":3,
 					"systems":
 						[
 							"ecs.RegisterPersonaSystem",
-							"ecs.AuthorizePersonaAddressSystem"
+							"ecs.AuthorizePersonaAddressSystem",
+							"ecs.CreateGUIDSystem"
 						]
 				}
 `
@@ -144,7 +149,7 @@ func TestWorldLogger(t *testing.T) {
 			{
 				"level":"debug",
 				"components":[{
-					"component_id":2,
+					"component_id":3,
 					"component_name":"EnergyComp"
 				}],
 				"entity_id":0,"archetype_id":0
@@ -162,7 +167,7 @@ func TestWorldLogger(t *testing.T) {
 			"level":"debug",
 			"components":[
 				{
-					"component_id":2,
+					"component_id":3,
 					"component_name":"EnergyComp"
 				}],
 			"entity_id":0,
@@ -177,7 +182,7 @@ func TestWorldLogger(t *testing.T) {
 	// testing output of logging a tick. Should log the system log and tick start and end strings.
 	err = w.Tick(ctx)
 	assert.NilError(t, err)
-	logStrings = strings.Split(buf.String(), "\n")[:6]
+	logStrings = strings.Split(buf.String(), "\n")[:8]
 	// test tick start
 	require.JSONEq(
 		t, `
@@ -193,7 +198,7 @@ func TestWorldLogger(t *testing.T) {
 			{
 				"system":"log_test.testSystemWarningTrigger",
 				"message":"test"
-			}`, logStrings[1],
+			}`, logStrings[3],
 	)
 	// test if updating component worked
 	require.JSONEq(
@@ -202,10 +207,10 @@ func TestWorldLogger(t *testing.T) {
 				"level":"debug",
 				"entity_id":"0",
 				"component_name":"EnergyComp",
-				"component_id":2,
+				"component_id":3,
 				"message":"entity updated",
 				"system":"log_test.testSystemWarningTrigger"
-			}`, logStrings[2],
+			}`, logStrings[4],
 	)
 	// test tick end
 	buf.Reset()
@@ -229,7 +234,7 @@ func TestWorldLogger(t *testing.T) {
 	if err = json.Unmarshal(json1, &expectedMap); err != nil {
 		t.Fatalf("Error unmarshalling json1: %v", err)
 	}
-	if err = json.Unmarshal([]byte(logStrings[4]), &map2); err != nil {
+	if err = json.Unmarshal([]byte(logStrings[6]), &map2); err != nil {
 		t.Fatalf("Error unmarshalling buf: %v", err)
 	}
 	names := []string{"level", "tick", "tick_execution_time_ms", "message", "make_pipe_time_ms", "exec_pipe_time_ms"}
@@ -260,11 +265,11 @@ func TestWorldLogger(t *testing.T) {
 				"components":
 					[
 						{
-							"component_id":2,
+							"component_id":3,
 							"component_name":"EnergyComp"
 						}
 					],
-				"entity_id":1,
+				"entity_id":2,
 				"archetype_id":0
 			}`, entityCreationStrings[0],
 	)
@@ -275,11 +280,11 @@ func TestWorldLogger(t *testing.T) {
 				"components":
 					[
 						{
-							"component_id":2,
+							"component_id":3,
 							"component_name":"EnergyComp"
 						}
 					],
-				"entity_id":2,
+				"entity_id":3,
 				"archetype_id":0
 			}`, entityCreationStrings[1],
 	)

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -339,7 +339,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 			"/tx/persona/create-persona", "/tx/game/authorize-persona-address", "/tx/game/send-energy",
 		},
 		QueryEndpoints: []string{
-			"/query/game/foo", "/query/http/endpoints", "/query/persona/signer",
+			"/query/game/guid", "/query/game/foo", "/query/http/endpoints", "/query/persona/signer",
 			"/query/receipt/list", "/query/game/cql",
 		},
 	}
@@ -462,7 +462,7 @@ func TestHandleSwaggerServer(t *testing.T) {
 		{cql: "CONTAINS(beta)", expectedStatus: 200, amount: bothCount},
 		{cql: "EXACT(alpha)", expectedStatus: 200, amount: alphaCount},
 		{cql: "EXACT(beta)", expectedStatus: 200, amount: 0},
-		{cql: "!(CONTAINS(alpha) | CONTAINS(beta))", expectedStatus: 200, amount: 1},
+		{cql: "!(CONTAINS(alpha) | CONTAINS(beta))", expectedStatus: 200, amount: 2},
 		{cql: "!CONTAINS(alpha) & CONTAINS(beta)", expectedStatus: 200, amount: 0},
 	} {
 		jsonQuery := struct{ CQL string }{v.cql}
@@ -821,6 +821,7 @@ func TestCanListQueries(t *testing.T) {
 	assert.NilError(t, json.NewDecoder(resp.Body).Decode(&gotEndpoints))
 
 	endpoints := []string{
+		"/query/game/guid",
 		"/query/game/foo",
 		"/query/game/bar",
 		"/query/game/baz",


### PR DESCRIPTION
Closes: WORLD-679

## Overview

Add a default system that creates a unique game id as well as a query that returns the game id. This game ID will be changes to something new each time the cardinal DB is reset.

## Testing and Verifying

From the world-engine directory, `make game` will build and run nakama and cardinal. 

From the Nakama console you can see the `/query/game/guid` endpoint. Querying that endpoint with `{}` as the body will give you the guid.
