### PR TITLE
refactor(cardinal): make ComponentFilter use component.Component

### DIFF
--- a/cardinal/ecs/cql/cql.go
+++ b/cardinal/ecs/cql/cql.go
@@ -155,7 +155,7 @@ func valueToComponentFilter(value *cqlValue, stringToComponent func(string) (com
 		if len(value.Exact.Components) == 0 {
 			return nil, eris.New("EXACT cannot have zero parameters")
 		}
-		components := make([]component.ComponentMetadata, 0, len(value.Exact.Components))
+		components := make([]component.Component, 0, len(value.Exact.Components))
 		for _, componentName := range value.Exact.Components {
 			comp, err := stringToComponent(componentName.Name)
 			if err != nil {
@@ -168,7 +168,7 @@ func valueToComponentFilter(value *cqlValue, stringToComponent func(string) (com
 		if len(value.Contains.Components) == 0 {
 			return nil, eris.New("CONTAINS cannot have zero parameters")
 		}
-		components := make([]component.ComponentMetadata, 0, len(value.Contains.Components))
+		components := make([]component.Component, 0, len(value.Contains.Components))
 		for _, componentName := range value.Contains.Components {
 			comp, err := stringToComponent(componentName.Name)
 			if err != nil {

--- a/cardinal/ecs/ecb/ecb.go
+++ b/cardinal/ecs/ecb/ecb.go
@@ -177,7 +177,7 @@ func (m *Manager) SetComponentForEntity(cType component.ComponentMetadata, id en
 	if err != nil {
 		return err
 	}
-	if !filter.MatchComponentMetaData(comps, cType) {
+	if !filter.MatchComponentMetadata(comps, cType) {
 		return eris.Wrap(storage.ErrComponentNotOnEntity, "")
 	}
 
@@ -198,7 +198,7 @@ func (m *Manager) GetComponentForEntity(cType component.ComponentMetadata, id en
 	if err != nil {
 		return nil, err
 	}
-	if !filter.MatchComponentMetaData(comps, cType) {
+	if !filter.MatchComponentMetadata(comps, cType) {
 		return nil, eris.Wrap(storage.ErrComponentNotOnEntity, "")
 	}
 
@@ -243,7 +243,7 @@ func (m *Manager) AddComponentToEntity(cType component.ComponentMetadata, id ent
 	if err != nil {
 		return err
 	}
-	if filter.MatchComponentMetaData(fromComps, cType) {
+	if filter.MatchComponentMetadata(fromComps, cType) {
 		return eris.Wrap(storage.ErrComponentAlreadyOnEntity, "")
 	}
 	toComps := append(fromComps, cType) //nolint:gocritic // easier this way.
@@ -346,7 +346,7 @@ func (m *Manager) SearchFrom(filter filter.ComponentFilter, start int) *storage.
 	itr := &storage.ArchetypeIterator{}
 	for i := start; i < len(m.archIDToComps); i++ {
 		archID := archetype.ID(i)
-		if !filter.MatchesComponents(m.archIDToComps[archID]) {
+		if !filter.MatchesComponents(component.ConvertComponentMetadatasToComponents(m.archIDToComps[archID])) {
 			continue
 		}
 		itr.Values = append(itr.Values, archID)

--- a/cardinal/ecs/ecb/read_only.go
+++ b/cardinal/ecs/ecb/read_only.go
@@ -151,7 +151,7 @@ func (r *readOnlyManager) SearchFrom(filter filter.ComponentFilter, start int) *
 	}
 	for i := start; i < len(r.archIDToComps); i++ {
 		archID := archetype.ID(i)
-		if !filter.MatchesComponents(r.archIDToComps[archID]) {
+		if !filter.MatchesComponents(component.ConvertComponentMetadatasToComponents(r.archIDToComps[archID])) {
 			continue
 		}
 		itr.Values = append(itr.Values, archID)

--- a/cardinal/ecs/filter.go
+++ b/cardinal/ecs/filter.go
@@ -88,28 +88,12 @@ func (s not) ConvertToComponentFilter(engine *Engine) (filter.ComponentFilter, e
 	return filter.Not(f), nil
 }
 
-func (s contains) ConvertToComponentFilter(engine *Engine) (filter.ComponentFilter, error) {
-	acc := make([]component.ComponentMetadata, 0, len(s.components))
-	for _, internalComponent := range s.components {
-		c, err := engine.GetComponentByName(internalComponent.Name())
-		if err != nil {
-			return nil, err
-		}
-		acc = append(acc, c)
-	}
-	return filter.Contains(acc...), nil
+func (s contains) ConvertToComponentFilter(_ *Engine) (filter.ComponentFilter, error) {
+	return filter.Contains(s.components...), nil
 }
 
-func (s exact) ConvertToComponentFilter(engine *Engine) (filter.ComponentFilter, error) {
-	acc := make([]component.ComponentMetadata, 0, len(s.components))
-	for _, internalComponent := range s.components {
-		c, err := engine.GetComponentByName(internalComponent.Name())
-		if err != nil {
-			return nil, err
-		}
-		acc = append(acc, c)
-	}
-	return filter.Exact(acc...), nil
+func (s exact) ConvertToComponentFilter(_ *Engine) (filter.ComponentFilter, error) {
+	return filter.Exact(s.components...), nil
 }
 
 func (a all) ConvertToComponentFilter(_ *Engine) (filter.ComponentFilter, error) {

--- a/cardinal/ecs/filter/all.go
+++ b/cardinal/ecs/filter/all.go
@@ -9,6 +9,6 @@ func All() ComponentFilter {
 	return &all{}
 }
 
-func (f *all) MatchesComponents(_ []component.ComponentMetadata) bool {
+func (f *all) MatchesComponents(_ []component.Component) bool {
 	return true
 }

--- a/cardinal/ecs/filter/and.go
+++ b/cardinal/ecs/filter/and.go
@@ -10,7 +10,7 @@ func And(filters ...ComponentFilter) ComponentFilter {
 	return &and{filters: filters}
 }
 
-func (f *and) MatchesComponents(components []component.ComponentMetadata) bool {
+func (f *and) MatchesComponents(components []component.Component) bool {
 	for _, filter := range f.filters {
 		if !filter.MatchesComponents(components) {
 			return false

--- a/cardinal/ecs/filter/contains.go
+++ b/cardinal/ecs/filter/contains.go
@@ -3,17 +3,17 @@ package filter
 import "pkg.world.dev/world-engine/cardinal/types/component"
 
 type contains struct {
-	components []component.ComponentMetadata
+	components []component.Component
 }
 
 // Contains matches archetypes that contain all the components specified.
-func Contains(components ...component.ComponentMetadata) ComponentFilter {
+func Contains(components ...component.Component) ComponentFilter {
 	return &contains{components: components}
 }
 
-func (f *contains) MatchesComponents(components []component.ComponentMetadata) bool {
+func (f *contains) MatchesComponents(components []component.Component) bool {
 	for _, componentType := range f.components {
-		if !MatchComponentMetaData(components, componentType) {
+		if !MatchComponent(components, componentType) {
 			return false
 		}
 	}

--- a/cardinal/ecs/filter/exact.go
+++ b/cardinal/ecs/filter/exact.go
@@ -3,22 +3,22 @@ package filter
 import "pkg.world.dev/world-engine/cardinal/types/component"
 
 type exact struct {
-	components []component.ComponentMetadata
+	components []component.Component
 }
 
 // Exact matches archetypes that contain exactly the same components specified.
-func Exact(components ...component.ComponentMetadata) ComponentFilter {
+func Exact(components ...component.Component) ComponentFilter {
 	return exact{
 		components: components,
 	}
 }
 
-func (f exact) MatchesComponents(components []component.ComponentMetadata) bool {
+func (f exact) MatchesComponents(components []component.Component) bool {
 	if len(components) != len(f.components) {
 		return false
 	}
 	for _, componentType := range components {
-		if !MatchComponentMetaData(f.components, componentType) {
+		if !MatchComponent(f.components, componentType) {
 			return false
 		}
 	}

--- a/cardinal/ecs/filter/filter.go
+++ b/cardinal/ecs/filter/filter.go
@@ -5,5 +5,5 @@ import "pkg.world.dev/world-engine/cardinal/types/component"
 // ComponentFilter is a filter that filters entities based on their components.
 type ComponentFilter interface {
 	// MatchesComponents returns true if the entity matches the filter.
-	MatchesComponents(components []component.ComponentMetadata) bool
+	MatchesComponents(components []component.Component) bool
 }

--- a/cardinal/ecs/filter/filter_test.go
+++ b/cardinal/ecs/filter/filter_test.go
@@ -2,6 +2,7 @@ package filter_test
 
 import (
 	"fmt"
+	"pkg.world.dev/world-engine/cardinal/types/component"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -256,7 +257,7 @@ func TestCanGetArchetypeFromEntity(t *testing.T) {
 	assert.NilError(t, err)
 
 	count := 0
-	err = ecs.NewSearch(filter.Exact(comps...)).Each(
+	err = ecs.NewSearch(filter.Exact(component.ConvertComponentMetadatasToComponents(comps)...)).Each(
 		eCtx, func(id entity.ID) bool {
 			count++
 			return true

--- a/cardinal/ecs/filter/helper.go
+++ b/cardinal/ecs/filter/helper.go
@@ -2,14 +2,28 @@ package filter
 
 import "pkg.world.dev/world-engine/cardinal/types/component"
 
-// MatchComponentMetaData returns true if the given slice of components contains the given component. Components are the
-// same if they have the same ID.
-func MatchComponentMetaData(
+// MatchComponentMetadata returns true if the given slice of components contains the given component.
+// Components are the same if they have the same Name.
+func MatchComponentMetadata(
 	components []component.ComponentMetadata,
 	cType component.ComponentMetadata,
 ) bool {
 	for _, c := range components {
-		if cType.ID() == c.ID() {
+		if cType.Name() == c.Name() {
+			return true
+		}
+	}
+	return false
+}
+
+// MatchComponent returns true if the given slice of components contains the given component.
+// Components are the same if they have the same Name.
+func MatchComponent(
+	components []component.Component,
+	cType component.Component,
+) bool {
+	for _, c := range components {
+		if cType.Name() == c.Name() {
 			return true
 		}
 	}

--- a/cardinal/ecs/filter/not.go
+++ b/cardinal/ecs/filter/not.go
@@ -10,6 +10,6 @@ type not struct {
 	filter ComponentFilter
 }
 
-func (f *not) MatchesComponents(components []component.ComponentMetadata) bool {
+func (f *not) MatchesComponents(components []component.Component) bool {
 	return !f.filter.MatchesComponents(components)
 }

--- a/cardinal/ecs/filter/or.go
+++ b/cardinal/ecs/filter/or.go
@@ -10,7 +10,7 @@ func Or(filters ...ComponentFilter) ComponentFilter {
 	return &or{filters: filters}
 }
 
-func (f *or) MatchesComponents(components []component.ComponentMetadata) bool {
+func (f *or) MatchesComponents(components []component.Component) bool {
 	for _, filter := range f.filters {
 		if filter.MatchesComponents(components) {
 			return true

--- a/cardinal/ecs/state_test.go
+++ b/cardinal/ecs/state_test.go
@@ -98,7 +98,7 @@ func TestArchetypeIDIsConsistentAfterSaveAndLoad(t *testing.T) {
 	assert.NilError(t, err)
 	wantComps := oneEngine.StoreManager().GetComponentTypesForArchID(wantID)
 	assert.Equal(t, 1, len(wantComps))
-	assert.Check(t, filter.MatchComponentMetaData(wantComps, oneNum))
+	assert.Check(t, filter.MatchComponent(component.ConvertComponentMetadatasToComponents(wantComps), oneNum))
 
 	assert.NilError(t, oneEngine.Tick(context.Background()))
 
@@ -112,7 +112,7 @@ func TestArchetypeIDIsConsistentAfterSaveAndLoad(t *testing.T) {
 	assert.NilError(t, err)
 	gotComps := twoEngine.StoreManager().GetComponentTypesForArchID(gotID)
 	assert.Equal(t, 1, len(gotComps))
-	assert.Check(t, filter.MatchComponentMetaData(gotComps, twoNum))
+	assert.Check(t, filter.MatchComponent(component.ConvertComponentMetadatasToComponents(gotComps), twoNum))
 
 	// Archetype indices should be the same across save/load cycles
 	assert.Equal(t, wantID, gotID)

--- a/cardinal/types/component/component_test.go
+++ b/cardinal/types/component/component_test.go
@@ -96,20 +96,20 @@ func TestComponents(t *testing.T) {
 	for _, tt := range tests {
 		componentsForArchID := storeManager.GetComponentTypesForArchID(tt.archID)
 		for _, comp := range tt.comps {
-			ok := filter.MatchComponentMetaData(componentsForArchID, comp)
+			ok := filter.MatchComponent(component.ConvertComponentMetadatasToComponents(componentsForArchID), comp)
 			if !ok {
 				t.Errorf("the archetype ID %d should contain the component %d", tt.archID, comp.ID())
 			}
 			iface, err := storeManager.GetComponentForEntity(comp, tt.entityID)
 			assert.NilError(t, err)
 
-			switch component := iface.(type) {
+			switch comp := iface.(type) {
 			case ComponentDataA:
-				component.Value = tt.Value
-				assert.NilError(t, storeManager.SetComponentForEntity(ca, tt.entityID, component))
+				comp.Value = tt.Value
+				assert.NilError(t, storeManager.SetComponentForEntity(ca, tt.entityID, comp))
 			case ComponentDataB:
-				component.Value = tt.Value
-				assert.NilError(t, storeManager.SetComponentForEntity(cb, tt.entityID, component))
+				comp.Value = tt.Value
+				assert.NilError(t, storeManager.SetComponentForEntity(cb, tt.entityID, comp))
 			default:
 				assert.Check(t, false, "unknown component type: %v", iface)
 			}

--- a/cardinal/types/component/utils.go
+++ b/cardinal/types/component/utils.go
@@ -1,0 +1,10 @@
+package component
+
+// ConvertComponentMetadatasToComponents Cast an array of ComponentMetadata into an array of Component
+func ConvertComponentMetadatasToComponents(comps []ComponentMetadata) []Component {
+	ret := make([]Component, len(comps))
+	for i, comp := range comps {
+		ret[i] = comp
+	}
+	return ret
+}


### PR DESCRIPTION
Closes: WORLD-707

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

This is PR 1 out of 2 to refactor the Search system. This PR is focused on refactoring
`filter.ComponentFilter` to work wih `component.Component` instead of `component.ComponentMetadata`.

By doing this, we will be able to make `filter.ComponentFilter` the main way to do filter throughout
the codebase. 

## Brief Changelog

- Refactor ComponentFilter to take in component.ComponentMetadata
- Minor adjustment to CQL to accomodate this new change
- Minor adjustment to tests to accomodate this new change


## Testing and Verifying

- Existing unit tests have been adjusted to accomodate this change

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
