### PR TITLE
refactor(cardinal): move config validation to config.go

### DIFF
--- a/cardinal/config.go
+++ b/cardinal/config.go
@@ -2,6 +2,7 @@ package cardinal
 
 import (
 	"github.com/JeremyLoy/config"
+	"github.com/rotisserie/eris"
 )
 
 type RunMode string
@@ -21,6 +22,23 @@ type WorldConfig struct {
 	CardinalLogLevel          string  `config:"CARDINAL_LOG_LEVEL"`
 	StatsdAddress             string  `config:"STATSD_ADDRESS"`
 	TraceAddress              string  `config:"TRACE_ADDRESS"`
+}
+
+func (w WorldConfig) Validate() error {
+	if w.CardinalMode != RunModeProd {
+		return nil
+	}
+	if w.RedisPassword == "" {
+		return eris.New("REDIS_PASSWORD is required in production")
+	}
+	if w.CardinalNamespace == DefaultNamespace {
+		return eris.New("CARDINAL_NAMESPACE cannot be the default value in production to avoid replay attack")
+	}
+	if w.BaseShardSequencerAddress == "" || w.BaseShardQueryAddress == "" {
+		return eris.New("must supply BASE_SHARD_SEQUENCER_ADDRESS and BASE_SHARD_QUERY_ADDRESS for production " +
+			"mode Cardinal worlds")
+	}
+	return nil
 }
 
 // Default configuration values.

--- a/cardinal/config_test.go
+++ b/cardinal/config_test.go
@@ -58,8 +58,14 @@ func TestValidateConfig(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "prod with all required values",
-			cfg:     WorldConfig{CardinalMode: RunModeProd, RedisPassword: "foo", CardinalNamespace: "foo", BaseShardQueryAddress: "bar", BaseShardSequencerAddress: "baz"},
+			name: "prod with all required values",
+			cfg: WorldConfig{
+				CardinalMode:              RunModeProd,
+				RedisPassword:             "foo",
+				CardinalNamespace:         "foo",
+				BaseShardQueryAddress:     "bar",
+				BaseShardSequencerAddress: "baz",
+			},
 			wantErr: false,
 		},
 	}
@@ -74,5 +80,4 @@ func TestValidateConfig(t *testing.T) {
 			}
 		})
 	}
-
 }


### PR DESCRIPTION
## Overview

moving some validation logic of the config to `config.go`. 

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
