### PR TITLE
refactor(cardinal): change comp registration to hold additional data.

### DIFF
--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -139,7 +139,7 @@ func TestECS(t *testing.T) {
 	amt, err := q.Count(eCtx)
 	assert.NilError(t, err)
 	assert.Equal(t, numPlanets+numEnergyOnly, amt)
-	comp, err := engine.GetComponentByName("EnergyComponent")
+	comp, err := engine.GetComponentMetadataByName("EnergyComponent")
 	assert.NilError(t, err)
 	assert.Equal(t, comp.Name(), Energy.Name())
 }

--- a/cardinal/ecs/entity.go
+++ b/cardinal/ecs/entity.go
@@ -23,7 +23,7 @@ func CreateMany(eCtx EngineContext, num int, components ...component.Component) 
 	engine := eCtx.GetEngine()
 	acc := make([]component.ComponentMetadata, 0, len(components))
 	for _, comp := range components {
-		c, err := engine.GetComponentByName(comp.Name())
+		c, err := engine.GetComponentMetadataByName(comp.Name())
 		if err != nil {
 			return nil, err
 		}
@@ -36,7 +36,7 @@ func CreateMany(eCtx EngineContext, num int, components ...component.Component) 
 	for _, id := range entityIds {
 		for _, comp := range components {
 			var c component.ComponentMetadata
-			c, err = engine.GetComponentByName(comp.Name())
+			c, err = engine.GetComponentMetadataByName(comp.Name())
 			if err != nil {
 				return nil, eris.Wrap(err, "must register component before creating an entity")
 			}
@@ -58,7 +58,7 @@ func RemoveComponentFrom[T component.Component](eCtx EngineContext, id entity.ID
 	e := eCtx.GetEngine()
 	var t T
 	name := t.Name()
-	c, err := e.GetComponentByName(name)
+	c, err := e.GetComponentMetadataByName(name)
 	if err != nil {
 		return eris.Wrap(err, "must register component")
 	}
@@ -72,7 +72,7 @@ func AddComponentTo[T component.Component](eCtx EngineContext, id entity.ID) err
 	e := eCtx.GetEngine()
 	var t T
 	name := t.Name()
-	c, err := e.GetComponentByName(name)
+	c, err := e.GetComponentMetadataByName(name)
 	if err != nil {
 		return eris.Wrap(err, "must register component")
 	}
@@ -83,7 +83,7 @@ func AddComponentTo[T component.Component](eCtx EngineContext, id entity.ID) err
 func GetComponent[T component.Component](eCtx EngineContext, id entity.ID) (comp *T, err error) {
 	var t T
 	name := t.Name()
-	c, err := eCtx.GetEngine().GetComponentByName(name)
+	c, err := eCtx.GetEngine().GetComponentMetadataByName(name)
 	if err != nil {
 		return nil, eris.Wrap(err, "must register component")
 	}
@@ -111,7 +111,7 @@ func SetComponent[T component.Component](eCtx EngineContext, id entity.ID, compo
 	}
 	var t T
 	name := t.Name()
-	c, err := eCtx.GetEngine().GetComponentByName(name)
+	c, err := eCtx.GetEngine().GetComponentMetadataByName(name)
 	if err != nil {
 		return eris.Errorf("%s is not registered, please register it before updating", t.Name())
 	}

--- a/cardinal/ecs/filter.go
+++ b/cardinal/ecs/filter.go
@@ -91,7 +91,7 @@ func (s not) ConvertToComponentFilter(engine *Engine) (filter.ComponentFilter, e
 func (s contains) ConvertToComponentFilter(engine *Engine) (filter.ComponentFilter, error) {
 	acc := make([]component.ComponentMetadata, 0, len(s.components))
 	for _, internalComponent := range s.components {
-		c, err := engine.GetComponentByName(internalComponent.Name())
+		c, err := engine.GetComponentMetadataByName(internalComponent.Name())
 		if err != nil {
 			return nil, err
 		}
@@ -103,7 +103,7 @@ func (s contains) ConvertToComponentFilter(engine *Engine) (filter.ComponentFilt
 func (s exact) ConvertToComponentFilter(engine *Engine) (filter.ComponentFilter, error) {
 	acc := make([]component.ComponentMetadata, 0, len(s.components))
 	for _, internalComponent := range s.components {
-		c, err := engine.GetComponentByName(internalComponent.Name())
+		c, err := engine.GetComponentMetadataByName(internalComponent.Name())
 		if err != nil {
 			return nil, err
 		}

--- a/cardinal/ecs/filter/filter_test.go
+++ b/cardinal/ecs/filter/filter_test.go
@@ -126,7 +126,7 @@ func TestExactVsContains(t *testing.T) {
 	assert.NilError(t, err)
 	assert.Equal(t, count, alphaCount+bothCount)
 	count2 := 0
-	sameQuery, err := cql.Parse("CONTAINS(alpha)", engine.GetComponentByName)
+	sameQuery, err := cql.Parse("CONTAINS(alpha)", engine.GetComponentMetadataByName)
 	assert.NilError(t, err)
 	err = ecs.NewSearch(sameQuery).Each(
 		eCtx, func(id entity.ID) bool {
@@ -151,7 +151,7 @@ func TestExactVsContains(t *testing.T) {
 	assert.Equal(t, count, bothCount)
 
 	count2 = 0
-	sameQuery, err = cql.Parse("CONTAINS(beta)", engine.GetComponentByName)
+	sameQuery, err = cql.Parse("CONTAINS(beta)", engine.GetComponentMetadataByName)
 	assert.NilError(t, err)
 	err = ecs.NewSearch(sameQuery).Each(
 		eCtx, func(id entity.ID) bool {
@@ -175,7 +175,7 @@ func TestExactVsContains(t *testing.T) {
 	assert.Equal(t, count, alphaCount)
 
 	count2 = 0
-	sameQuery, err = cql.Parse("EXACT(alpha)", engine.GetComponentByName)
+	sameQuery, err = cql.Parse("EXACT(alpha)", engine.GetComponentMetadataByName)
 	assert.NilError(t, err)
 	err = ecs.NewSearch(sameQuery).Each(
 		eCtx, func(id entity.ID) bool {
@@ -200,7 +200,7 @@ func TestExactVsContains(t *testing.T) {
 	assert.Equal(t, count, bothCount)
 
 	count2 = 0
-	sameQuery, err = cql.Parse("EXACT(alpha, beta)", engine.GetComponentByName)
+	sameQuery, err = cql.Parse("EXACT(alpha, beta)", engine.GetComponentMetadataByName)
 	assert.NilError(t, err)
 	err = ecs.NewSearch(sameQuery).Each(
 		eCtx, func(id entity.ID) bool {
@@ -225,7 +225,7 @@ func TestExactVsContains(t *testing.T) {
 	assert.Equal(t, count, bothCount)
 
 	count2 = 0
-	sameQuery, err = cql.Parse("EXACT(beta, alpha)", engine.GetComponentByName)
+	sameQuery, err = cql.Parse("EXACT(beta, alpha)", engine.GetComponentMetadataByName)
 	assert.NilError(t, err)
 	err = ecs.NewSearch(sameQuery).Each(
 		eCtx, func(id entity.ID) bool {
@@ -276,7 +276,7 @@ func TestCanGetArchetypeFromEntity(t *testing.T) {
 	}
 	queryString += ")"
 
-	sameQuery, err := cql.Parse(queryString, engine.GetComponentByName)
+	sameQuery, err := cql.Parse(queryString, engine.GetComponentMetadataByName)
 	assert.NilError(t, err)
 	err = ecs.NewSearch(sameQuery).Each(
 		eCtx, func(id entity.ID) bool {

--- a/cardinal/ecs/log/log_test.go
+++ b/cardinal/ecs/log/log_test.go
@@ -114,7 +114,7 @@ func TestEngineLogger(t *testing.T) {
 `
 	require.JSONEq(t, jsonEngineInfoString, buf.String())
 	buf.Reset()
-	energy, err := engine.GetComponentByName(EnergyComp{}.Name())
+	energy, err := engine.GetComponentMetadataByName(EnergyComp{}.Name())
 	assert.NilError(t, err)
 	components := []component.ComponentMetadata{energy}
 	eCtx := ecs.NewEngineContext(engine)

--- a/cardinal/ecs/persona.go
+++ b/cardinal/ecs/persona.go
@@ -237,7 +237,7 @@ func (e *Engine) GetSignerForPersonaTag(personaTag string, tick uint64) (addr st
 func getComponent[T component.Component](eCtx EngineContext, id entity.ID) (comp *T, err error) {
 	var t T
 	name := t.Name()
-	c, err := eCtx.GetEngine().GetComponentByName(name)
+	c, err := eCtx.GetEngine().GetComponentMetadataByName(name)
 	if err != nil {
 		return nil, eris.Wrap(err, "must register component")
 	}
@@ -269,7 +269,7 @@ func setComponent[T component.Component](eCtx EngineContext, id entity.ID, compo
 	}
 	var t T
 	name := t.Name()
-	c, err := eCtx.GetEngine().GetComponentByName(name)
+	c, err := eCtx.GetEngine().GetComponentMetadataByName(name)
 	if err != nil {
 		return eris.Wrapf(err, "%s is not registered, please register it before updating", t.Name())
 	}
@@ -312,7 +312,7 @@ func createMany(eCtx EngineContext, num int, components ...component.Component) 
 	engine := eCtx.GetEngine()
 	acc := make([]component.ComponentMetadata, 0, len(components))
 	for _, comp := range components {
-		c, err := engine.GetComponentByName(comp.Name())
+		c, err := engine.GetComponentMetadataByName(comp.Name())
 		if err != nil {
 			return nil, err
 		}
@@ -324,7 +324,7 @@ func createMany(eCtx EngineContext, num int, components ...component.Component) 
 	}
 	for _, id := range entityIds {
 		for _, comp := range components {
-			c, err := engine.GetComponentByName(comp.Name())
+			c, err := engine.GetComponentMetadataByName(comp.Name())
 			if err != nil {
 				return nil, eris.Wrap(err, "must register component before creating an entity")
 			}

--- a/cardinal/ecs/state_test.go
+++ b/cardinal/ecs/state_test.go
@@ -92,7 +92,7 @@ func TestArchetypeIDIsConsistentAfterSaveAndLoad(t *testing.T) {
 
 	_, err := ecs.Create(ecs.NewEngineContext(oneEngine), NumberComponent{})
 	assert.NilError(t, err)
-	oneNum, err := oneEngine.GetComponentByName(NumberComponent{}.Name())
+	oneNum, err := oneEngine.GetComponentMetadataByName(NumberComponent{}.Name())
 	assert.NilError(t, err)
 	wantID, err := oneEngine.StoreManager().GetArchIDForComponents(comps(oneNum))
 	assert.NilError(t, err)
@@ -106,7 +106,7 @@ func TestArchetypeIDIsConsistentAfterSaveAndLoad(t *testing.T) {
 	twoEngine := testutil.InitEngineWithRedis(t, redisStore)
 	assert.NilError(t, ecs.RegisterComponent[NumberComponent](twoEngine))
 	assert.NilError(t, twoEngine.LoadGameState())
-	twoNum, err := twoEngine.GetComponentByName(NumberComponent{}.Name())
+	twoNum, err := twoEngine.GetComponentMetadataByName(NumberComponent{}.Name())
 	assert.NilError(t, err)
 	gotID, err := twoEngine.StoreManager().GetArchIDForComponents(comps(twoNum))
 	assert.NilError(t, err)
@@ -133,9 +133,9 @@ func TestCanRecoverArchetypeInformationAfterLoad(t *testing.T) {
 	assert.NilError(t, err)
 	_, err = ecs.Create(oneEngineCtx, OneAlphaNum{}, OneBetaNum{})
 	assert.NilError(t, err)
-	oneAlphaNum, err := oneEngine.GetComponentByName(OneAlphaNum{}.Name())
+	oneAlphaNum, err := oneEngine.GetComponentMetadataByName(OneAlphaNum{}.Name())
 	assert.NilError(t, err)
-	oneBetaNum, err := oneEngine.GetComponentByName(OneBetaNum{}.Name())
+	oneBetaNum, err := oneEngine.GetComponentMetadataByName(OneBetaNum{}.Name())
 	assert.NilError(t, err)
 	// At this point 3 archetypes exist:
 	// oneAlphaNum
@@ -216,7 +216,7 @@ func TestCanReloadState(t *testing.T) {
 	alphaEngine := testutil.InitEngineWithRedis(t, redisStore)
 	assert.NilError(t, ecs.RegisterComponent[oneAlphaNumComp](alphaEngine))
 
-	oneAlphaNum, err := alphaEngine.GetComponentByName(oneAlphaNumComp{}.Name())
+	oneAlphaNum, err := alphaEngine.GetComponentMetadataByName(oneAlphaNumComp{}.Name())
 	assert.NilError(t, err)
 	alphaEngine.RegisterSystem(
 		func(eCtx ecs.EngineContext) error {

--- a/cardinal/server/query.go
+++ b/cardinal/server/query.go
@@ -123,7 +123,7 @@ func (handler *Handler) registerQueryHandlerSwagger(api *untyped.API) error {
 					eris.Errorf("json is invalid"),
 				), nil
 			}
-			resultFilter, err := cql.Parse(cqlString, handler.w.GetComponentByName)
+			resultFilter, err := cql.Parse(cqlString, handler.w.GetComponentMetadataByName)
 			if err != nil {
 				return middleware.Error(http.StatusUnprocessableEntity, err), nil
 			}

--- a/cardinal/types/component/component_test.go
+++ b/cardinal/types/component/component_test.go
@@ -59,9 +59,9 @@ func TestComponents(t *testing.T) {
 	ecs.MustRegisterComponent[ComponentDataA](engine)
 	ecs.MustRegisterComponent[ComponentDataB](engine)
 
-	ca, err := engine.GetComponentByName("a")
+	ca, err := engine.GetComponentMetadataByName("a")
 	assert.NilError(t, err)
-	cb, err := engine.GetComponentByName("b")
+	cb, err := engine.GetComponentMetadataByName("b")
 	assert.NilError(t, err)
 
 	tests := []*struct {


### PR DESCRIPTION
Closes: WORLD-705

Register an instance of a component during component registration. For various reasons Scott wants a specific implementation of `NewSearch` The change he wants necessitates that CQL should be able to compile into `Filterable` components. So modifications to the parser and all related unit tests are needed. The first part for the parser change is that we have to register components which is required to build the FIlterable object. 

Most of the code below involves a rename. The main change is the addition of a `map[string]component.Component` on the `ecs.world` type (now called `engine`)