### PR TITLE
refactor(nakama): isolate allowlist and notifications

### DIFF
--- a/relay/nakama/allowlist/allowlist.go
+++ b/relay/nakama/allowlist/allowlist.go
@@ -1,4 +1,4 @@
-package main
+package allowlist
 
 import (
 	"context"
@@ -25,7 +25,7 @@ var (
 	allowedUsers           = "allowed_users"
 )
 
-func initAllowlist(_ runtime.Logger, initializer runtime.Initializer) error {
+func InitAllowlist(_ runtime.Logger, initializer runtime.Initializer) error {
 	enabledStr := os.Getenv(allowlistEnabledEnvVar)
 	if enabledStr == "" {
 		return nil
@@ -144,7 +144,7 @@ func claimKeyRPC(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk runti
 		return utils.LogErrorWithMessageAndCode(logger, err, nakamaerrors.NotFound, "unable to get userID: %v", err)
 	}
 
-	if verified, err := isUserVerified(ctx, nk, userID); err != nil {
+	if verified, err := IsUserVerified(ctx, nk, userID); err != nil {
 		return utils.LogErrorMessageFailedPrecondition(logger, err, "failed to check beta key status")
 	} else if verified {
 		msg := fmt.Sprintf("user %q already verified with a beta key", userID)
@@ -215,8 +215,8 @@ func writeVerified(ctx context.Context, nk runtime.NakamaModule, userID string) 
 	return err
 }
 
-// isUserVerified returns true if the user has registered a beta key and false if they have not registered a beta key.
-func isUserVerified(ctx context.Context, nk runtime.NakamaModule, userID string) (verified bool, err error) {
+// IsUserVerified returns true if the user has registered a beta key and false if they have not registered a beta key.
+func IsUserVerified(ctx context.Context, nk runtime.NakamaModule, userID string) (verified bool, err error) {
 	if !allowlistEnabled {
 		// When allowlist is disabled, treat all users as if they were on the allowlist
 		return true, nil

--- a/relay/nakama/allowlist/allowlist_test.go
+++ b/relay/nakama/allowlist/allowlist_test.go
@@ -1,4 +1,4 @@
-package main
+package allowlist
 
 import (
 	"context"
@@ -110,14 +110,14 @@ func (a *AllowListTestSuite) TestCanDisableAllowList() {
 	}
 	for _, tc := range testCases {
 		t.Setenv(allowlistEnabledEnvVar, tc)
-		assert.NilError(t, initAllowlist(nil, nil))
+		assert.NilError(t, InitAllowlist(nil, nil))
 		assert.Equal(t, false, allowlistEnabled)
 	}
 }
 
 func (a *AllowListTestSuite) TestRejectBadAllowListFlag() {
 	a.T().Setenv(allowlistEnabledEnvVar, "unclear-boolean-value")
-	assert.IsError(a.T(), initAllowlist(nil, nil))
+	assert.IsError(a.T(), InitAllowlist(nil, nil))
 }
 
 func (a *AllowListTestSuite) TestCanEnableAllowList() {
@@ -135,7 +135,7 @@ func (a *AllowListTestSuite) TestCanEnableAllowList() {
 		initializer.On("RegisterRpc", "claim-key", mock.Anything).
 			Return(nil)
 
-		assert.NilError(a.T(), initAllowlist(nil, initializer))
+		assert.NilError(a.T(), InitAllowlist(nil, initializer))
 		assert.Equal(a.T(), true, allowlistEnabled)
 	}
 }
@@ -146,7 +146,7 @@ func (a *AllowListTestSuite) TestAllowListFailsIfRPCRegistrationFails() {
 	initializer.On("RegisterRpc", "generate-beta-keys", mock.Anything).
 		Return(errors.New("failed to register"))
 
-	assert.IsError(a.T(), initAllowlist(nil, initializer))
+	assert.IsError(a.T(), InitAllowlist(nil, initializer))
 
 	initializer = mocks.NewInitializer(a.T())
 	initializer.On("RegisterRpc", "generate-beta-keys", mock.Anything).
@@ -155,7 +155,7 @@ func (a *AllowListTestSuite) TestAllowListFailsIfRPCRegistrationFails() {
 	initializer.On("RegisterRpc", "claim-key", mock.Anything).
 		Return(errors.New("failed to register"))
 
-	assert.IsError(a.T(), initAllowlist(nil, initializer))
+	assert.IsError(a.T(), InitAllowlist(nil, initializer))
 }
 
 func (a *AllowListTestSuite) TestCanHandleBetaKeyGenerationFailures() {

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -9,9 +9,10 @@ import (
 	"io"
 	"net/http"
 	"os"
-	"pkg.world.dev/world-engine/relay/nakama/dispatcher"
+	"pkg.world.dev/world-engine/relay/nakama/allowlist"
 	nakamaerrors "pkg.world.dev/world-engine/relay/nakama/errors"
 	"pkg.world.dev/world-engine/relay/nakama/persona"
+	"pkg.world.dev/world-engine/relay/nakama/receipt"
 	"pkg.world.dev/world-engine/relay/nakama/signer"
 	"pkg.world.dev/world-engine/relay/nakama/utils"
 	"strings"
@@ -35,7 +36,7 @@ var (
 	globalCardinalAddress      string
 	globalNamespace            string
 	globalPersonaTagAssignment = sync.Map{}
-	globalReceiptsDispatcher   *dispatcher.ReceiptsDispatcher
+	globalReceiptsDispatcher   *receipt.ReceiptsDispatcher
 )
 
 func InitModule(
@@ -61,7 +62,7 @@ func InitModule(
 		return eris.Wrap(err, "failed to init event hub")
 	}
 
-	notifier := newReceiptNotifier(logger, nk)
+	notifier := receipt.NewNotifier(logger, nk, globalReceiptsDispatcher)
 
 	if err := signer.InitPrivateKey(ctx, logger, nk); err != nil {
 		return eris.Wrap(err, "failed to init private key")
@@ -81,7 +82,7 @@ func InitModule(
 		return eris.Wrap(err, "failed to init cardinal endpoints")
 	}
 
-	if err := initAllowlist(logger, initializer); err != nil {
+	if err := allowlist.InitAllowlist(logger, initializer); err != nil {
 		return eris.Wrap(err, "failed to init allowlist endpoints")
 	}
 
@@ -97,7 +98,7 @@ func InitModule(
 }
 
 func initReceiptDispatcher(log runtime.Logger) {
-	globalReceiptsDispatcher = dispatcher.NewReceiptsDispatcher()
+	globalReceiptsDispatcher = receipt.NewReceiptsDispatcher()
 	go globalReceiptsDispatcher.PollReceipts(log, globalCardinalAddress)
 	go globalReceiptsDispatcher.Dispatch(log)
 }
@@ -171,7 +172,7 @@ func initPersonaTagEndpoints(
 	_ runtime.Logger,
 	initializer runtime.Initializer,
 	ptv *persona.Verifier,
-	notifier *receiptNotifier) error {
+	notifier *receipt.Notifier) error {
 	if err := initializer.RegisterRpc("nakama/claim-persona", handleClaimPersona(ptv, notifier)); err != nil {
 		return eris.Wrap(err, "")
 	}
@@ -186,7 +187,7 @@ type nakamaRPCHandler func(ctx context.Context, logger runtime.Logger, db *sql.D
 // handleClaimPersona handles a request to Nakama to associate the current user with the persona tag in the payload.
 //
 //nolint:gocognit
-func handleClaimPersona(ptv *persona.Verifier, notifier *receiptNotifier) nakamaRPCHandler {
+func handleClaimPersona(ptv *persona.Verifier, notifier *receipt.Notifier) nakamaRPCHandler {
 	return func(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, payload string) (
 		string, error) {
 		userID, err := utils.GetUserID(ctx)
@@ -195,7 +196,7 @@ func handleClaimPersona(ptv *persona.Verifier, notifier *receiptNotifier) nakama
 		}
 
 		// check if the user is verified. this requires them to input a valid beta key.
-		if verified, err := isUserVerified(ctx, nk, userID); err != nil {
+		if verified, err := allowlist.IsUserVerified(ctx, nk, userID); err != nil {
 			return utils.LogErrorMessageFailedPrecondition(logger, err, "unable to claim persona tag")
 		} else if !verified {
 			return utils.LogDebugWithMessageAndCode(
@@ -308,7 +309,11 @@ func handleShowPersona(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk
 // set up RPC wrappers around each one.
 //
 //nolint:gocognit,funlen // its fine.
-func initCardinalEndpoints(logger runtime.Logger, initializer runtime.Initializer, notify *receiptNotifier) error {
+func initCardinalEndpoints(
+	logger runtime.Logger,
+	initializer runtime.Initializer,
+	notify *receipt.Notifier,
+) error {
 	txEndpoints, queryEndpoints, err := getCardinalEndpoints()
 	if err != nil {
 		return err

--- a/relay/nakama/mocks/mock_Match.go
+++ b/relay/nakama/mocks/mock_Match.go
@@ -93,7 +93,7 @@ func (_c *Match_MatchInit_Call) RunAndReturn(run func(context.Context, runtime.L
 	return _c
 }
 
-// MatchJoin provides a mock function with given fields: ctx, logger, db, nk, dispatcher, tick, state, presences
+// MatchJoin provides a mock function with given fields: ctx, logger, db, nk, receipt, tick, state, presences
 func (_m *Match) MatchJoin(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, dispatcher runtime.MatchDispatcher, tick int64, state interface{}, presences []runtime.Presence) interface{} {
 	ret := _m.Called(ctx, logger, db, nk, dispatcher, tick, state, presences)
 
@@ -123,7 +123,7 @@ type Match_MatchJoin_Call struct {
 //   - logger runtime.Logger
 //   - db *sql.DB
 //   - nk runtime.NakamaModule
-//   - dispatcher runtime.MatchDispatcher
+//   - receipt runtime.MatchDispatcher
 //   - tick int64
 //   - state interface{}
 //   - presences []runtime.Presence
@@ -148,7 +148,7 @@ func (_c *Match_MatchJoin_Call) RunAndReturn(run func(context.Context, runtime.L
 	return _c
 }
 
-// MatchJoinAttempt provides a mock function with given fields: ctx, logger, db, nk, dispatcher, tick, state, presence, metadata
+// MatchJoinAttempt provides a mock function with given fields: ctx, logger, db, nk, receipt, tick, state, presence, metadata
 func (_m *Match) MatchJoinAttempt(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, dispatcher runtime.MatchDispatcher, tick int64, state interface{}, presence runtime.Presence, metadata map[string]string) (interface{}, bool, string) {
 	ret := _m.Called(ctx, logger, db, nk, dispatcher, tick, state, presence, metadata)
 
@@ -195,7 +195,7 @@ type Match_MatchJoinAttempt_Call struct {
 //   - logger runtime.Logger
 //   - db *sql.DB
 //   - nk runtime.NakamaModule
-//   - dispatcher runtime.MatchDispatcher
+//   - receipt runtime.MatchDispatcher
 //   - tick int64
 //   - state interface{}
 //   - presence runtime.Presence
@@ -221,7 +221,7 @@ func (_c *Match_MatchJoinAttempt_Call) RunAndReturn(run func(context.Context, ru
 	return _c
 }
 
-// MatchLeave provides a mock function with given fields: ctx, logger, db, nk, dispatcher, tick, state, presences
+// MatchLeave provides a mock function with given fields: ctx, logger, db, nk, receipt, tick, state, presences
 func (_m *Match) MatchLeave(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, dispatcher runtime.MatchDispatcher, tick int64, state interface{}, presences []runtime.Presence) interface{} {
 	ret := _m.Called(ctx, logger, db, nk, dispatcher, tick, state, presences)
 
@@ -251,7 +251,7 @@ type Match_MatchLeave_Call struct {
 //   - logger runtime.Logger
 //   - db *sql.DB
 //   - nk runtime.NakamaModule
-//   - dispatcher runtime.MatchDispatcher
+//   - receipt runtime.MatchDispatcher
 //   - tick int64
 //   - state interface{}
 //   - presences []runtime.Presence
@@ -276,7 +276,7 @@ func (_c *Match_MatchLeave_Call) RunAndReturn(run func(context.Context, runtime.
 	return _c
 }
 
-// MatchLoop provides a mock function with given fields: ctx, logger, db, nk, dispatcher, tick, state, messages
+// MatchLoop provides a mock function with given fields: ctx, logger, db, nk, receipt, tick, state, messages
 func (_m *Match) MatchLoop(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, dispatcher runtime.MatchDispatcher, tick int64, state interface{}, messages []runtime.MatchData) interface{} {
 	ret := _m.Called(ctx, logger, db, nk, dispatcher, tick, state, messages)
 
@@ -306,7 +306,7 @@ type Match_MatchLoop_Call struct {
 //   - logger runtime.Logger
 //   - db *sql.DB
 //   - nk runtime.NakamaModule
-//   - dispatcher runtime.MatchDispatcher
+//   - receipt runtime.MatchDispatcher
 //   - tick int64
 //   - state interface{}
 //   - messages []runtime.MatchData
@@ -331,7 +331,7 @@ func (_c *Match_MatchLoop_Call) RunAndReturn(run func(context.Context, runtime.L
 	return _c
 }
 
-// MatchSignal provides a mock function with given fields: ctx, logger, db, nk, dispatcher, tick, state, data
+// MatchSignal provides a mock function with given fields: ctx, logger, db, nk, receipt, tick, state, data
 func (_m *Match) MatchSignal(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, dispatcher runtime.MatchDispatcher, tick int64, state interface{}, data string) (interface{}, string) {
 	ret := _m.Called(ctx, logger, db, nk, dispatcher, tick, state, data)
 
@@ -371,7 +371,7 @@ type Match_MatchSignal_Call struct {
 //   - logger runtime.Logger
 //   - db *sql.DB
 //   - nk runtime.NakamaModule
-//   - dispatcher runtime.MatchDispatcher
+//   - receipt runtime.MatchDispatcher
 //   - tick int64
 //   - state interface{}
 //   - data string
@@ -396,7 +396,7 @@ func (_c *Match_MatchSignal_Call) RunAndReturn(run func(context.Context, runtime
 	return _c
 }
 
-// MatchTerminate provides a mock function with given fields: ctx, logger, db, nk, dispatcher, tick, state, graceSeconds
+// MatchTerminate provides a mock function with given fields: ctx, logger, db, nk, receipt, tick, state, graceSeconds
 func (_m *Match) MatchTerminate(ctx context.Context, logger runtime.Logger, db *sql.DB, nk runtime.NakamaModule, dispatcher runtime.MatchDispatcher, tick int64, state interface{}, graceSeconds int) interface{} {
 	ret := _m.Called(ctx, logger, db, nk, dispatcher, tick, state, graceSeconds)
 
@@ -426,7 +426,7 @@ type Match_MatchTerminate_Call struct {
 //   - logger runtime.Logger
 //   - db *sql.DB
 //   - nk runtime.NakamaModule
-//   - dispatcher runtime.MatchDispatcher
+//   - receipt runtime.MatchDispatcher
 //   - tick int64
 //   - state interface{}
 //   - graceSeconds int

--- a/relay/nakama/persona/persona_tag_verifier.go
+++ b/relay/nakama/persona/persona_tag_verifier.go
@@ -2,7 +2,7 @@ package persona
 
 import (
 	"context"
-	"pkg.world.dev/world-engine/relay/nakama/dispatcher"
+	"pkg.world.dev/world-engine/relay/nakama/receipt"
 	"time"
 
 	"github.com/heroiclabs/nakama-common/runtime"
@@ -18,7 +18,7 @@ type Verifier struct {
 	// because all map updates happen in a single goroutine. Updates are transmitted to the goroutine
 	// via the receiptCh channel and the pendingCh channel.
 	txHashToPending map[string]pendingPersonaTagRequest
-	receiptCh       chan *dispatcher.Receipt
+	receiptCh       chan *receipt.Receipt
 	pendingCh       chan txHashAndUserID
 	nk              runtime.NakamaModule
 	logger          runtime.Logger
@@ -44,12 +44,12 @@ func (p *Verifier) AddPendingPersonaTag(userID, txHash string) {
 	}
 }
 
-func NewVerifier(logger runtime.Logger, nk runtime.NakamaModule, rd *dispatcher.ReceiptsDispatcher,
+func NewVerifier(logger runtime.Logger, nk runtime.NakamaModule, rd *receipt.ReceiptsDispatcher,
 ) *Verifier {
 	channelLimit := 100
 	ptv := &Verifier{
 		txHashToPending: map[string]pendingPersonaTagRequest{},
-		receiptCh:       make(chan *dispatcher.Receipt, channelLimit),
+		receiptCh:       make(chan *receipt.Receipt, channelLimit),
 		pendingCh:       make(chan txHashAndUserID),
 		nk:              nk,
 		logger:          logger,
@@ -88,7 +88,7 @@ func (p *Verifier) cleanupStaleEntries(now time.Time) {
 	}
 }
 
-func (p *Verifier) handleReceipt(receipt *dispatcher.Receipt) string {
+func (p *Verifier) handleReceipt(receipt *receipt.Receipt) string {
 	result, ok := receipt.Result["Success"]
 	if !ok {
 		return ""

--- a/relay/nakama/receipt/dispatcher.go
+++ b/relay/nakama/receipt/dispatcher.go
@@ -1,4 +1,4 @@
-package dispatcher
+package receipt
 
 import (
 	"bytes"

--- a/relay/nakama/save.go
+++ b/relay/nakama/save.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
+	"pkg.world.dev/world-engine/relay/nakama/allowlist"
 	nakamaerrors "pkg.world.dev/world-engine/relay/nakama/errors"
 	"pkg.world.dev/world-engine/relay/nakama/persona"
 	"pkg.world.dev/world-engine/relay/nakama/utils"
@@ -135,7 +136,7 @@ func handleGetSaveGame(ctx context.Context, logger runtime.Logger, _ *sql.DB, nk
 	// check if the user is allowlisted. NOTE: checkVerified will return true in two cases:
 	// case 1: if the allowlist is disabled (via ENABLE_ALLOWLIST env var).
 	// case 2: the user is actually allowlisted.
-	verified, err := isUserVerified(ctx, nk, userID)
+	verified, err := allowlist.IsUserVerified(ctx, nk, userID)
 	if err != nil {
 		return utils.LogErrorFailedPrecondition(logger, eris.Wrap(err, "could not read verification table"))
 	}


### PR DESCRIPTION
Closes: WORLD-740

## Overview

This PR breaks allowlist functionality into it's own package, and add `notifications.go` alongside `dispatcher.go` to the `receipt` package. 

Please note that there is an upcoming PR via [WORLD-739](https://linear.app/arguslabs/issue/WORLD-739/locate-and-refactor-all-nakama-endpoints-to-be-in-the-same-place) that will refactor allowlist endpoint related code into `rpc.go` separately.

## Testing and Verifying

No new tests required, existing tests passing. 