### PR TITLE
test(nakama): Add more nakama unit tests using mocks

### DIFF
--- a/relay/nakama/allowlist_test.go
+++ b/relay/nakama/allowlist_test.go
@@ -2,10 +2,14 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"os"
 	"testing"
 
 	"github.com/heroiclabs/nakama-common/api"
+	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/suite"
 	"pkg.world.dev/world-engine/assert"
@@ -15,6 +19,7 @@ import (
 type AllowListTestSuite struct {
 	suite.Suite
 	originalAllowListEnabled bool
+	originalEnvVar           string
 }
 
 func TestAllowList(t *testing.T) {
@@ -24,10 +29,14 @@ func TestAllowList(t *testing.T) {
 func (a *AllowListTestSuite) SetupTest() {
 	a.originalAllowListEnabled = allowlistEnabled
 	allowlistEnabled = true
+	a.originalEnvVar = os.Getenv(allowlistEnabledEnvVar)
 }
 
 func (a *AllowListTestSuite) TearDownTest() {
 	allowlistEnabled = a.originalAllowListEnabled
+	if err := os.Setenv(allowlistEnabledEnvVar, a.originalEnvVar); err != nil {
+		panic(err)
+	}
 }
 
 func (a *AllowListTestSuite) TestUserIDRequired() {
@@ -40,9 +49,8 @@ func (a *AllowListTestSuite) TestUserIDRequired() {
 	assert.IsError(t, err)
 }
 
-func (a *AllowListTestSuite) TestChecksCorrectStorageObject() {
+func (a *AllowListTestSuite) TestErrorFromStorageIsReturnedToCaller() {
 	t := a.T()
-	t.Skip("This test fails because we treat all errors from checkVerified as the user not having a beta key")
 	userID := "the-user-id-is-also-the-store-key"
 	ctx := ctxWithUserID(userID)
 	errorMsg := "read failure"
@@ -76,7 +84,7 @@ func (a *AllowListTestSuite) TestCannotClaimASecondBetaKey() {
 	assert.ErrorContains(t, err, ErrAlreadyVerified.Error())
 }
 
-func (a *AllowListTestSuite) TestEmptyKeyRejected() {
+func (a *AllowListTestSuite) TestBadKeyRequestsAreRejected() {
 	t := a.T()
 	ctx := ctxWithUserID("foo")
 	mockNK := mocks.NewNakamaModule(t)
@@ -84,9 +92,212 @@ func (a *AllowListTestSuite) TestEmptyKeyRejected() {
 	// no results will be returned.
 	mockNK.On("StorageRead", mock.Anything, mock.Anything).
 		Return(nil, nil).
-		Once()
+		Twice()
 
 	_, err := claimKeyRPC(ctx, noopLogger(t), nil, mockNK, `{"key": ""}`)
 	// Nakama returns its own custom runtime error which does NOT implement the Is method, making ErrorIs not helpful.
 	assert.ErrorContains(t, err, ErrInvalidBetaKey.Error())
+
+	badBody := `{"key": "{{{{`
+	_, err = claimKeyRPC(ctx, noopLogger(t), nil, mockNK, badBody)
+	assert.IsError(t, err)
+}
+
+func (a *AllowListTestSuite) TestCanDisableAllowList() {
+	testCases := []string{
+		"false",
+		"F",
+		"False",
+	}
+	for _, tc := range testCases {
+		os.Setenv(allowlistEnabledEnvVar, tc)
+		assert.NilError(a.T(), initAllowlist(nil, nil))
+		assert.Equal(a.T(), false, allowlistEnabled)
+	}
+}
+
+func (a *AllowListTestSuite) TestRejectBadAllowListFlag() {
+	os.Setenv(allowlistEnabledEnvVar, "unclear-boolean-value")
+	assert.IsError(a.T(), initAllowlist(nil, nil))
+}
+
+func (a *AllowListTestSuite) TestCanEnableAllowList() {
+	testCases := []string{
+		"true",
+		"True",
+		"T",
+	}
+	for _, tc := range testCases {
+		os.Setenv(allowlistEnabledEnvVar, tc)
+		initializer := mocks.NewInitializer(a.T())
+		initializer.On("RegisterRpc", "generate-beta-keys", mock.Anything).
+			Return(nil)
+
+		initializer.On("RegisterRpc", "claim-key", mock.Anything).
+			Return(nil)
+
+		assert.NilError(a.T(), initAllowlist(nil, initializer))
+		assert.Equal(a.T(), true, allowlistEnabled)
+	}
+}
+
+func (a *AllowListTestSuite) TestAllowListFailsIfRPCRegistrationFails() {
+	os.Setenv(allowlistEnabledEnvVar, "true")
+	initializer := mocks.NewInitializer(a.T())
+	initializer.On("RegisterRpc", "generate-beta-keys", mock.Anything).
+		Return(errors.New("failed to register"))
+
+	assert.IsError(a.T(), initAllowlist(nil, initializer))
+
+	initializer = mocks.NewInitializer(a.T())
+	initializer.On("RegisterRpc", "generate-beta-keys", mock.Anything).
+		Return(nil)
+
+	initializer.On("RegisterRpc", "claim-key", mock.Anything).
+		Return(errors.New("failed to register"))
+
+	assert.IsError(a.T(), initAllowlist(nil, initializer))
+}
+
+func (a *AllowListTestSuite) TestCanHandleBetaKeyGenerationFailures() {
+	t := a.T()
+	ctx := context.Background()
+	logger := noopLogger(t)
+
+	// No user ID is defined
+	_, err := allowListRPC(ctx, logger, nil, nil, "")
+	assert.IsError(t, err)
+
+	// Non admin user ID is defined
+	ctx = ctxWithUserID("some-non-admin-user-id")
+	_, err = allowListRPC(ctx, logger, nil, nil, "")
+	assert.ErrorContains(t, err, "unauthorized")
+
+	// The GenKeys payload is malformed
+	ctx = ctxWithUserID(adminAccountID)
+	_, err = allowListRPC(ctx, logger, nil, nil, `{"bad-payload":{{{{`)
+	assert.IsError(t, err)
+
+	nk := mocks.NewNakamaModule(t)
+	errMsg := "storage write failure"
+	nk.On("StorageWrite", mock.Anything, mock.Anything).
+		Return(nil, errors.New(errMsg))
+	_, err = allowListRPC(ctx, logger, nil, nk, `{"amount":10}`)
+	assert.ErrorContains(t, err, errMsg)
+}
+
+func (a *AllowListTestSuite) TestCanAddBetaKeys() {
+	t := a.T()
+	ctx := ctxWithUserID(adminAccountID)
+	numOfKeysToGenerate := 100
+	nk := mocks.NewNakamaModule(t)
+	keysInDB := map[string]bool{}
+	nk.On("StorageWrite", mock.Anything, mock.MatchedBy(func(writes []*runtime.StorageWrite) bool {
+		// Make sure all keys are unique
+		seenKeys := map[string]bool{}
+		for _, write := range writes {
+			assert.Equal(t, false, seenKeys[write.Key])
+			seenKeys[write.Key] = true
+			keysInDB[write.Key] = true
+		}
+		assert.Equal(t, len(writes), numOfKeysToGenerate)
+		assert.Equal(t, len(seenKeys), numOfKeysToGenerate)
+		return true
+	})).Return(nil, nil)
+
+	payload := fmt.Sprintf(`{"amount":%d}`, numOfKeysToGenerate)
+	resp, err := allowListRPC(ctx, noopLogger(t), nil, nk, payload)
+	assert.NilError(t, err)
+
+	// Make sure the beta keys were included in the response
+	result := map[string]any{}
+
+	assert.NilError(t, json.Unmarshal([]byte(resp), &result))
+	keysAsIface, ok := result["keys"]
+	assert.Check(t, ok)
+	keys, ok := keysAsIface.([]any)
+	assert.Check(t, ok)
+	assert.Equal(t, len(keys), numOfKeysToGenerate)
+	// Make sure the keys in the response are unique
+	seenKeys := map[string]bool{}
+	for _, key := range keys {
+		assert.Equal(t, false, seenKeys[key.(string)])
+		seenKeys[key.(string)] = true
+	}
+	assert.Equal(t, numOfKeysToGenerate, len(seenKeys))
+	// Make sure the returned keys and keys in DB are the same
+	assert.DeepEqual(t, seenKeys, keysInDB)
+}
+
+func (a *AllowListTestSuite) TestCanClaimBetaKey() {
+	t := a.T()
+
+	userID := "foobar"
+	ctx := ctxWithUserID(userID)
+	mockNK := mocks.NewNakamaModule(t)
+
+	// First call is to check if the user already has a beta key
+	mockNK.On("StorageRead",
+		anyContext, mockMatchStoreRead(allowedUsers, userID, adminAccountID)).
+		// No storageObject objects signals that this user has not yet claimed a beta key
+		Return(nil, nil).
+		Once()
+
+	betaKeyToUse := "abcd-efgh"
+	// Make sure the beta keys are converted to upper case.
+	validBetaKey := "ABCD-EFGH"
+
+	// This single storage object indicates that the beta key was found (and is valid)
+	betaKeyReadReturnVal := []*api.StorageObject{{
+		Value: fmt.Sprintf(`{"Key":"%s","UsedBy":"","Used":false}`, validBetaKey),
+	}}
+
+	// Second call is to see if the beta key is valid
+	mockNK.On("StorageRead", anyContext,
+		mockMatchStoreRead(allowlistKeyCollection, validBetaKey, adminAccountID)).
+		Return(betaKeyReadReturnVal, nil).
+		Once()
+
+	// Third call is to update the beta key to mark it as used
+	mockNK.On("StorageWrite", anyContext,
+		mockMatchStoreWrite(allowlistKeyCollection, validBetaKey, adminAccountID)).
+		Return(nil, nil).
+		Once()
+
+	// Fourth call is to save the newly validated user into the DB
+	mockNK.On("StorageWrite", anyContext,
+		mockMatchStoreWrite(allowedUsers, "", adminAccountID)).
+		Return(nil, nil).
+		Once()
+
+	payload := fmt.Sprintf(`{"key":"%s"}`, betaKeyToUse)
+
+	_, err := claimKeyRPC(ctx, noopLogger(t), nil, mockNK, payload)
+	assert.NilError(t, err)
+}
+
+func (a *AllowListTestSuite) TestClaimedBetaKeyCannotBeReclaimed() {
+	t := a.T()
+	userID := "foobar"
+	ctx := ctxWithUserID(userID)
+	mockNK := mocks.NewNakamaModule(t)
+	mockNK.On("StorageRead", anyContext, mock.Anything).
+		// No storageObject objects signals that this user has not yet claimed a beta key
+		Return(nil, nil).
+		Once()
+
+	// This single storage object indicates that the beta key was found (and is valid)
+	betaKeyReadReturnVal := []*api.StorageObject{{
+		// This beta key is used by someone else
+		Value: `{"Key":"xyzzy","UsedBy":"someone-else","Used":true}`,
+	}}
+
+	mockNK.On("StorageRead", anyContext, mock.Anything).
+		Return(betaKeyReadReturnVal, nil).
+		Once()
+
+	payload := `{"key": "xyzzy"}`
+	_, err := claimKeyRPC(ctx, noopLogger(t), nil, mockNK, payload)
+	assert.ErrorContains(t, err, ErrBetaKeyAlreadyUsed.Error())
+
 }

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -267,12 +267,10 @@ func handleClaimPersona(ptv *personaTagVerifier, notifier *receiptNotifier) naka
 		}
 
 		// check if the user is verified. this requires them to input a valid beta key.
-		err = checkVerified(ctx, nk, userID)
-		if err != nil {
-			if eris.Is(eris.Cause(err), ErrNotAllowlisted) {
-				return logDebugWithMessageAndCode(logger, err, AlreadyExists, "unable to claim persona tag")
-			}
+		if verified, err := isUserVerified(ctx, nk, userID); err != nil {
 			return logErrorMessageFailedPrecondition(logger, err, "unable to claim persona tag")
+		} else if !verified {
+			return logDebugWithMessageAndCode(logger, ErrNotAllowlisted, AlreadyExists, "unable to claim persona tag")
 		}
 
 		ptr := &personaTagStorageObj{}

--- a/relay/nakama/util_test.go
+++ b/relay/nakama/util_test.go
@@ -23,11 +23,55 @@ import (
 //
 // The configuration file at .mockery.yaml will be used to generate the Nakama mocks.
 
+// anyContext is used to make mock expectations more readable.
+// someMock.On("SomeFunction", anyContext...) makes it clear that the first parameter is supposed to be a context.
+// context.valueCtx is the type returned by context.Background.
+var anyContext = mock.AnythingOfType("*context.valueCtx")
+
 // ctxWithUserID saves the given user ID to the background context in a location that Nakama expects to find user IDs.
 func ctxWithUserID(userID string) context.Context {
 	ctx := context.Background()
 	//nolint:staticcheck // this is how Nakama reads userIDs from the context.
 	return context.WithValue(ctx, runtime.RUNTIME_CTX_USER_ID, userID)
+}
+
+func mockMatchStoreWrite(collection, key, userID string) any {
+	return mock.MatchedBy(func(writes []*runtime.StorageWrite) bool {
+		if len(writes) != 1 {
+			return false
+		}
+		if collection != "" && writes[0].Collection != collection {
+			return false
+		}
+		if key != "" && writes[0].Key != key {
+			return false
+		}
+		if userID != "" && writes[0].UserID != userID {
+			return false
+		}
+		return true
+	})
+}
+
+// mockMatchStoreReads creates a mock.Matcher (suitable for use as a variadic argument into an "On" method).
+// It should be used when your test is expecting a call to "StorageRead", and it verifies that the single
+// read request matches the given collection/key/userID. Use the empty string ("") to skip any of the comparisons.
+func mockMatchStoreRead(collection, key, userID string) any {
+	return mock.MatchedBy(func(reads []*runtime.StorageRead) bool {
+		if len(reads) != 1 {
+			return false
+		}
+		if collection != "" && reads[0].Collection != collection {
+			return false
+		}
+		if key != "" && reads[0].Key != key {
+			return false
+		}
+		if userID != "" && reads[0].UserID != userID {
+			return false
+		}
+		return true
+	})
 }
 
 // noopLogger returns a mock logger that ignores all log messages.


### PR DESCRIPTION


## Overview

Add more unit tests for the allowlist code using the mock framework.
Rename the checkVerified to isUserVerified to make it more explicit when a user is and is not verified. Now, an error is only returned if there was a problem accessing the user's data.

## Testing and Verifying

Unit tests added. Use `go test`