### PR TITLE
feat(cardinal): Delay error of building a search query to happen on the Each, Count, First, and MustFirst method calls. 

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -95,9 +95,7 @@ func TestCanQueryInsideSystem(t *testing.T) {
 
 	gotNumOfEntities := 0
 	err := cardinal.RegisterSystems(world, func(worldCtx cardinal.WorldContext) error {
-		q, err := worldCtx.NewSearch(cardinal.Exact(Foo{}))
-		assert.NilError(t, err)
-		err = q.Each(worldCtx, func(cardinal.EntityID) bool {
+		err := worldCtx.NewSearch(cardinal.Exact(Foo{})).Each(worldCtx, func(cardinal.EntityID) bool {
 			gotNumOfEntities++
 			return true
 		})

--- a/cardinal/component_test.go
+++ b/cardinal/component_test.go
@@ -75,19 +75,15 @@ func TestComponentExample(t *testing.T) {
 	assert.NilError(t, cardinal.RemoveComponentFrom[Age](testWorldCtx, targetID))
 
 	// Age was removed form exactly 1 entity.
-	search, err := testWorldCtx.NewSearch(cardinal.Exact(Height{}, Weight{}))
-	assert.NilError(t, err)
-	count, err := search.Count(testWorldCtx)
+	count, err := testWorldCtx.NewSearch(cardinal.Exact(Height{}, Weight{})).Count(testWorldCtx)
 	assert.NilError(t, err)
 	assert.Equal(t, 1, count)
 
 	// The rest of the entities still have the Age field.
-	search, err = testWorldCtx.NewSearch(cardinal.Contains(Age{}))
-	assert.NilError(t, err)
-	count, err = search.Count(testWorldCtx)
+	count, err = testWorldCtx.NewSearch(cardinal.Contains(Age{})).Count(testWorldCtx)
 	assert.NilError(t, err)
 	assert.Equal(t, len(peopleIDs)-1, count)
-	first, err := search.First(testWorldCtx)
+	first, err := testWorldCtx.NewSearch(cardinal.Contains(Age{})).First(testWorldCtx)
 	assert.NilError(t, err)
 	assert.Equal(t, first, cardinal.EntityID(1))
 

--- a/cardinal/ecs/lazycontainer.go
+++ b/cardinal/ecs/lazycontainer.go
@@ -1,6 +1,6 @@
 package ecs
 
-// Lazy container can be moved to a package later.
+// Lazy container stores a closure that evaluates to T.
 type LazyContainer[T any] struct {
 	Unbox func() (T, error)
 }

--- a/cardinal/ecs/lazycontainer.go
+++ b/cardinal/ecs/lazycontainer.go
@@ -1,0 +1,12 @@
+package ecs
+
+// Lazy container can be moved to a package later.
+type LazyContainer[T any] struct {
+	Unbox func() (T, error)
+}
+
+func NewLazyContainer[T any](unboxMethod func() (T, error)) LazyContainer[T] {
+	return LazyContainer[T]{
+		Unbox: unboxMethod,
+	}
+}

--- a/cardinal/ecs/lazysearch.go
+++ b/cardinal/ecs/lazysearch.go
@@ -2,6 +2,8 @@ package ecs
 
 import "pkg.world.dev/world-engine/cardinal/types/entity"
 
+// LazySearch stores a LazyContainer of Search. It essentially delays the error created by instantiating search
+// so that the error happens on the method calls of Each, Count, First and MustFirst
 type LazySearch struct {
 	Container LazyContainer[*Search]
 }

--- a/cardinal/ecs/lazysearch.go
+++ b/cardinal/ecs/lazysearch.go
@@ -1,0 +1,43 @@
+package ecs
+
+import "pkg.world.dev/world-engine/cardinal/types/entity"
+
+type LazySearch struct {
+	Container LazyContainer[*Search]
+}
+
+func (q *LazySearch) Each(wCtx WorldContext, callback SearchCallBackFn) error {
+	query, err := q.Container.Unbox()
+	if err != nil {
+		return err
+	}
+	return query.Each(wCtx, callback)
+}
+
+func (q *LazySearch) Count(wCtx WorldContext) (int, error) {
+	query, err := q.Container.Unbox()
+	if err != nil {
+		return 0, err
+	}
+	return query.Count(wCtx)
+}
+
+func (q *LazySearch) First(wCtx WorldContext) (id entity.ID, err error) {
+	query, err := q.Container.Unbox()
+	if err != nil {
+		return 0, err
+	}
+	return query.First(wCtx)
+}
+
+func (q *LazySearch) MustFirst(wCtx WorldContext) entity.ID {
+	query, err := q.Container.Unbox()
+	if err != nil {
+		panic("error building query")
+	}
+	return query.MustFirst(wCtx)
+}
+
+func NewLazySearch(callback func() (*Search, error)) *LazySearch {
+	return &LazySearch{Container: NewLazyContainer(callback)}
+}

--- a/cardinal/ecs/world.go
+++ b/cardinal/ecs/world.go
@@ -11,9 +11,10 @@ import (
 	"sync/atomic"
 	"time"
 
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+
 	"github.com/redis/go-redis/v9"
 	"github.com/rotisserie/eris"
-	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 	"pkg.world.dev/world-engine/cardinal/statsd"
 	"pkg.world.dev/world-engine/cardinal/txpool"
 	"pkg.world.dev/world-engine/cardinal/types/message"
@@ -875,4 +876,10 @@ func (w *World) NewSearch(filter Filterable) (*Search, error) {
 		return nil, err
 	}
 	return NewSearch(componentFilter), nil
+}
+
+func (w *World) NewLazySearch(filter Filterable) *LazySearch {
+	return NewLazySearch(func() (*Search, error) {
+		return w.NewSearch(filter)
+	})
 }

--- a/cardinal/ecs/world_context.go
+++ b/cardinal/ecs/world_context.go
@@ -13,6 +13,7 @@ type WorldContext interface {
 	CurrentTick() uint64
 	Logger() *zerolog.Logger
 	NewSearch(filter Filterable) (*Search, error)
+	NewLazySearch(filter Filterable) *LazySearch
 
 	// For internal use.
 	GetWorld() *World
@@ -101,4 +102,8 @@ func (w *worldContext) StoreReader() store.Reader {
 
 func (w *worldContext) NewSearch(filter Filterable) (*Search, error) {
 	return w.world.NewSearch(filter)
+}
+
+func (w *worldContext) NewLazySearch(filter Filterable) *LazySearch {
+	return w.world.NewLazySearch(filter)
 }

--- a/cardinal/entity_test.go
+++ b/cardinal/entity_test.go
@@ -22,10 +22,8 @@ func TestCanRemoveEntity(t *testing.T) {
 
 	assert.NilError(t, cardinal.Remove(testWorldCtx, removeID))
 
-	search, err := testWorldCtx.NewSearch(cardinal.Exact(Alpha{}))
-	assert.NilError(t, err)
 	count := 0
-	assert.NilError(t, search.Each(testWorldCtx, func(id cardinal.EntityID) bool {
+	assert.NilError(t, testWorldCtx.NewSearch(cardinal.Exact(Alpha{})).Each(testWorldCtx, func(id cardinal.EntityID) bool {
 		assert.Equal(t, id, keepID)
 		count++
 		return true

--- a/cardinal/query_test.go
+++ b/cardinal/query_test.go
@@ -23,12 +23,9 @@ func handleQueryHealth(
 	worldCtx cardinal.WorldContext,
 	request *QueryHealthRequest,
 ) (*QueryHealthResponse, error) {
-	q, err := worldCtx.NewSearch(cardinal.Exact(Health{}))
-	if err != nil {
-		return nil, err
-	}
 	resp := &QueryHealthResponse{}
-	err = q.Each(worldCtx, func(id cardinal.EntityID) bool {
+	err := worldCtx.NewSearch(cardinal.Exact(Health{})).Each(worldCtx, func(id cardinal.EntityID) bool {
+		var err error
 		var health *Health
 		health, err = cardinal.GetComponent[Health](worldCtx, id)
 		if err != nil {

--- a/cardinal/search.go
+++ b/cardinal/search.go
@@ -7,7 +7,7 @@ import (
 
 // Search allowed for the querying of entities within a World.
 type Search struct {
-	impl *ecs.Search
+	impl *ecs.LazySearch
 }
 
 // SearchCallBackFn represents a function that can operate on a single EntityID, and returns whether the next EntityID

--- a/cardinal/search_test.go
+++ b/cardinal/search_test.go
@@ -86,11 +86,8 @@ func TestSearchExample(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		msg := "problem with " + tc.name
-		var q *cardinal.Search
-		q, err = worldCtx.NewSearch(tc.filter)
-		assert.NilError(t, err, msg)
 		var count int
-		count, err = q.Count(worldCtx)
+		count, err = worldCtx.NewSearch(tc.filter).Count(worldCtx)
 		assert.NilError(t, err, msg)
 		assert.Equal(t, tc.want, count, msg)
 	}

--- a/cardinal/system_test.go
+++ b/cardinal/system_test.go
@@ -18,21 +18,15 @@ type Health struct {
 func (Health) Name() string { return "health" }
 
 func HealthSystem(worldCtx cardinal.WorldContext) error {
-	q, err := worldCtx.NewSearch(cardinal.Exact(Health{}))
-	if err != nil {
-		return err
-	}
 	var errs []error
-	errs = append(errs, q.Each(worldCtx, func(id cardinal.EntityID) bool {
+	errs = append(errs, worldCtx.NewSearch(cardinal.Exact(Health{})).Each(worldCtx, func(id cardinal.EntityID) bool {
 		errs = append(errs, cardinal.UpdateComponent[Health](worldCtx, id, func(h *Health) *Health {
 			h.Value++
 			return h
 		}))
 		return true
 	}))
-	if err = errors.Join(errs...); err != nil {
-		return err
-	}
+	err := errors.Join(errs...)
 	return err
 }
 

--- a/cardinal/world_context.go
+++ b/cardinal/world_context.go
@@ -21,7 +21,7 @@ type WorldContext interface {
 	// if err != nil {
 	// 		return err
 	// }
-	NewSearch(filter Filter) (*Search, error)
+	NewSearch(filter Filter) *Search
 
 	// CurrentTick returns the current game tick of the world.
 	CurrentTick() uint64
@@ -57,12 +57,9 @@ func (wCtx *worldContext) Logger() *zerolog.Logger {
 	return wCtx.instance.Logger()
 }
 
-func (wCtx *worldContext) NewSearch(filter Filter) (*Search, error) {
-	ecsSearch, err := wCtx.instance.NewSearch(filter.convertToFilterable())
-	if err != nil {
-		return nil, err
-	}
-	return &Search{impl: ecsSearch}, nil
+func (wCtx *worldContext) NewSearch(filter Filter) *Search {
+	ecsLazySearch := wCtx.instance.NewLazySearch(filter.convertToFilterable())
+	return &Search{impl: ecsLazySearch}
 }
 
 func (wCtx *worldContext) Instance() ecs.WorldContext {


### PR DESCRIPTION
Closes: WORLD-699

Created a new search entity called `LazySearch` which holds something called a `LazyContainer` which holds `Search`

`LazySearch` acts very similarly to `Search` except when you instantiate `LazySearch` with the associated New method, it does not return an error. This error is forward to occur on the method calls as stated in the title. 