### PR TITLE
chore: add nakama beta key option to world toml

### DIFF
--- a/starter-game-template/docker-compose.yml
+++ b/starter-game-template/docker-compose.yml
@@ -87,6 +87,7 @@ services:
       - CARDINAL_ADDR=${CARDINAL_ADDR:-cardinal:3333}
       - CARDINAL_NAMESPACE=${CARDINAL_NAMESPACE}
       - DB_PASSWORD=${DB_PASSWORD:-very_unsafe_password_replace_me}
+      - ENABLE_ALLOWLIST=${ENABLE_ALLOWLIST:-false}
     entrypoint:
       - "/bin/sh"
       - "-ecx"

--- a/starter-game-template/world.toml
+++ b/starter-game-template/world.toml
@@ -28,3 +28,6 @@ CHAIN_ID="world-engine"
 KEY_MNEMONIC="enact adjust liberty squirrel bulk ticket invest tissue antique window thank slam unknown fury script among bread social switch glide wool clog flag enroll"
 FAUCET_ADDR="world142fg37yzx04cslgeflezzh83wa4xlmjpms0sg5"
 BLOCK_TIME="1s"
+
+[nakama]
+ENABLE_ALLOWLIST="false" # enable nakama's beta key feature. you can generate and claim beta keys by setting this to true


### PR DESCRIPTION
Closes: WORLD-726

## Overview
Expose `ENABLE_ALLOWLIST` env variable through world.toml

## Brief Changelog
- add `ENABLE_ALLOWLIST` to nakama docker env
- add `ENABLE_ALLOWLIST` field to world.toml

## Testing and Verifying
