### PR TITLE
refactor(cardinal): stronger assertion of disallowing entity creation before loading game state

### DIFF
--- a/cardinal/component_test.go
+++ b/cardinal/component_test.go
@@ -37,13 +37,15 @@ type Age struct {
 func (Age) Name() string { return "age" }
 
 func TestComponentExample(t *testing.T) {
-	world := testutils.NewTestFixture(t, nil).World
+	fixture := testutils.NewTestFixture(t, nil)
+	world := fixture.World
+	engine := fixture.Engine
 
 	assert.NilError(t, cardinal.RegisterComponent[Height](world))
 	assert.NilError(t, cardinal.RegisterComponent[Weight](world))
 	assert.NilError(t, cardinal.RegisterComponent[Age](world))
 	assert.NilError(t, cardinal.RegisterComponent[Number](world))
-
+	assert.NilError(t, engine.LoadGameState())
 	testWorldCtx := testutils.WorldToWorldContext(world)
 	assert.Equal(t, testWorldCtx.CurrentTick(), uint64(0))
 	testWorldCtx.Logger().Info().Msg("test") // Check for compile errors.

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -661,6 +661,7 @@ func (ValueComponent1) Name() string {
 func TestCanRemoveFirstEntity(t *testing.T) {
 	engine := testutils.NewTestFixture(t, nil).World.Engine()
 	assert.NilError(t, ecs.RegisterComponent[ValueComponent1](engine))
+	assert.NilError(t, engine.LoadGameState())
 
 	eCtx := ecs.NewEngineContext(engine)
 	ids, err := ecs.CreateMany(eCtx, 3, ValueComponent1{})
@@ -699,6 +700,7 @@ func TestCanChangeArchetypeOfFirstEntity(t *testing.T) {
 	engine := testutils.NewTestFixture(t, nil).World.Engine()
 	assert.NilError(t, ecs.RegisterComponent[ValueComponent2](engine))
 	assert.NilError(t, ecs.RegisterComponent[OtherComponent](engine))
+	assert.NilError(t, engine.LoadGameState())
 
 	eCtx := ecs.NewEngineContext(engine)
 	ids, err := ecs.CreateMany(eCtx, 3, ValueComponent2{})
@@ -724,6 +726,7 @@ func TestEntityCreationAndSetting(t *testing.T) {
 	assert.NilError(t, ecs.RegisterComponent[OtherComponent](engine))
 
 	eCtx := ecs.NewEngineContext(engine)
+	assert.NilError(t, engine.LoadGameState())
 	ids, err := ecs.CreateMany(eCtx, 300, ValueComponent2{999}, OtherComponent{999})
 	assert.NilError(t, err)
 	for _, id := range ids {

--- a/cardinal/ecs/engine.go
+++ b/cardinal/ecs/engine.go
@@ -62,7 +62,6 @@ type Engine struct {
 	registeredMessages     []message.Message
 	registeredQueries      []Query
 	isComponentsRegistered bool
-	isEntitiesCreated      bool
 	isMessagesRegistered   bool
 	stateIsLoaded          bool
 
@@ -114,24 +113,12 @@ func (e *Engine) GetEventHub() events.EventHub {
 	return e.eventHub
 }
 
-func (e *Engine) IsEntitiesCreated() bool {
-	return e.isEntitiesCreated
-}
-
-func (e *Engine) SetEntitiesCreated(value bool) {
-	e.isEntitiesCreated = value
-}
-
 func (e *Engine) SetEventHub(eventHub events.EventHub) {
 	e.eventHub = eventHub
 }
 
 func (e *Engine) EmitEvent(event *events.Event) {
 	e.eventHub.EmitEvent(event)
-}
-
-func (e *Engine) FlushEvents() {
-	e.eventHub.FlushEvents()
 }
 
 func (e *Engine) IsRecovering() bool {
@@ -396,7 +383,6 @@ func NewEngine(
 		txQueue:           txpool.NewTxQueue(),
 		Logger:            logger,
 		isGameLoopRunning: atomic.Bool{},
-		isEntitiesCreated: false,
 		endGameLoopCh:     make(chan bool),
 		nextComponentID:   1,
 		evmTxReceipts:     make(map[string]EVMTxReceipt),
@@ -739,9 +725,6 @@ func (e *Engine) recoverGameState() (recoveredTxs *txpool.TxQueue, err error) {
 }
 
 func (e *Engine) LoadGameState() error {
-	if e.IsEntitiesCreated() {
-		return eris.Wrap(ErrEntitiesCreatedBeforeLoadingGameState, "")
-	}
 	if e.stateIsLoaded {
 		return eris.New("cannot load game state multiple times")
 	}

--- a/cardinal/ecs/engine_test.go
+++ b/cardinal/ecs/engine_test.go
@@ -248,6 +248,8 @@ func TestWithoutRegistration(t *testing.T) {
 
 	assert.NilError(t, ecs.RegisterComponent[EnergyComponent](engine))
 	assert.NilError(t, ecs.RegisterComponent[OwnableComponent](engine))
+	assert.NilError(t, engine.LoadGameState())
+
 	id, err = ecs.Create(eCtx, EnergyComponent{}, OwnableComponent{})
 	assert.NilError(t, err)
 	err = ecs.UpdateComponent[EnergyComponent](

--- a/cardinal/ecs/entity.go
+++ b/cardinal/ecs/entity.go
@@ -17,6 +17,9 @@ func Create(eCtx EngineContext, components ...component.Component) (entity.ID, e
 }
 
 func CreateMany(eCtx EngineContext, num int, components ...component.Component) ([]entity.ID, error) {
+	if !eCtx.GetEngine().stateIsLoaded {
+		return nil, eris.Wrap(ErrEntitiesCreatedBeforeLoadingGameState, "")
+	}
 	if eCtx.IsReadOnly() {
 		return nil, eris.Wrap(ErrCannotModifyStateWithReadOnlyContext, "")
 	}
@@ -46,7 +49,6 @@ func CreateMany(eCtx EngineContext, num int, components ...component.Component) 
 			}
 		}
 	}
-	eCtx.GetEngine().SetEntitiesCreated(true)
 	return entityIds, nil
 }
 

--- a/cardinal/ecs/filter/filter_test.go
+++ b/cardinal/ecs/filter/filter_test.go
@@ -109,6 +109,7 @@ func TestExactVsContains(t *testing.T) {
 
 	alphaCount := 75
 	eCtx := ecs.NewEngineContext(engine)
+	assert.NilError(t, engine.LoadGameState())
 	_, err := ecs.CreateMany(eCtx, alphaCount, Alpha{})
 	assert.NilError(t, err)
 	bothCount := 100

--- a/cardinal/ecs/search_test.go
+++ b/cardinal/ecs/search_test.go
@@ -24,6 +24,7 @@ func (FooComponent) Name() string {
 func TestSearchEarlyTermination(t *testing.T) {
 	engine := testutils.NewTestFixture(t, nil).Engine
 	assert.NilError(t, ecs.RegisterComponent[FooComponent](engine))
+	assert.NilError(t, engine.LoadGameState())
 
 	total := 10
 	count := 0

--- a/cardinal/entity_test.go
+++ b/cardinal/entity_test.go
@@ -9,9 +9,11 @@ import (
 )
 
 func TestCanRemoveEntity(t *testing.T) {
-	world := testutils.NewTestFixture(t, nil).World
+	fixture := testutils.NewTestFixture(t, nil)
+	world := fixture.World
 
 	assert.NilError(t, cardinal.RegisterComponent[Alpha](world))
+	assert.NilError(t, fixture.Engine.LoadGameState())
 
 	testWorldCtx := testutils.WorldToWorldContext(world)
 	ids, err := cardinal.CreateMany(testWorldCtx, 2, Alpha{})

--- a/cardinal/query_test.go
+++ b/cardinal/query_test.go
@@ -63,7 +63,8 @@ func TestNewQueryTypeWithEVMSupport(t *testing.T) {
 }
 
 func TestQueryExample(t *testing.T) {
-	world := testutils.NewTestFixture(t, nil).World
+	fixture := testutils.NewTestFixture(t, nil)
+	world := fixture.World
 	assert.NilError(t, cardinal.RegisterComponent[Health](world))
 	assert.NilError(
 		t,
@@ -73,7 +74,7 @@ func TestQueryExample(t *testing.T) {
 			handleQueryHealth,
 		),
 	)
-
+	assert.NilError(t, fixture.Engine.LoadGameState())
 	worldCtx := testutils.WorldToWorldContext(world)
 	ids, err := cardinal.CreateMany(worldCtx, 100, Health{})
 	assert.NilError(t, err)

--- a/cardinal/search_test.go
+++ b/cardinal/search_test.go
@@ -25,10 +25,12 @@ type Gamma struct{}
 func (Gamma) Name() string { return "gamma" }
 
 func TestSearchExample(t *testing.T) {
-	world := testutils.NewTestFixture(t, nil).World
+	fixture := testutils.NewTestFixture(t, nil)
+	world := fixture.World
 	assert.NilError(t, cardinal.RegisterComponent[Alpha](world))
 	assert.NilError(t, cardinal.RegisterComponent[Beta](world))
 	assert.NilError(t, cardinal.RegisterComponent[Gamma](world))
+	assert.NilError(t, fixture.Engine.LoadGameState())
 
 	worldCtx := testutils.WorldToWorldContext(world)
 	_, err := cardinal.CreateMany(worldCtx, 10, Alpha{})

--- a/cardinal/types/component/component_test.go
+++ b/cardinal/types/component/component_test.go
@@ -161,6 +161,7 @@ func TestErrorWhenAccessingComponentNotOnEntity(t *testing.T) {
 	ecs.MustRegisterComponent[notFoundComp](engine)
 
 	wCtx := ecs.NewEngineContext(engine)
+	assert.NilError(t, engine.LoadGameState())
 	id, err := ecs.Create(wCtx, foundComp{})
 	assert.NilError(t, err)
 	_, err = ecs.GetComponent[notFoundComp](wCtx, id)
@@ -180,6 +181,7 @@ func TestMultipleCallsToCreateSupported(t *testing.T) {
 	assert.NilError(t, ecs.RegisterComponent[ValueComponent](engine))
 
 	eCtx := ecs.NewEngineContext(engine)
+	assert.NilError(t, engine.LoadGameState())
 	id, err := ecs.Create(eCtx, ValueComponent{})
 	assert.NilError(t, err)
 


### PR DESCRIPTION
## Overview

Closes: WORLD-752

before this PR, we had a delayed error of disallowing entity creation before loading game state.

this PR makes that assertion stronger, by erroring IMMEDIATELY if the state is not loaded. 

also removes an unused function.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
