### PR TITLE
fix(cardinal): Fix memory leak in ECB and remove CommitPending

### DIFF
--- a/CHANGELOG.MD
+++ b/CHANGELOG.MD
@@ -60,6 +60,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ### Bug Fixes
 
+- (cardinal) #WORLD-653: Fix memory leak in ECB.
+
 - (nakama) #WORLD-643: Reject a persona tag request if it seems like cardinal didn't actually get the corresponding transaction.
 
 ### Client Breaking

--- a/cardinal/ecs/ecb/doc.go
+++ b/cardinal/ecs/ecb/doc.go
@@ -24,10 +24,10 @@ accumulated.
 Pending changes can be discarded with Manager.DiscardPending. A subsequent read will return identical data to the data
 stored in Redis.
 
-Pending changes can be committed to redis with Manager.CommitPending. All pending changes will be packaged into a single
+Pending changes can be committed to redis with Manager.FinalizeTick. All pending changes will be packaged into a single
 redis [multi/exec pipeline](https://redis.io/docs/interact/transactions/) and applied atomically. Reads to redis during
 this time will never return any pending state. For example, if a series of 100 commands increments some value from 0 to
-100, and then CommitPending is called, reading this value from the DB will only ever return 0 or 100 (depending on the
+100, and then FinalizeTick is called, reading this value from the DB will only ever return 0 or 100 (depending on the
 exact timing of the call).
 
 # Redis Storage Model
@@ -77,7 +77,7 @@ In redis, the ECB:ACTIVE-ENTITY-IDS and ECB:ARCHETYPE-ID:ENTITY-ID keys contains
 mapping of one another. The amount of data in redis, and the data written can likely be reduced if we abandon one of
 these keys and rebuild the other mapping in memory.
 
-In memory, compValues are written to redis during a CommitPending cycle. Components that were not actually changed (e.g.
+In memory, compValues are written to redis during a FinalizeTick cycle. Components that were not actually changed (e.g.
 only read operations were performed) are still written to the DB.
 */
 package ecb

--- a/cardinal/ecs/ecb/ecb.go
+++ b/cardinal/ecs/ecb/ecb.go
@@ -85,26 +85,6 @@ func (m *Manager) RegisterComponents(comps []component.ComponentMetadata) error 
 	return m.loadArchIDs()
 }
 
-// CommitPending commits any pending state changes to the DB. If an error is returned, there will be no changes
-// to the underlying DB.
-func (m *Manager) CommitPending() error {
-	ctx := context.Background()
-	pipe, err := m.makePipeOfRedisCommands(ctx)
-	if err != nil {
-		return err
-	}
-	_, err = pipe.Exec(ctx)
-	if err != nil {
-		return eris.Wrap(err, "")
-	}
-
-	m.pendingArchIDs = nil
-
-	// All changes were just successfully committed to redis, so stop tracking them locally
-	m.DiscardPending()
-	return nil
-}
-
 // DiscardPending discards any pending state changes.
 func (m *Manager) DiscardPending() {
 	clear(m.compValues)

--- a/cardinal/ecs/ecb/tick.go
+++ b/cardinal/ecs/ecb/tick.go
@@ -80,7 +80,13 @@ func (m *Manager) FinalizeTick(ctx context.Context) error {
 	flushStartTime := time.Now()
 	_, err = pipe.Exec(ctx)
 	statsd.EmitTickStat(flushStartTime, "pipe_exec")
-	return eris.Wrap(err, "")
+	if err != nil {
+		return eris.Wrap(err, "")
+	}
+
+	m.pendingArchIDs = nil
+	m.DiscardPending()
+	return nil
 }
 
 // Recover fetches the pending transactions for an incomplete tick. This should only be called if GetTickNumbers


### PR DESCRIPTION

Closes: WORLD-653

## Overview

There were two ways to commit pending ECB changes to redis. FinalizeTick and CommitPending. CommitPending would call "DiscardPending" after saving data to redis, meaning subsequent calls to CommitPending would only include changes that were made since the last call to CommitPending.

FinalizeTick, on the other hand, didn't call DiscardPending. Every time FinalizeTick was called, ALL previous changes would be re-submitted to redis. This includes data that wasn't actually modified.

This PR 1) Calls DiscardPending at the end of FinalizeTick and 2) Removes CommitPending completely (so there is only 1 way to save data to redis).

## Brief Changelog

- Remove CommitPending
- Update tests to use FinalizeTick instead of CommitPending
- Add a test to ensure FinalizeTick execution times and memory allocations do not grow abnormally.
 
## Testing and Verifying

A unit test was added.