### PR TITLE
docs: fix loop page

### DIFF
--- a/docs/cardinal/loop.mdx
+++ b/docs/cardinal/loop.mdx
@@ -1,6 +1,6 @@
 ---
 title: 'Loop-driven Runtime'
-description: 'How Cardinal's loop-driven runtime makes developing games on the blockchain easier.'
+description: "How Cardinal's loop-driven runtime makes developing games on the blockchain easier"
 ---
 
 Cardinal employs a loop-driven runtime. This is in contrast to EVM smart contracts that are event-driven in nature. But how do they differ?


### PR DESCRIPTION
## Overview

fixes an issue with loop page. quote block messed up

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
