### PR TITLE
style(cardinal): use `New` prefix in EventHub constructors

### DIFF
--- a/cardinal/ecs/options.go
+++ b/cardinal/ecs/options.go
@@ -47,6 +47,6 @@ func WithEventHub(eventHub events.EventHub) Option {
 
 func WithLoggingEventHub(logger *ecslog.Logger) Option {
 	return func(w *World) {
-		w.eventHub = events.CreateLoggingEventHub(logger)
+		w.eventHub = events.NewLoggingEventHub(logger)
 	}
 }

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -374,7 +374,7 @@ func NewWorld(
 	if err != nil {
 		return nil, err
 	}
-	opts = append([]Option{WithEventHub(events.CreateWebSocketEventHub())}, opts...)
+	opts = append([]Option{WithEventHub(events.NewWebSocketEventHub())}, opts...)
 	for _, opt := range opts {
 		opt(w)
 	}

--- a/cardinal/events/events.go
+++ b/cardinal/events/events.go
@@ -81,7 +81,7 @@ func (eh *loggingEventHub) ShutdownEventHub() {
 	eh.shutdown <- true
 }
 
-func CreateLoggingEventHub(logger *ecslog.Logger) EventHub {
+func NewLoggingEventHub(logger *ecslog.Logger) EventHub {
 	res := loggingEventHub{
 		eventQueue: make([]*Event, 0),
 		running:    atomic.Bool{},
@@ -97,7 +97,7 @@ func CreateLoggingEventHub(logger *ecslog.Logger) EventHub {
 	return &res
 }
 
-func CreateWebSocketEventHub() EventHub {
+func NewWebSocketEventHub() EventHub {
 	res := webSocketEventHub{
 		websocketConnections: map[*websocket.Conn]bool{},
 		broadcast:            make(chan *Event),

--- a/cardinal/testutils/testutils.go
+++ b/cardinal/testutils/testutils.go
@@ -28,7 +28,7 @@ func MakeTestTransactionHandler(
 	world *ecs.World,
 	opts ...server.Option,
 ) *TestTransactionHandler {
-	eventHub := events.CreateWebSocketEventHub()
+	eventHub := events.NewWebSocketEventHub()
 	world.SetEventHub(eventHub)
 	eventBuilder := events.CreateNewWebSocketBuilder(
 		"/events",
@@ -208,7 +208,7 @@ func MakeWorldAndTicker(
 	opts ...cardinal.WorldOption,
 ) (world *cardinal.World, doTick func()) {
 	startTickCh, doneTickCh := make(chan time.Time), make(chan uint64)
-	eventHub := events.CreateWebSocketEventHub()
+	eventHub := events.NewWebSocketEventHub()
 	opts = append(
 		opts,
 		cardinal.WithTickChannel(startTickCh),

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -274,7 +274,7 @@ func (w *World) StartGame() error {
 		return err
 	}
 	if !w.instance.DoesWorldHaveAnEventHub() {
-		w.instance.SetEventHub(events.CreateWebSocketEventHub())
+		w.instance.SetEventHub(events.NewWebSocketEventHub())
 	}
 	eventHub := w.instance.GetEventHub()
 	eventBuilder := events.CreateNewWebSocketBuilder("/events", events.CreateWebSocketEventHandler(eventHub))


### PR DESCRIPTION
## Overview

title title title

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
