### PR TITLE
refactor(cardinal): cleanup server <> event hub interaction

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -71,7 +71,7 @@ func TestNewWorld(t *testing.T) {
 	world, err := cardinal.NewMockWorld()
 	assert.NilError(t, err)
 	assert.Equal(t, string(world.Engine().Namespace()), cardinal.DefaultNamespace)
-	err = world.ShutDown()
+	err = world.Shutdown()
 	assert.NilError(t, err)
 }
 
@@ -80,7 +80,7 @@ func TestNewWorldWithCustomNamespace(t *testing.T) {
 	world, err := cardinal.NewMockWorld()
 	assert.NilError(t, err)
 	assert.Equal(t, string(world.Engine().Namespace()), "custom-namespace")
-	err = world.ShutDown()
+	err = world.Shutdown()
 	assert.NilError(t, err)
 }
 

--- a/cardinal/ecs/ecs_test.go
+++ b/cardinal/ecs/ecs_test.go
@@ -94,9 +94,9 @@ func TestSchemaChecking(t *testing.T) {
 	engine2 := cardinalWorld2.Engine()
 	assert.NilError(t, ecs.RegisterComponent[OwnableComponent](engine2))
 	assert.Assert(t, ecs.RegisterComponent[AlteredEnergyComponent](engine2) != nil)
-	err := cardinalWorld2.ShutDown()
+	err := cardinalWorld2.Shutdown()
 	assert.NilError(t, err)
-	err = cardinalWorld.ShutDown()
+	err = cardinalWorld.Shutdown()
 	assert.NilError(t, err)
 }
 

