### PR TITLE
ci: cleaning up and update CI action dependencies.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,10 +17,6 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      # - name: Cache Docker images
-      #   uses: ScribeMD/docker-cache@0.3.4
-      #   with:
-      #     key: docker-${{ runner.os }}-${{ hashFiles('evm/Dockerfile') }}
+        uses: docker/setup-buildx-action@v3
       - name: Build Rollup
         run: make rollup-build

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Golang
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
           cache-dependency-path: "**/*.sum"

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -12,6 +12,6 @@ jobs:
       statuses: write # for amannn/action-semantic-pull-request to mark status of analyzed PR
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.1.0
+      - uses: amannn/action-semantic-pull-request@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,7 +81,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.4
+        uses: ScribeMD/docker-cache@0.3.7
         with:
           key: docker-${{ runner.os }}-${{ hashFiles('relay/nakama/Dockerfile') }}
       - name: GCP auth

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,38 +4,17 @@ name: Release
 ## except image release that have jobs condition to trigger only on tagging
 on:
   push:
-    branches:
-      - main
     tags:
       - 'evm/v*.*.*'
       - 'relay/nakama/v*.*.*'
-  pull_request:
 
 env:
   REGISTRY_URL: us-docker.pkg.dev
 
 jobs:
-  dir-changes:
-    name: Check directory/path changes
-    runs-on: ubuntu-latest
-    outputs:
-      evm: ${{ steps.changes.outputs.evm }}
-      nakama: ${{ steps.changes.outputs.nakama }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
-        id: changes
-        with:
-          filters: |
-            evm:
-              - 'evm/**'
-            nakama:
-              - 'relay/nakama/**'
   evm-release:
     name: EVM Image Release
-    needs: dir-changes
-    if: (github.ref == 'refs/heads/main' && needs.dir-changes.outputs.evm == 'true') || startsWith(github.ref, 'refs/tags/evm/v')
+    if: startsWith(github.ref, 'refs/tags/evm/v')
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -86,8 +65,7 @@ jobs:
           docker push $IMAGE_ID_EVM:$VERSION
   nakama-release:
     name: Nakama Image Release
-    needs: dir-changes
-    if: (github.ref == 'refs/heads/main' && needs.dir-changes.outputs.nakama == 'true') || startsWith(github.ref, 'refs/tags/relay/nakama/v')
+    if: startsWith(github.ref, 'refs/tags/relay/nakama/v')
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.3.4
         with:

--- a/.github/workflows/starter-template-sync.yaml
+++ b/.github/workflows/starter-template-sync.yaml
@@ -36,7 +36,7 @@ jobs:
         uses: actions/checkout@v4
       - name: Sync starter-game-template content to upstream repo
         id: push_directory
-        uses: cpina/github-action-push-to-another-repository@main
+        uses: cpina/github-action-push-to-another-repository@v1.7.2
         env:
           SSH_DEPLOY_KEY: ${{ secrets.STARTER_GAME_TEMPLATE_SSH_KEY }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,20 +17,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Cache Golang Deps
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            /home/runner/go
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golang-
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
       - name: Cache Docker images
         uses: ScribeMD/docker-cache@0.3.4
         with:
@@ -48,18 +39,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Setup Golang
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
-      - name: Cache Golang Deps
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/go-build
-            /home/runner/go
-          key: ${{ runner.os }}-golang-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-golang-
       - name: Run Unit Test
         run: make unit-test-all
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/*.sum"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Cache Docker images
@@ -42,6 +43,7 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.GO_VERSION }}
+          cache-dependency-path: "**/*.sum"
       - name: Run Unit Test
         run: make unit-test-all
       - name: Upload coverage to Codecov

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.4
+        uses: ScribeMD/docker-cache@0.3.7
         with:
           key: docker-${{ runner.os }}-${{ hashFiles('internal/e2e/tester/cardinal/Dockerfile') }}
       - name: E2E Test Nakama


### PR DESCRIPTION
Closes: DEVOP-169


## Overview

- Cleaning up and updating CI action dependencies.
- Fix container release behavior: only on tags
- Remove Go action/cache -- enable default cache on new actions/setup-go@v5

## Brief Changelog

- docker/setup-buildx-action `@v2` --> `@v3`
- actions/setup-go `@v4` --> `@v5`
- amannn/action-semantic-pull-request `@v5.1.0` --> `@v5.4.0`
- ScribeMD/docker-cache `@0.3.4` --> `@0.3.7`
- cpina/github-action-push-to-another-repository `@main` --> `@v1.7.2`

- remove Go actions/cache@v3 -- replaced by default cache on actions/setup-go@v5
- changes release condition to only on tags ( `'evm/v*.*.*' , 'relay/nakama/v*.*.*'` )

## Testing and Verifying

- All CI checks pass.
