### PR TITLE
refactor(cardinal): make Engine responsible for defaulting the EventHub

### DIFF
--- a/cardinal/ecs/engine.go
+++ b/cardinal/ecs/engine.go
@@ -106,10 +106,6 @@ const (
 	defaultReceiptHistorySize = 10
 )
 
-func (e *Engine) DoesEngineHaveAnEventHub() bool {
-	return e.eventHub != nil
-}
-
 func (e *Engine) GetEventHub() events.EventHub {
 	return e.eventHub
 }
@@ -120,10 +116,6 @@ func (e *Engine) IsEntitiesCreated() bool {
 
 func (e *Engine) SetEntitiesCreated(value bool) {
 	e.isEntitiesCreated = value
-}
-
-func (e *Engine) SetEventHub(eventHub events.EventHub) {
-	e.eventHub = eventHub
 }
 
 func (e *Engine) EmitEvent(event *events.Event) {
@@ -415,6 +407,9 @@ func NewEngine(
 	}
 	if e.receiptHistory == nil {
 		e.receiptHistory = receipt.NewHistory(e.CurrentTick(), defaultReceiptHistorySize)
+	}
+	if e.eventHub == nil {
+		e.eventHub = events.NewWebSocketEventHub()
 	}
 	return e, nil
 }

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -24,7 +24,6 @@ import (
 	"pkg.world.dev/world-engine/cardinal/ecs/iterators"
 	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
 	"pkg.world.dev/world-engine/cardinal/ecs/storage/redis"
-	"pkg.world.dev/world-engine/cardinal/events"
 	"pkg.world.dev/world-engine/cardinal/gamestage"
 	"pkg.world.dev/world-engine/cardinal/server"
 	"pkg.world.dev/world-engine/cardinal/statsd"
@@ -325,10 +324,6 @@ func (w *World) StartGame() error {
 			return eris.Wrap(ErrEntitiesCreatedBeforeStartGame, "")
 		}
 		return err
-	}
-	if !w.instance.DoesEngineHaveAnEventHub() {
-		eventHub := events.NewWebSocketEventHub()
-		w.instance.SetEventHub(eventHub)
 	}
 	srvr, err := server.New(w.instance, w.instance.GetEventHub(), w.serverOptions...)
 	if err != nil {


### PR DESCRIPTION
## Overview

previously, World would be responsible for setting up the event hub if engine didn't have one. this PR moves the responsibility to engine.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
