### PR TITLE
fix(evm): add sed command to replace cometBFT API address with working address

### DIFF
--- a/evm/scripts/start-sequencer.sh
+++ b/evm/scripts/start-sequencer.sh
@@ -47,6 +47,10 @@ world-evm genesis collect-gentxs
 
 cp app.toml /root/.world-evm/config/app.toml
 
+# CometBFT API
+sed -i'.bak' 's#"tcp://127.0.0.1:26657"#"tcp://0.0.0.0:26657"#g' /root/.world-evm/config/config.toml
+
+# Faucet setup. changes the default account to the provided account, then supplies it with tokens.
 sed -i'.bak' "s#'20f33ce90a13a4b5e7697e3544c3083b8f8a51d4'#'$FAUCET_ADDR'#g" /root/.world-evm/config/genesis.json
 sed -i'.bak' 's#"0x1b1ae4d6e2ef500000"#"0x3fffffffffffffff0000000000000001"#g' /root/.world-evm/config/genesis.json
 


### PR DESCRIPTION
## Overview

default addr doesn't work, need to update it via sed.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
