### PR TITLE
fix(cardinal): Make sure the endpoints declared in swagger are actually created

### DIFF
--- a/cardinal/ecs/engine.go
+++ b/cardinal/ecs/engine.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rotisserie/eris"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
+
 	"pkg.world.dev/world-engine/cardinal/ecs/iterators"
 
 	"pkg.world.dev/world-engine/cardinal/ecs/filter"
@@ -309,9 +310,9 @@ func (e *Engine) registerInternalQueries() {
 	}
 
 	debugQueryType, err := NewQueryType[DebugRequest, DebugStateResponse](
-		"debug",
+		"state",
 		queryDebugState,
-		WithCustomQueryGroup[DebugRequest, DebugStateResponse]("state"),
+		WithCustomQueryGroup[DebugRequest, DebugStateResponse]("debug"),
 	)
 	if err != nil {
 		panic(err)
@@ -323,9 +324,9 @@ func (e *Engine) registerInternalQueries() {
 	}
 
 	receiptQueryType, err := NewQueryType[ListTxReceiptsRequest, ListTxReceiptsReply](
-		"receipts",
+		"list",
 		receiptsQuery,
-		WithCustomQueryGroup[ListTxReceiptsRequest, ListTxReceiptsReply]("list"),
+		WithCustomQueryGroup[ListTxReceiptsRequest, ListTxReceiptsReply]("receipts"),
 	)
 	if err != nil {
 		panic(err)

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gofiber/fiber/v2/middleware/cors"
 	"github.com/rotisserie/eris"
 	"github.com/rs/zerolog/log"
+
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/events"
 	"pkg.world.dev/world-engine/cardinal/server/handler"
@@ -155,7 +156,7 @@ func setupRoutes(app *fiber.App, engine *ecs.Engine, eventHub events.EventHub, c
 	app.Get("/health", handler.GetHealth(engine))
 	// TODO(scott): this should be moved outside of /query, but nakama is currrently depending on it
 	//  so we should do this on a separate PR.
-	app.Get("/query/http/endpoints", handler.GetEndpoints(msgs, queries))
+	app.Post("/query/http/endpoints", handler.GetEndpoints(msgs, queries))
 
 	// Route: /query/...
 	query := app.Group("/query")

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -156,7 +156,7 @@ func setupRoutes(app *fiber.App, engine *ecs.Engine, eventHub events.EventHub, c
 	app.Get("/health", handler.GetHealth(engine))
 	// TODO(scott): this should be moved outside of /query, but nakama is currrently depending on it
 	//  so we should do this on a separate PR.
-	app.Post("/query/http/endpoints", handler.GetEndpoints(msgs, queries))
+	app.Get("/query/http/endpoints", handler.GetEndpoints(msgs, queries))
 
 	// Route: /query/...
 	query := app.Group("/query")

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -119,6 +119,8 @@ func (s *ServerTestSuite) TestSwaggerEndpointsAreActuallyCreated() {
 			// This test is only checking to make sure the endpoint can be found.
 			s.NotEqualf(res.StatusCode, 404,
 				"swagger defines GET %q, but that endpoint was not found", path)
+			s.NotEqualf(res.StatusCode, 405,
+				"swagger defines GET %q, but GET is not allowed on that endpoint", path)
 		}
 		if _, ok := info["post"]; ok {
 			emptyPayload := struct{}{}
@@ -126,6 +128,8 @@ func (s *ServerTestSuite) TestSwaggerEndpointsAreActuallyCreated() {
 			// This test is only checking to make sure the endpoint can be found.
 			s.NotEqualf(res.StatusCode, 404,
 				"swagger defines POST %q, but that endpoint was not found", path)
+			s.NotEqualf(res.StatusCode, 405,
+				"swagger defines GET %q, but POST is not allowed on that endpoint", path)
 		}
 	}
 }

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -3,13 +3,21 @@ package server_test
 import (
 	"context"
 	"crypto/ecdsa"
+	_ "embed"
 	"encoding/json"
 	"fmt"
+	"io"
+	"math/rand"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/gofiber/fiber/v2"
 	"github.com/stretchr/testify/suite"
-	"io"
-	"math/rand"
+	"gopkg.in/yaml.v3"
+
 	"pkg.world.dev/world-engine/cardinal"
 	"pkg.world.dev/world-engine/cardinal/ecs"
 	"pkg.world.dev/world-engine/cardinal/server/handler"
@@ -18,9 +26,6 @@ import (
 	"pkg.world.dev/world-engine/cardinal/types/entity"
 	"pkg.world.dev/world-engine/cardinal/types/message"
 	"pkg.world.dev/world-engine/sign"
-	"slices"
-	"testing"
-	"time"
 )
 
 type ServerTestSuite struct {
@@ -85,6 +90,40 @@ func (s *ServerTestSuite) TestCanListEndpoints() {
 	}
 	for _, query := range queries {
 		s.Require().True(slices.Contains(result.QueryEndpoints, utils.GetQueryURL(query.Group(), query.Name())))
+	}
+}
+
+//go:embed swagger.yml
+var swaggerData []byte
+
+// TestSwaggerEndpointsAreActuallyCreated verifies the non-variable endpoints that are declared in the swagger.yml file
+// actually have endpoints when the cardinal server starts.
+func (s *ServerTestSuite) TestDeclaredSwaggerEndpointsAreActuallyCreated() {
+	s.setupWorld()
+	s.fixture.DoTick()
+
+	m := map[string]any{}
+	s.Require().NoError(yaml.Unmarshal(swaggerData, m))
+
+	for path, iface := range m["paths"].(map[string]any) {
+		info := iface.(map[string]any)
+		if strings.ContainsAny(path, "{}") {
+			// Don't bother verifying paths that contain variables.
+			continue
+		}
+		if _, ok := info["get"]; ok {
+			res := s.fixture.Get(path)
+			// This test is only checking to make sure the endpoint can be found.
+			s.NotEqualf(res.StatusCode, 404,
+				"swagger defines GET %q, but that endpoint was not found", path)
+		}
+		if _, ok := info["post"]; ok {
+			emptyPayload := struct{}{}
+			res := s.fixture.Post(path, emptyPayload)
+			// This test is only checking to make sure the endpoint can be found.
+			s.NotEqualf(res.StatusCode, 404,
+				"swagger defines POST %q, but that endpoint was not found", path)
+		}
 	}
 }
 

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -98,15 +98,18 @@ var swaggerData []byte
 
 // TestSwaggerEndpointsAreActuallyCreated verifies the non-variable endpoints that are declared in the swagger.yml file
 // actually have endpoints when the cardinal server starts.
-func (s *ServerTestSuite) TestDeclaredSwaggerEndpointsAreActuallyCreated() {
+func (s *ServerTestSuite) TestSwaggerEndpointsAreActuallyCreated() {
 	s.setupWorld()
 	s.fixture.DoTick()
 
 	m := map[string]any{}
 	s.Require().NoError(yaml.Unmarshal(swaggerData, m))
+	paths, ok := m["paths"].(map[string]any)
+	s.Require().True(ok)
 
-	for path, iface := range m["paths"].(map[string]any) {
-		info := iface.(map[string]any)
+	for path, iface := range paths {
+		info, ok := iface.(map[string]any)
+		s.Require().True(ok)
 		if strings.ContainsAny(path, "{}") {
 			// Don't bother verifying paths that contain variables.
 			continue

--- a/cardinal/server/swagger.yml
+++ b/cardinal/server/swagger.yml
@@ -162,7 +162,7 @@ paths:
         '400':
           description: Invalid query request
   /query/http/endpoints:
-    get:
+    post:
       summary: Get all http endpoints from cardinal
       description: Get all http endpoints from cardinal
       consumes:

--- a/cardinal/server/swagger.yml
+++ b/cardinal/server/swagger.yml
@@ -162,7 +162,7 @@ paths:
         '400':
           description: Invalid query request
   /query/http/endpoints:
-    post:
+    get:
       summary: Get all http endpoints from cardinal
       description: Get all http endpoints from cardinal
       consumes:

--- a/cardinal/server/swagger.yml
+++ b/cardinal/server/swagger.yml
@@ -12,8 +12,8 @@ schemes:
 swagger: "2.0"
 
 paths:
-  /debug/state:
-    get:
+  /query/debug/state:
+    post:
       summary: Get information on all entities and components in world-engine
       description: Displays the entire game state.
       produces:
@@ -162,7 +162,7 @@ paths:
         '400':
           description: Invalid query request
   /query/http/endpoints:
-    post:
+    get:
       summary: Get all http endpoints from cardinal
       description: Get all http endpoints from cardinal
       consumes:

--- a/docs/cardinal/openapi.json
+++ b/docs/cardinal/openapi.json
@@ -303,8 +303,8 @@
         "x-codegen-request-body-name": "txBody"
       }
     },
-    "/debug/state": {
-      "get": {
+    "/query/debug/state": {
+      "post": {
         "tags": [
           "Misc"
         ],

--- a/docs/cardinal/rest/debug-state.mdx
+++ b/docs/cardinal/rest/debug-state.mdx
@@ -1,4 +1,4 @@
 ---
-title: /debug/state
-openapi: get /debug/state
+title: /query/debug/state
+openapi: post /query/debug/state
 ---

--- a/docs/client/rest/debug-state.mdx
+++ b/docs/client/rest/debug-state.mdx
@@ -1,4 +1,4 @@
 ---
-title: /debug/state
-openapi: get /debug/state
+title: /query/debug/state
+openapi: post /query/debug/state
 ---


### PR DESCRIPTION

## Overview

Our swagger.yml file describes the endpoints our cardinal server should expose. Some of those endpoints have variables in them (e.g. custom queries and message), but some endpoints should ALWAYS exist.

This newly added test verifies that the non-variable endpoints are actually created, have the correct method attached to them, and fixes some errors in our code base.

The biggest change here is going from "/debug/state" -> "/query/debug/state". If we're OK with this change, I need to also update the relevant docs.


## Testing and Verifying

Newly added unit tests verifies the swagger endpoints actually get created.