--- a/cardinal/ecs/engine.go
+++ b/cardinal/ecs/engine.go
@@ -84,7 +84,7 @@ type Engine struct {
 
 	nextComponentID component.TypeID
 
-	eventHub events.EventHub
+	eventHub *events.EventHub
 
 	// addChannelWaitingForNextTick accepts a channel which will be closed after a tick has been completed.
 	addChannelWaitingForNextTick chan chan struct{}
@@ -106,7 +106,7 @@ const (
 	defaultReceiptHistorySize = 10
 )
 
-func (e *Engine) GetEventHub() events.EventHub {
+func (e *Engine) GetEventHub() *events.EventHub {
 	return e.eventHub
 }
 
@@ -396,7 +396,7 @@ func NewEngine(
 		e.receiptHistory = receipt.NewHistory(e.CurrentTick(), defaultReceiptHistorySize)
 	}
 	if e.eventHub == nil {
-		e.eventHub = events.NewWebSocketEventHub()
+		e.eventHub = events.NewEventHub()
 	}
 	return e, nil
 }
@@ -690,7 +690,7 @@ func (e *Engine) Shutdown() error {
 	}
 	log.Info().Msg("Successfully shut down game loop.")
 	if e.eventHub != nil {
-		e.eventHub.ShutdownEventHub()
+		e.eventHub.Shutdown()
 	}
 	log.Info().Msg("Closing storage connection.")
 	err := e.redisStorage.Close()

--- a/cardinal/ecs/options.go
+++ b/cardinal/ecs/options.go
@@ -8,7 +8,6 @@ import (
 	"github.com/rs/zerolog/log"
 	"pkg.world.dev/world-engine/cardinal/ecs/gamestate"
 	"pkg.world.dev/world-engine/cardinal/ecs/receipt"
-	"pkg.world.dev/world-engine/cardinal/events"
 )
 
 type Option func(e *Engine)
@@ -35,11 +34,5 @@ func WithPrettyLog() Option {
 func WithStoreManager(s gamestate.Manager) Option {
 	return func(e *Engine) {
 		e.entityStore = s
-	}
-}
-
-func WithEventHub(eventHub *events.EventHub) Option {
-	return func(e *Engine) {
-		e.eventHub = eventHub
 	}
 }

--- a/cardinal/ecs/options.go
+++ b/cardinal/ecs/options.go
@@ -38,14 +38,8 @@ func WithStoreManager(s gamestate.Manager) Option {
 	}
 }
 
-func WithEventHub(eventHub events.EventHub) Option {
+func WithEventHub(eventHub *events.EventHub) Option {
 	return func(e *Engine) {
 		e.eventHub = eventHub
-	}
-}
-
-func WithLoggingEventHub(logger *zerolog.Logger) Option {
-	return func(e *Engine) {
-		e.eventHub = events.NewLoggingEventHub(logger)
 	}
 }

--- a/cardinal/events/events.go
+++ b/cardinal/events/events.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/gofiber/contrib/websocket"
-	"github.com/gofiber/fiber/v2"
 	"github.com/rotisserie/eris"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
@@ -15,140 +14,64 @@ import (
 
 const shutdownPollInterval = 200
 
-type EventHub interface {
-	EmitEvent(event *Event)
-	FlushEvents()
-	ShutdownEventHub()
-	Run()
-	UnregisterConnection(ws *websocket.Conn)
-	RegisterConnection(ws *websocket.Conn)
-}
-
 const (
 	writeDeadline = 5 * time.Second
-	bufferSize    = 1024
 )
 
-type loggingEventHub struct {
-	logger     *zerolog.Logger
-	eventQueue []*Event
-	running    atomic.Bool
-	broadcast  chan *Event
-	shutdown   chan bool
-	flush      chan bool
+type Event struct {
+	Message string
 }
 
-func (eh *loggingEventHub) EmitEvent(event *Event) {
-	eh.broadcast <- event
+type EventHub struct {
+	websocketConnections map[*websocket.Conn]bool
+	broadcast            chan *Event
+	flush                chan bool
+	register             chan *websocket.Conn
+	unregister           chan *websocket.Conn
+	shutdown             chan bool
+	eventQueue           []*Event
+	isRunning            atomic.Bool
 }
 
-func (eh *loggingEventHub) FlushEvents() {
-	eh.flush <- true
-}
-
-func (eh *loggingEventHub) UnregisterConnection(_ *websocket.Conn) {}
-
-func (eh *loggingEventHub) RegisterConnection(_ *websocket.Conn) {}
-
-func (eh *loggingEventHub) Run() {
-	if eh.running.Load() {
-		return
-	}
-	eh.running.Store(true)
-	for eh.running.Load() {
-		select {
-		case event := <-eh.broadcast:
-			eh.eventQueue = append(eh.eventQueue, event)
-		case <-eh.flush:
-			wg := sync.WaitGroup{}
-			wg.Add(1)
-			go func() {
-				defer wg.Done()
-				for _, event := range eh.eventQueue {
-					eh.logger.Info().Msg("EVENT: " + event.Message)
-				}
-			}() // a goroutine is not technically necessary here but this imitates the websocket eventhub as much as possible.
-			wg.Wait()
-			eh.eventQueue = eh.eventQueue[:0]
-		case <-eh.shutdown:
-			eh.running.Store(false)
-		}
-	}
-}
-
-func (eh *loggingEventHub) ShutdownEventHub() {
-	eh.shutdown <- true
-}
-
-func NewLoggingEventHub(logger *zerolog.Logger) EventHub {
-	res := loggingEventHub{
-		eventQueue: make([]*Event, 0),
-		running:    atomic.Bool{},
-		broadcast:  make(chan *Event),
-		shutdown:   make(chan bool),
-		flush:      make(chan bool),
-		logger:     logger,
-	}
-	res.running.Store(false)
-	go func() {
-		res.Run()
-	}()
-	return &res
-}
-
-func NewWebSocketEventHub() EventHub {
-	res := webSocketEventHub{
+func NewEventHub() *EventHub {
+	res := EventHub{
 		websocketConnections: map[*websocket.Conn]bool{},
 		broadcast:            make(chan *Event),
 		flush:                make(chan bool),
 		register:             make(chan *websocket.Conn),
 		unregister:           make(chan *websocket.Conn),
 		shutdown:             make(chan bool),
-		running:              atomic.Bool{},
+		eventQueue:           make([]*Event, 0),
+		isRunning:            atomic.Bool{},
 	}
-	res.running.Store(false)
+	res.isRunning.Store(false)
 	go func() {
 		res.Run()
 	}()
 	return &res
 }
 
-type Event struct {
-	Message string
-}
-
-type webSocketEventHub struct {
-	websocketConnections map[*websocket.Conn]bool
-	broadcast            chan *Event
-	flush                chan bool
-	unregister           chan *websocket.Conn
-	register             chan *websocket.Conn
-	shutdown             chan bool
-	eventQueue           []*Event
-	running              atomic.Bool
-}
-
-func (eh *webSocketEventHub) EmitEvent(event *Event) {
+func (eh *EventHub) EmitEvent(event *Event) {
 	eh.broadcast <- event
 }
 
-func (eh *webSocketEventHub) FlushEvents() {
+func (eh *EventHub) FlushEvents() {
 	eh.flush <- true
 }
 
-func (eh *webSocketEventHub) RegisterConnection(ws *websocket.Conn) {
+func (eh *EventHub) RegisterConnection(ws *websocket.Conn) {
 	eh.register <- ws
 }
 
-func (eh *webSocketEventHub) UnregisterConnection(ws *websocket.Conn) {
+func (eh *EventHub) UnregisterConnection(ws *websocket.Conn) {
 	eh.unregister <- ws
 }
 
-func (eh *webSocketEventHub) ShutdownEventHub() {
+func (eh *EventHub) Shutdown() {
 	eh.shutdown <- true
 	// block until the loop fully exits.
 	for {
-		if !eh.running.Load() {
+		if !eh.isRunning.Load() {
 			break
 		}
 		time.Sleep(shutdownPollInterval * time.Millisecond)
@@ -156,11 +79,11 @@ func (eh *webSocketEventHub) ShutdownEventHub() {
 }
 
 //nolint:gocognit
-func (eh *webSocketEventHub) Run() {
-	if eh.running.Load() {
+func (eh *EventHub) Run() {
+	if eh.isRunning.Load() {
 		return
 	}
-	eh.running.Store(true)
+	eh.isRunning.Store(true)
 	unregisterConnection := func(conn *websocket.Conn) {
 		if _, ok := eh.websocketConnections[conn]; ok {
 			delete(eh.websocketConnections, conn)
@@ -171,7 +94,7 @@ func (eh *webSocketEventHub) Run() {
 		}
 	}
 Loop:
-	for eh.running.Load() {
+	for eh.isRunning.Load() {
 		select {
 		case conn := <-eh.register:
 			eh.websocketConnections[conn] = true
@@ -219,12 +142,12 @@ Loop:
 			break Loop
 		}
 	}
-	eh.running.Store(false)
+	eh.isRunning.Store(false)
 }
 
-func NewWebSocketEventHandler(hub EventHub) func(conn *websocket.Conn) {
+func (eh *EventHub) NewWebSocketEventHandler() func(conn *websocket.Conn) {
 	return func(conn *websocket.Conn) {
-		hub.RegisterConnection(conn)
+		eh.RegisterConnection(conn)
 		var err error
 		var mt int
 		var msg []byte
@@ -246,30 +169,4 @@ func NewWebSocketEventHandler(hub EventHub) func(conn *websocket.Conn) {
 			}
 		}
 	}
-}
-
-func WebSocketEchoHandler(ws *websocket.Conn) error {
-	if ws == nil {
-		return eris.New("websocket connection cannot be nil")
-	}
-	for {
-		mt, message, err := ws.ReadMessage()
-		if err != nil {
-			return eris.Wrap(err, "")
-		}
-		log.Printf("recv: %s", message)
-		err = ws.WriteMessage(mt, message)
-		if err != nil {
-			return eris.Wrap(err, "")
-		}
-	}
-}
-
-func WebSocketUpgrader(c *fiber.Ctx) error {
-	if websocket.IsWebSocketUpgrade(c) {
-		c.Locals("allowed", true)
-		err := eris.Wrap(c.Next(), "")
-		return err
-	}
-	return fiber.ErrUpgradeRequired
 }

--- a/cardinal/events/events_test.go
+++ b/cardinal/events/events_test.go
@@ -38,12 +38,12 @@ func TestEvents(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			tf.EventHub.EmitEvent(&events.Event{Message: fmt.Sprintf("test%d", i)})
+			tf.World.Engine().GetEventHub().EmitEvent(&events.Event{Message: fmt.Sprintf("test%d", i)})
 		}()
 	}
 	wg.Wait()
 	go func() {
-		tf.EventHub.FlushEvents()
+		tf.World.Engine().GetEventHub().FlushEvents()
 	}()
 	var count atomic.Int32
 	count.Store(0)

--- a/cardinal/option.go
+++ b/cardinal/option.go
@@ -5,10 +5,8 @@ import (
 
 	"github.com/alicebob/miniredis/v2"
 	"github.com/rs/zerolog/log"
-	"pkg.world.dev/world-engine/cardinal/ecs/gamestate"
-	"pkg.world.dev/world-engine/cardinal/events"
-
 	"pkg.world.dev/world-engine/cardinal/ecs"
+	"pkg.world.dev/world-engine/cardinal/ecs/gamestate"
 	"pkg.world.dev/world-engine/cardinal/server"
 	"pkg.world.dev/world-engine/cardinal/shard/adapter"
 )
@@ -80,12 +78,6 @@ func WithTickDoneChannel(ch chan<- uint64) WorldOption {
 func WithStoreManager(s gamestate.Manager) WorldOption {
 	return WorldOption{
 		ecsOption: ecs.WithStoreManager(s),
-	}
-}
-
-func WithEventHub(eventHub *events.EventHub) WorldOption {
-	return WorldOption{
-		ecsOption: ecs.WithEventHub(eventHub),
 	}
 }
 

--- a/cardinal/option.go
+++ b/cardinal/option.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/alicebob/miniredis/v2"
-	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"pkg.world.dev/world-engine/cardinal/ecs/gamestate"
 	"pkg.world.dev/world-engine/cardinal/events"
@@ -84,15 +83,9 @@ func WithStoreManager(s gamestate.Manager) WorldOption {
 	}
 }
 
-func WithEventHub(eventHub events.EventHub) WorldOption {
+func WithEventHub(eventHub *events.EventHub) WorldOption {
 	return WorldOption{
 		ecsOption: ecs.WithEventHub(eventHub),
-	}
-}
-
-func WithLoggingEventHub(logger *zerolog.Logger) WorldOption {
-	return WorldOption{
-		ecsOption: ecs.WithLoggingEventHub(logger),
 	}
 }
 

--- a/cardinal/option_test.go
+++ b/cardinal/option_test.go
@@ -13,6 +13,5 @@ func TestOptionFunctionSignatures(_ *testing.T) {
 	WithTickDoneChannel(nil)
 	WithStoreManager(nil)
 	WithEventHub(nil)
-	WithLoggingEventHub(nil)
 	WithDisableSignatureVerification() //nolint:staticcheck //this test just looks for compile errors
 }

--- a/cardinal/option_test.go
+++ b/cardinal/option_test.go
@@ -12,6 +12,5 @@ func TestOptionFunctionSignatures(_ *testing.T) {
 	WithTickChannel(nil)
 	WithTickDoneChannel(nil)
 	WithStoreManager(nil)
-	WithEventHub(nil)
 	WithDisableSignatureVerification() //nolint:staticcheck //this test just looks for compile errors
 }

--- a/cardinal/server/handler/events.go
+++ b/cardinal/server/handler/events.go
@@ -3,9 +3,18 @@ package handler
 import (
 	"github.com/gofiber/contrib/websocket"
 	"github.com/gofiber/fiber/v2"
-	"pkg.world.dev/world-engine/cardinal/events"
+	"github.com/rotisserie/eris"
 )
 
-func WebSocketEvents(hub events.EventHub) (func(*fiber.Ctx) error, func(*fiber.Ctx) error) {
-	return events.WebSocketUpgrader, websocket.New(events.NewWebSocketEventHandler(hub))
+func WebSocketEvents(wsEventHandler func(conn *websocket.Conn)) func(c *fiber.Ctx) error {
+	return websocket.New(wsEventHandler)
+}
+func WebSocketUpgrader(c *fiber.Ctx) error {
+	// IsWebSocketUpgrade returns true if the client
+	// requested upgrade to the WebSocket protocol.
+	if websocket.IsWebSocketUpgrade(c) {
+		c.Locals("allowed", true)
+		return eris.Wrap(c.Next(), "")
+	}
+	return fiber.ErrUpgradeRequired
 }

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -54,7 +54,7 @@ func (s *ServerTestSuite) SetupTest() {
 
 // TearDownTest runs after each test in the suite.
 func (s *ServerTestSuite) TearDownTest() {
-	s.Require().NoError(s.fixture.World.ShutDown())
+	s.Require().NoError(s.fixture.World.Shutdown())
 }
 
 // TestCanClaimPersonaSendGameTxAndQueryGame tests that you can claim a persona, send a tx, and then query.

--- a/cardinal/testutils/world.go
+++ b/cardinal/testutils/world.go
@@ -31,7 +31,7 @@ type TestFixture struct {
 	Redis    *miniredis.Miniredis
 	World    *cardinal.World
 	Engine   *ecs.Engine
-	EventHub events.EventHub
+	EventHub *events.EventHub
 
 	startTickCh chan time.Time
 	doneTickCh  chan uint64
@@ -56,8 +56,8 @@ func NewTestFixture(t testing.TB, miniRedis *miniredis.Miniredis, opts ...cardin
 	t.Setenv("CARDINAL_EVM_PORT", evmPort)
 
 	startTickCh, doneTickCh := make(chan time.Time), make(chan uint64)
-	eventHub := events.NewWebSocketEventHub()
-	t.Cleanup(eventHub.ShutdownEventHub)
+	eventHub := events.NewEventHub()
+	t.Cleanup(eventHub.Shutdown)
 
 	defaultOpts := []cardinal.WorldOption{
 		cardinal.WithCustomMockRedis(miniRedis),
@@ -157,7 +157,8 @@ func (t *TestFixture) Post(path string, payload any) *http.Response {
 
 // Get executes a http GET request to this TestFixture's cardinal server.
 func (t *TestFixture) Get(path string) *http.Response {
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, t.httpURL(strings.Trim(path, "/")), nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, t.httpURL(strings.Trim(path, "/")),
+		nil)
 	assert.NilError(t, err)
 	resp, err := http.DefaultClient.Do(req)
 	assert.NilError(t, err)

--- a/cardinal/testutils/world.go
+++ b/cardinal/testutils/world.go
@@ -18,7 +18,6 @@ import (
 
 	"pkg.world.dev/world-engine/cardinal"
 	"pkg.world.dev/world-engine/cardinal/ecs"
-	"pkg.world.dev/world-engine/cardinal/events"
 )
 
 // TestFixture is a helper struct that manages a cardinal.World instance. It will automatically clean up its resources
@@ -27,11 +26,10 @@ type TestFixture struct {
 	testing.TB
 
 	// Base url is something like "localhost:5050". You must attach http:// or ws:// as well as a resource path
-	BaseURL  string
-	Redis    *miniredis.Miniredis
-	World    *cardinal.World
-	Engine   *ecs.Engine
-	EventHub *events.EventHub
+	BaseURL string
+	Redis   *miniredis.Miniredis
+	World   *cardinal.World
+	Engine  *ecs.Engine
 
 	startTickCh chan time.Time
 	doneTickCh  chan uint64
@@ -56,14 +54,11 @@ func NewTestFixture(t testing.TB, miniRedis *miniredis.Miniredis, opts ...cardin
 	t.Setenv("CARDINAL_EVM_PORT", evmPort)
 
 	startTickCh, doneTickCh := make(chan time.Time), make(chan uint64)
-	eventHub := events.NewEventHub()
-	t.Cleanup(eventHub.Shutdown)
 
 	defaultOpts := []cardinal.WorldOption{
 		cardinal.WithCustomMockRedis(miniRedis),
 		cardinal.WithTickChannel(startTickCh),
 		cardinal.WithTickDoneChannel(doneTickCh),
-		cardinal.WithEventHub(eventHub),
 		cardinal.WithPort(cardinalPort),
 	}
 
@@ -74,12 +69,11 @@ func NewTestFixture(t testing.TB, miniRedis *miniredis.Miniredis, opts ...cardin
 	assert.NilError(t, err)
 
 	testFixture := &TestFixture{
-		TB:       t,
-		BaseURL:  "localhost:" + cardinalPort,
-		Redis:    miniRedis,
-		World:    world,
-		Engine:   world.Engine(),
-		EventHub: eventHub,
+		TB:      t,
+		BaseURL: "localhost:" + cardinalPort,
+		Redis:   miniRedis,
+		World:   world,
+		Engine:  world.Engine(),
 
 		startTickCh: startTickCh,
 		doneTickCh:  doneTickCh,
@@ -91,7 +85,7 @@ func NewTestFixture(t testing.TB, miniRedis *miniredis.Miniredis, opts ...cardin
 				for range doneTickCh { //nolint:revive // This pattern drains the channel until closed
 				}
 			}()
-			assert.NilError(t, world.ShutDown())
+			assert.NilError(t, world.Shutdown())
 		},
 	}
 

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -298,7 +298,7 @@ func (w *World) handleShutdown() {
 		signal.Notify(signalChannel, syscall.SIGINT, syscall.SIGTERM)
 		for sig := range signalChannel {
 			if sig == syscall.SIGINT || sig == syscall.SIGTERM {
-				err := w.ShutDown()
+				err := w.Shutdown()
 				if err != nil {
 					log.Err(err).Msgf("There was an error during shutdown.")
 				}
@@ -372,7 +372,7 @@ func (w *World) IsGameRunning() bool {
 	return w.gameSequenceStage.Load() == gamestage.StageRunning
 }
 
-func (w *World) ShutDown() error {
+func (w *World) Shutdown() error {
 	if w.cleanup != nil {
 		w.cleanup()
 	}

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -325,7 +325,7 @@ func (w *World) StartGame() error {
 		}
 		return err
 	}
-	srvr, err := server.New(w.instance, w.instance.GetEventHub(), w.serverOptions...)
+	srvr, err := server.New(w.instance, w.instance.GetEventHub().NewWebSocketEventHandler(), w.serverOptions...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Closes: WORLD-753

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

This PR cleans up the dependency injection surface area to server to avoid dependency injecting the entire EventHub, which led to tight coupling between the two modules. Additionally, this PR also remove the EventHub interface and the EventHubLogger in favor of just using websocket mocks for I/O instead of using polymorphic EventHub.

## Brief Changelog

- Replace EventHub dependency injection to server with just the websocket connection
- Cleans up the server router /events handler to make it consistent with the rest
- EventHub constructor now returns a pointer, making it consistent with server and engine.
- Some method/property renaming in EventHub

## Testing and Verifying

- All existing tests passes
