### PR TITLE
feat: makefile command to run go generate 

### DIFF
--- a/cardinal/go.mod
+++ b/cardinal/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/gofiber/contrib/websocket v1.3.0
 	github.com/gofiber/fiber/v2 v2.52.0
 	github.com/gofiber/swagger v0.1.14
+	github.com/golang/mock v1.6.0
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/websocket v1.5.1
 	github.com/invopop/jsonschema v0.7.0

--- a/makefiles/build.mk
+++ b/makefiles/build.mk
@@ -31,3 +31,17 @@ rollup-install:
 
 rollup-proto-gen:
 	cd evm && $(MAKE) proto-gen
+
+# Find all directories containing go.mod files
+GO_MOD_DIRS := $(shell find . -name "go.mod" -exec dirname {} \;)
+
+
+# Runs go generate ./... in all go.mod directories.
+generate:
+	@echo "Running go generate..."
+	@for dir in $(GO_MOD_DIRS); do \
+		(cd $$dir && go generate ./...); \
+	done
+	@echo "Go generate completed successfully."
+
+.PHONY: generate


### PR DESCRIPTION
## Overview

run `make generate` from root to hit all go:generate directives. 

NOTE: your go.mod must be tidy for this to work!!

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
