### PR TITLE
feat(cardinal): allow shutdown to be called from within a system.

### DIFF
--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -7,12 +7,13 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
-	"pkg.world.dev/world-engine/cardinal/router"
 	"reflect"
 	"runtime"
 	"strings"
 	"syscall"
 	"time"
+
+	"pkg.world.dev/world-engine/cardinal/router"
 
 	"github.com/rotisserie/eris"
 	"github.com/rs/zerolog"
@@ -358,7 +359,17 @@ func (w *World) Shutdown() error {
 		}
 	}
 	close(w.endStartGame)
-	return w.Engine().Shutdown()
+	w.Engine().Shutdown()
+	counter := 0
+	for w.Engine().IsGameLoopRunning() {
+		if counter > 25 {
+			return eris.New("Engine failed to shutdown.")
+		} else {
+			counter++
+		}
+		time.Sleep(1 * time.Second)
+	}
+	return nil
 }
 
 func RegisterSystems(w *World, systems ...System) error {


### PR DESCRIPTION
Closes: WORLD-801

- Changed old shutdown function to private `shutdownEngine`. 
- Created new nonblocking public Shutdown function. 
- Created test to see if this new `Shutdown` function can be called from within systems. 

This was broken anyway and developers can cause a deadlock via `eCtx.GetEngine().Engine().Shutdown()`

What necessitated the need for this feature is the fact that profiling with golang is extremely finicky. Shutting down world, engine and cardinal must all be done properly without any panics, fatals and even a sleeping go routine that shutsdown the engine in X seconds would corrupt the profiling results. 

So basically I just need to create a system that will cleanly Shutdown world.Engine after X amount of ticks in order to get profiling to work. 