### PR TITLE
chore(cardinal): make server.Config unexported

### DIFF
--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -26,7 +26,7 @@ var (
 	swaggerData []byte
 )
 
-type Config struct {
+type config struct {
 	port                            string
 	isSignatureVerificationDisabled bool
 	isSwaggerDisabled               bool
@@ -34,7 +34,7 @@ type Config struct {
 
 type Server struct {
 	app       *fiber.App
-	config    Config
+	config    config
 	isRunning atomic.Bool
 }
 
@@ -43,7 +43,7 @@ func New(engine *ecs.Engine, wsEventHandler func(conn *websocket.Conn), opts ...
 	app := fiber.New()
 	s := &Server{
 		app: app,
-		config: Config{
+		config: config{
 			port:                            DefaultPort,
 			isSignatureVerificationDisabled: false,
 			isSwaggerDisabled:               false,
@@ -118,7 +118,7 @@ func setupSwagger(app *fiber.App) error {
 	return nil
 }
 
-func setupRoutes(app *fiber.App, engine *ecs.Engine, wsEventHandler func(conn *websocket.Conn), cfg Config) {
+func setupRoutes(app *fiber.App, engine *ecs.Engine, wsEventHandler func(conn *websocket.Conn), cfg config) {
 	// TODO(scott): we should refactor this such that we only dependency inject these maps
 	//  instead of having to dependency inject the entire engine.
 	// /query/:group/:queryType


### PR DESCRIPTION
## Overview

quick pr after i noticed config was exported when it didn't need to be

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
