### PR TITLE
refactor(nakama): break global vars into local vars and pass in as params

### DIFF
--- a/relay/nakama/cardinal.go
+++ b/relay/nakama/cardinal.go
@@ -20,9 +20,9 @@ type endpoints struct {
 	QueryEndpoints []string `json:"queryEndpoints"`
 }
 
-func getCardinalEndpoints() (txEndpoints []string, queryEndpoints []string, err error) {
+func getCardinalEndpoints(cardinalAddress string) (txEndpoints []string, queryEndpoints []string, err error) {
 	var resp *http.Response
-	url := utils.MakeHTTPURL(ListEndpoints, globalCardinalAddress)
+	url := utils.MakeHTTPURL(ListEndpoints, cardinalAddress)
 	//nolint:gosec,noctx // its ok. maybe revisit.
 	resp, err = http.Get(url)
 	if err != nil {
@@ -50,11 +50,12 @@ func makeRequestAndReadResp(
 	notifier *receipt.Notifier,
 	endpoint string,
 	payload io.Reader,
+	cardinalAddress string,
 ) (res string, err error) {
 	req, err := http.NewRequestWithContext(
 		ctx,
 		http.MethodPost,
-		utils.MakeHTTPURL(endpoint, globalCardinalAddress),
+		utils.MakeHTTPURL(endpoint, cardinalAddress),
 		payload,
 	)
 	if err != nil {

--- a/relay/nakama/handlers.go
+++ b/relay/nakama/handlers.go
@@ -26,7 +26,7 @@ func handleClaimPersona(
 	txSigner signer.Signer,
 	cardinalAddress string,
 	globalNamespace string,
-	globalPersonaAssignment sync.Map,
+	globalPersonaAssignment *sync.Map,
 ) nakamaRPCHandler {
 	return func(
 		ctx context.Context,
@@ -54,7 +54,7 @@ func handleClaimPersona(
 			txSigner,
 			cardinalAddress,
 			globalNamespace,
-			&globalPersonaAssignment,
+			globalPersonaAssignment,
 		)
 		if err == nil {
 			return utils.MarshalResult(logger, result)

--- a/relay/nakama/handlers.go
+++ b/relay/nakama/handlers.go
@@ -21,7 +21,8 @@ import (
 // handleClaimPersona handles a request to Nakama to associate the current user with the persona tag in the payload.
 func handleClaimPersona(verifier *persona.Verifier,
 	notifier *receipt.Notifier,
-	txSigner signer.Signer) nakamaRPCHandler {
+	txSigner signer.Signer,
+	cardinalAddress string) nakamaRPCHandler {
 	return func(
 		ctx context.Context,
 		logger runtime.Logger,
@@ -46,7 +47,7 @@ func handleClaimPersona(verifier *persona.Verifier,
 			notifier,
 			ptr,
 			txSigner,
-			globalCardinalAddress,
+			cardinalAddress,
 			globalNamespace,
 			&globalPersonaTagAssignment,
 		)
@@ -69,14 +70,14 @@ func handleClaimPersona(verifier *persona.Verifier,
 	}
 }
 
-func handleShowPersona(txSigner signer.Signer) nakamaRPCHandler {
+func handleShowPersona(txSigner signer.Signer, cardinalAddress string) nakamaRPCHandler {
 	return func(ctx context.Context,
 		logger runtime.Logger,
 		_ *sql.DB,
 		nk runtime.NakamaModule,
 		_ string,
 	) (string, error) {
-		result, err := persona.ShowPersona(ctx, nk, txSigner, globalCardinalAddress)
+		result, err := persona.ShowPersona(ctx, nk, txSigner, cardinalAddress)
 		if err == nil {
 			return utils.MarshalResult(logger, result)
 		}
@@ -192,6 +193,7 @@ func handleCardinalRequest(
 	currEndpoint string,
 	createPayload func(string, string, runtime.NakamaModule, context.Context) (io.Reader, error),
 	notifier *receipt.Notifier,
+	cardinalAddress string,
 ) nakamaRPCHandler {
 	return func(
 		ctx context.Context,
@@ -207,7 +209,7 @@ func handleCardinalRequest(
 			return utils.LogErrorWithMessageAndCode(logger, err, codes.FailedPrecondition, "unable to make payload")
 		}
 
-		result, err := makeRequestAndReadResp(ctx, notifier, currEndpoint, resultPayload)
+		result, err := makeRequestAndReadResp(ctx, notifier, currEndpoint, resultPayload, cardinalAddress)
 		if err != nil {
 			return utils.LogErrorWithMessageAndCode(logger, err, codes.FailedPrecondition, "")
 		}

--- a/relay/nakama/handlers.go
+++ b/relay/nakama/handlers.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"sync"
 
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/rotisserie/eris"
@@ -19,10 +20,14 @@ import (
 )
 
 // handleClaimPersona handles a request to Nakama to associate the current user with the persona tag in the payload.
-func handleClaimPersona(verifier *persona.Verifier,
+func handleClaimPersona(
+	verifier *persona.Verifier,
 	notifier *receipt.Notifier,
 	txSigner signer.Signer,
-	cardinalAddress string) nakamaRPCHandler {
+	cardinalAddress string,
+	globalNamespace string,
+	globalPersonaAssignment sync.Map,
+) nakamaRPCHandler {
 	return func(
 		ctx context.Context,
 		logger runtime.Logger,
@@ -49,7 +54,7 @@ func handleClaimPersona(verifier *persona.Verifier,
 			txSigner,
 			cardinalAddress,
 			globalNamespace,
-			&globalPersonaTagAssignment,
+			&globalPersonaAssignment,
 		)
 		if err == nil {
 			return utils.MarshalResult(logger, result)

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -33,12 +33,6 @@ const (
 	TransactionEndpointPrefix = "/tx"
 )
 
-var (
-	globalNamespace            string
-	globalPersonaTagAssignment = sync.Map{}
-	globalReceiptsDispatcher   *receipt.ReceiptsDispatcher
-)
-
 func InitModule(
 	ctx context.Context,
 	logger runtime.Logger,
@@ -53,11 +47,12 @@ func InitModule(
 		return eris.Wrap(err, "failed to init cardinal address")
 	}
 
-	if err := initNamespace(); err != nil {
-		return eris.Wrap(err, "failed to init namespace")
+	globalNamespace, err := initNamespace()
+	if err != nil {
+		return eris.Wrap(err, "failed to init globalNamespace")
 	}
 
-	initReceiptDispatcher(logger, cardinalAddress)
+	globalReceiptsDispatcher := initReceiptDispatcher(logger, cardinalAddress)
 
 	if err := initEventHub(ctx, logger, nk, EventEndpoint, cardinalAddress); err != nil {
 		return eris.Wrap(err, "failed to init event hub")
@@ -70,17 +65,40 @@ func InitModule(
 		return eris.Wrap(err, "failed to create a crypto signer")
 	}
 
-	if err := initPersonaTagAssignmentMap(ctx, logger, nk, persona.CardinalCollection); err != nil {
+	globalPersonaAssignment := sync.Map{}
+	if err := initPersonaTagAssignmentMap(
+		ctx,
+		logger,
+		nk,
+		persona.CardinalCollection,
+		globalPersonaAssignment,
+	); err != nil {
 		return eris.Wrap(err, "failed to init persona tag assignment map")
 	}
 
 	verifier := persona.NewVerifier(logger, nk, globalReceiptsDispatcher)
 
-	if err := initPersonaTagEndpoints(logger, initializer, verifier, notifier, txSigner); err != nil {
+	if err := initPersonaTagEndpoints(
+		logger,
+		initializer,
+		verifier,
+		notifier,
+		txSigner,
+		cardinalAddress,
+		globalNamespace,
+		globalPersonaAssignment,
+	); err != nil {
 		return eris.Wrap(err, "failed to init persona tag endpoints")
 	}
 
-	if err := initCardinalEndpoints(logger, initializer, notifier, txSigner, cardinalAddress); err != nil {
+	if err := initCardinalEndpoints(
+		logger,
+		initializer,
+		notifier,
+		txSigner,
+		cardinalAddress,
+		globalNamespace,
+	); err != nil {
 		return eris.Wrap(err, "failed to init cardinal endpoints")
 	}
 
@@ -99,10 +117,11 @@ func InitModule(
 	return nil
 }
 
-func initReceiptDispatcher(log runtime.Logger, cardinalAddress string) {
-	globalReceiptsDispatcher = receipt.NewReceiptsDispatcher()
+func initReceiptDispatcher(log runtime.Logger, cardinalAddress string) *receipt.Dispatcher {
+	globalReceiptsDispatcher := receipt.NewDispatcher()
 	go globalReceiptsDispatcher.PollReceipts(log, cardinalAddress)
 	go globalReceiptsDispatcher.Dispatch(log)
+	return globalReceiptsDispatcher
 }
 
 func selectSigner(ctx context.Context, logger runtime.Logger, nk runtime.NakamaModule) (signer.Signer, error) {
@@ -168,6 +187,7 @@ func initPersonaTagAssignmentMap(
 	logger runtime.Logger,
 	nk runtime.NakamaModule,
 	collectionName string,
+	globalPersonaAssignment sync.Map,
 ) error {
 	logger.Debug("attempting to build personaTag->userID mapping")
 	var cursor string
@@ -189,7 +209,7 @@ func initPersonaTagAssignmentMap(
 			}
 			if ptr.Status == persona.StatusAccepted || ptr.Status == persona.StatusPending {
 				logger.Debug("%s has been assigned to %s", ptr.PersonaTag, userID)
-				globalPersonaTagAssignment.Store(ptr.PersonaTag, userID)
+				globalPersonaAssignment.Store(ptr.PersonaTag, userID)
 			}
 		}
 		if cursor == "" {
@@ -207,6 +227,7 @@ func initCardinalEndpoints(
 	notifier *receipt.Notifier,
 	txSigner signer.Signer,
 	cardinalAddress string,
+	globalNamespace string,
 ) error {
 	txEndpoints, queryEndpoints, err := getCardinalEndpoints(cardinalAddress)
 	if err != nil {
@@ -217,7 +238,7 @@ func initCardinalEndpoints(
 	) (io.Reader, error) {
 		logger.Debug("The %s endpoint requires a signed payload", endpoint)
 		var transaction io.Reader
-		transaction, err = makeTransaction(ctx, nk, txSigner, payload, cardinalAddress)
+		transaction, err = makeTransaction(ctx, nk, txSigner, payload, cardinalAddress, globalNamespace)
 		if err != nil {
 			return nil, err
 		}
@@ -254,6 +275,7 @@ func makeTransaction(ctx context.Context,
 	txSigner signer.Signer,
 	payload string,
 	cardinalAddress string,
+	globalNamespace string,
 ) (io.Reader, error) {
 	ptr, err := persona.LoadPersonaTagStorageObj(ctx, nk)
 	if err != nil {
@@ -287,12 +309,12 @@ func initCardinalAddress() (string, error) {
 	return globalCardinalAddress, nil
 }
 
-func initNamespace() error {
-	globalNamespace = os.Getenv(EnvCardinalNamespace)
+func initNamespace() (string, error) {
+	globalNamespace := os.Getenv(EnvCardinalNamespace)
 	if globalNamespace == "" {
-		return eris.Errorf("must specify a cardinal namespace via %s", EnvCardinalNamespace)
+		return "", eris.Errorf("must specify a cardinal namespace via %s", EnvCardinalNamespace)
 	}
-	return nil
+	return globalNamespace, nil
 }
 
 func getDebugModeFromEnvironment() bool {

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -65,7 +65,7 @@ func InitModule(
 		return eris.Wrap(err, "failed to create a crypto signer")
 	}
 
-	globalPersonaAssignment := sync.Map{}
+	globalPersonaAssignment := &sync.Map{}
 	if err := initPersonaTagAssignmentMap(
 		ctx,
 		logger,
@@ -187,7 +187,7 @@ func initPersonaTagAssignmentMap(
 	logger runtime.Logger,
 	nk runtime.NakamaModule,
 	collectionName string,
-	globalPersonaAssignment sync.Map,
+	globalPersonaAssignment *sync.Map,
 ) error {
 	logger.Debug("attempting to build personaTag->userID mapping")
 	var cursor string

--- a/relay/nakama/persona/verifier.go
+++ b/relay/nakama/persona/verifier.go
@@ -44,7 +44,7 @@ func (p *Verifier) AddPendingPersonaTag(userID, txHash string) {
 	}
 }
 
-func NewVerifier(logger runtime.Logger, nk runtime.NakamaModule, rd *receipt.ReceiptsDispatcher,
+func NewVerifier(logger runtime.Logger, nk runtime.NakamaModule, rd *receipt.Dispatcher,
 ) *Verifier {
 	channelLimit := 100
 	ptv := &Verifier{

--- a/relay/nakama/receipt/dispatcher_test.go
+++ b/relay/nakama/receipt/dispatcher_test.go
@@ -33,7 +33,7 @@ func setupMockServer(t *testing.T) *httptest.Server {
 
 // Test that the Dispatcher can poll receipts from the Server and pass them to subscribed channels.
 func TestPollingFetchesAndDispatchesReceipts(t *testing.T) {
-	dispatcher := NewReceiptsDispatcher()
+	dispatcher := NewDispatcher()
 	mockServer := setupMockServer(t)
 
 	testChannel := make(chan *Receipt, 10)
@@ -54,7 +54,7 @@ func TestPollingFetchesAndDispatchesReceipts(t *testing.T) {
 
 // Test error handling in the polling process.
 func TestPollingHandlesErrorsGracefully(t *testing.T) {
-	dispatcher := NewReceiptsDispatcher()
+	dispatcher := NewDispatcher()
 
 	errorMockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -77,7 +77,7 @@ func TestPollingHandlesErrorsGracefully(t *testing.T) {
 
 // Test the non-blocking behavior of the Dispatch method.
 func TestNonBlockingDispatch(t *testing.T) {
-	dispatcher := NewReceiptsDispatcher()
+	dispatcher := NewDispatcher()
 	fullChannel := make(chan *Receipt)
 	dispatcher.Subscribe("testSessionFull", fullChannel)
 

--- a/relay/nakama/receipt/notifications.go
+++ b/relay/nakama/receipt/notifications.go
@@ -37,7 +37,7 @@ type Notifier struct {
 	logger runtime.Logger
 }
 
-func NewNotifier(logger runtime.Logger, nk runtime.NakamaModule, rd *ReceiptsDispatcher) *Notifier {
+func NewNotifier(logger runtime.Logger, nk runtime.NakamaModule, rd *Dispatcher) *Notifier {
 	ch := make(chan *Receipt)
 	rd.Subscribe("notifications", ch)
 	notifier := &Notifier{

--- a/relay/nakama/receipt/notifications_test.go
+++ b/relay/nakama/receipt/notifications_test.go
@@ -15,7 +15,7 @@ func TestNotifierIntegrationWithDispatcher(t *testing.T) {
 	nk := mocks.NewNakamaModule(t)
 	logger := &testutils.FakeLogger{}
 	mockServer := setupMockServer(t)
-	rd := NewReceiptsDispatcher()
+	rd := NewDispatcher()
 	notifier := NewNotifier(logger, nk, rd)
 
 	txHash := "hash1"
@@ -39,7 +39,7 @@ func TestNotifierIntegrationWithDispatcher(t *testing.T) {
 func TestAddTxHashToPendingNotifications(t *testing.T) {
 	logger := &testutils.FakeLogger{}
 	nk := mocks.NewNakamaModule(t)
-	rd := NewReceiptsDispatcher()
+	rd := NewDispatcher()
 	notifier := NewNotifier(logger, nk, rd)
 
 	txHash := "hash1"
@@ -55,7 +55,7 @@ func TestAddTxHashToPendingNotifications(t *testing.T) {
 func TestHandleReceipt(t *testing.T) {
 	logger := &testutils.FakeLogger{}
 	nk := mocks.NewNakamaModule(t)
-	rd := NewReceiptsDispatcher()
+	rd := NewDispatcher()
 	notifier := NewNotifier(logger, nk, rd)
 
 	txHash := "hash1"
@@ -86,7 +86,7 @@ func TestHandleReceipt(t *testing.T) {
 func TestCleanupStaleTransactions(t *testing.T) {
 	logger := &testutils.FakeLogger{}
 	nk := mocks.NewNakamaModule(t)
-	rd := NewReceiptsDispatcher()
+	rd := NewDispatcher()
 	notifier := NewNotifier(logger, nk, rd)
 
 	staleTxHash := "staleHash1"

--- a/relay/nakama/rpc.go
+++ b/relay/nakama/rpc.go
@@ -85,14 +85,16 @@ func registerEndpoints(
 	endpoints []string,
 	createPayload func(string, string, runtime.NakamaModule,
 		context.Context,
-	) (io.Reader, error)) error {
+	) (io.Reader, error),
+	cardinalAddress string,
+) error {
 	for _, e := range endpoints {
 		logger.Debug("registering: %v", e)
 		currEndpoint := e
 		if currEndpoint[0] == '/' {
 			currEndpoint = currEndpoint[1:]
 		}
-		err := initializer.RegisterRpc(currEndpoint, handleCardinalRequest(currEndpoint, createPayload, notifier))
+		err := initializer.RegisterRpc(currEndpoint, handleCardinalRequest(currEndpoint, createPayload, notifier, cardinalAddress))
 		if err != nil {
 			return eris.Wrap(err, "")
 		}

--- a/relay/nakama/rpc.go
+++ b/relay/nakama/rpc.go
@@ -25,7 +25,7 @@ func initPersonaTagEndpoints(
 	txSigner signer.Signer,
 	cardinalAddress string,
 	globalNamespace string,
-	globalPersonaAssignment sync.Map,
+	globalPersonaAssignment *sync.Map,
 ) error {
 	err := initializer.RegisterRpc(
 		"nakama/claim-persona",


### PR DESCRIPTION
Closes: WORLD-741

## Overview

There are several global vars at the top of our nakama plugin's `main.go` file. We create these global vars locally now and pass them in as params to the functions that need them instead.

## Testing and Verifying

- No new tests, existing tests passing.