### PR TITLE
ci: change CI runner to macos M1 & bump CI deps 

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   go-lint:
     name: Go
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     env:
       GO_VERSION: 1.21.0
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,6 @@
 name: Release
 
-## workflow will trigger on below condition,
-## except image release that have jobs condition to trigger only on tagging
+## workflow will trigger only on evm & relay/nakama tag event
 on:
   push:
     tags:
@@ -26,21 +25,17 @@ jobs:
       id-token: 'write'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.4
-        with:
-          key: docker-${{ runner.os }}-${{ hashFiles('evm/Dockerfile') }}
+        uses: docker/setup-buildx-action@v3
       - name: GCP auth
         id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
       - name: GCP - Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ env.GCP_PROJECT_ID_PACKAGES }}
       - name: Docker - Auth to artifact registry
@@ -77,21 +72,17 @@ jobs:
       id-token: 'write'
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Cache Docker images
-        uses: ScribeMD/docker-cache@0.3.7
-        with:
-          key: docker-${{ runner.os }}-${{ hashFiles('relay/nakama/Dockerfile') }}
       - name: GCP auth
         id: auth
-        uses: google-github-actions/auth@v1
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
           service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
       - name: GCP - Set up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v1
+        uses: google-github-actions/setup-gcloud@v2
         with:
           project_id: ${{ env.GCP_PROJECT_ID_PACKAGES }}
       - name: Docker - Auth to artifact registry

--- a/.github/workflows/starter-template-sync.yaml
+++ b/.github/workflows/starter-template-sync.yaml
@@ -6,6 +6,9 @@ on:
       - main
     paths:
       - starter-game-template/**
+  pull_request:
+    paths:
+      - starter-game-template/**
 
 jobs:
   dir-changes:
@@ -22,9 +25,29 @@ jobs:
           filters: |
             starter-game-template:
               - 'starter-game-template/**'
+  lint-cardinal:
+    name: Lint Cardinal
+    needs: dir-changes
+    if: (needs.dir-changes.outputs.starter-game-template == 'true')
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: starter-game-template/cardinal
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Docker Build
+        uses: docker/setup-buildx-action@v3
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+        with:
+          version: v1.54.2
+          args: --timeout=10m --concurrency 8 -v
+      - name: Build Cardinal Docker Image
+        run: docker build .
   git-repo-sync:
     name: Starter-Game-Template Repo Sync
-    needs: dir-changes
+    needs: lint-cardinal
     if: (github.ref == 'refs/heads/main' && needs.dir-changes.outputs.starter-game-template == 'true')
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
           docker compose logs
   unit-test-coverage:
     name: Unit & Coverage
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,10 +23,6 @@ jobs:
           cache-dependency-path: "**/*.sum"
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      #- name: Cache Docker images
-      #  uses: ScribeMD/docker-cache@0.3.7
-      #  with:
-      #    key: docker-${{ runner.os }}-${{ hashFiles('e2e/testgames/game/Dockerfile') }}
       - name: E2E Test Nakama
         run: make e2e-nakama
       - name: E2E docker compose logs last status


### PR DESCRIPTION
Closes: WORLD-783 WORLD-797

## Overview

Update World Engine CI: changes runner to macos M1, update deps, some nits

## Brief Changelog

- Change some jobs to macos-14 M1 runner, other Docker-related jobs are keep using Linux runner due to compatibility
- Bump dependency version for some CI jobs using marketplace actions
- Add lint and build checks for starter-game-template sync

## Testing and Verifying

- CI checks passed
