### PR TITLE
test(nakama): Make a fake version of nakama module and update some tests

### DIFF
--- a/relay/nakama/signer/nakama_test.go
+++ b/relay/nakama/signer/nakama_test.go
@@ -2,86 +2,60 @@ package signer
 
 import (
 	"context"
-	"encoding/hex"
-	"fmt"
 	"testing"
 
 	"pkg.world.dev/world-engine/relay/nakama/testutils"
 
-	"github.com/ethereum/go-ethereum/crypto"
-	"github.com/heroiclabs/nakama-common/api"
-	"github.com/stretchr/testify/mock"
 	"pkg.world.dev/world-engine/assert"
-
-	"pkg.world.dev/world-engine/relay/nakama/mocks"
 )
 
 func TestPrivateKeyCanBeLoadedFromDB(t *testing.T) {
 	ctx := context.Background()
 	logger := testutils.MockNoopLogger(t)
-	nk := mocks.NewNakamaModule(t)
-	nonceManager := NewNakamaNonceManager(nk)
-	wantPrivateKey, err := crypto.GenerateKey()
-	assert.NilError(t, err)
-	storageObj := fmt.Sprintf(`{"Value":"%s"}`, hex.EncodeToString(crypto.FromECDSA(wantPrivateKey)))
-	storeReadResult := []*api.StorageObject{
-		{
-			Value: storageObj,
-		},
-	}
-	nk.On("StorageRead", mock.Anything, testutils.MockMatchReadKey(privateKeyKey)).
-		Return(storeReadResult, nil).
-		Once()
+	fakeNK := testutils.NewFakeNakamaModule()
+	nonceManager := NewNakamaNonceManager(fakeNK)
 
-	txSigner, err := NewNakamaSigner(ctx, logger, nk, nonceManager)
+	// A private key should be generated and saved in fakeNK
+	firstTxSigner, err := NewNakamaSigner(ctx, logger, fakeNK, nonceManager)
 	assert.NilError(t, err)
-	gotPrivateKey := txSigner.(*nakamaSigner).privateKey
-	assert.Check(t, nil != gotPrivateKey)
-	assert.Check(t, gotPrivateKey.Equal(wantPrivateKey))
+	firstSignerAddress := firstTxSigner.SignerAddress()
+	assert.NotEmpty(t, firstSignerAddress)
+
+	// Since we're reusing fakeNK, the previously stored private key should be found.
+	secondTxSigner, err := NewNakamaSigner(ctx, logger, fakeNK, nonceManager)
+	assert.NilError(t, err)
+	secondSignerAddress := secondTxSigner.SignerAddress()
+	assert.NotEmpty(t, secondSignerAddress)
+
+	// If the first and second signer addresses match, it means the private keys are the same.
+	assert.Equal(t, firstSignerAddress, secondSignerAddress)
+
+	// Generating a new signer, with a brand new (empty) nakama storage layer should generate a new key
+	emptyNK := testutils.NewFakeNakamaModule()
+	thirdTxSigner, err := NewNakamaSigner(ctx, logger, emptyNK, nonceManager)
+	assert.NilError(t, err)
+	thirdSignerAddress := thirdTxSigner.SignerAddress()
+
+	// This new key's signer address should not match the first or second.
+	assert.NotEqual(t, firstSignerAddress, thirdSignerAddress)
 }
 
-func TestPrivateKeyIsGenerated(t *testing.T) {
+func TestNonceIsIncremented(t *testing.T) {
 	ctx := context.Background()
 	logger := testutils.MockNoopLogger(t)
-	nk := mocks.NewNakamaModule(t)
+	nk := testutils.NewFakeNakamaModule()
 	nonceManager := NewNakamaNonceManager(nk)
-	// The DB is checked for an existing private key.
-	nk.On("StorageRead", mock.Anything, testutils.MockMatchReadKey(privateKeyKey)).
-		Return(nil, nil).
-		Once()
-
-	// A newly generated private key is written to the DB.
-	nk.On("StorageWrite", mock.Anything, testutils.MockMatchWriteKey(privateKeyKey)).
-		Return(nil, nil).
-		Once()
-
-	// A new nonce is written to the DB.
-	nk.On("StorageWrite", mock.Anything, testutils.MockMatchWriteKey(privateKeyNonce)).
-		Return(nil, nil).
-		Once()
 
 	txSigner, err := NewNakamaSigner(ctx, logger, nk, nonceManager)
 	assert.NilError(t, err)
 	gotPrivateKey := txSigner.(*nakamaSigner).privateKey
 	assert.Check(t, nil != gotPrivateKey)
 
-	nonceReadResult := []*api.StorageObject{
-		{
-			Value: `{"Value":"99"}`,
-		},
+	// The nonce should increment each time we sign a transaction
+	for wantNonce := 1; wantNonce <= 10; wantNonce++ {
+		payload := map[string]any{"foo": "bar", "baz": "quz"}
+		tx, err := txSigner.SignTx(ctx, "foobar", "baz", payload)
+		assert.NilError(t, err)
+		assert.Equal(t, tx.Nonce, uint64(wantNonce))
 	}
-
-	// To sign a transaction, a nonce will be loaded and incremented
-	nk.On("StorageRead", mock.Anything, testutils.MockMatchReadKey(privateKeyNonce)).
-		Return(nonceReadResult, nil).
-		Once()
-
-	nk.On("StorageWrite", mock.Anything, testutils.MockMatchWriteKey(privateKeyNonce)).
-		Return(nil, nil).
-		Once()
-
-	payload := map[string]any{"foo": "bar", "baz": "quz"}
-	tx, err := txSigner.SignTx(ctx, "foobar", "baz", payload)
-	assert.NilError(t, err)
-	assert.Equal(t, tx.Nonce, uint64(99))
 }

--- a/relay/nakama/testutils/testutils.go
+++ b/relay/nakama/testutils/testutils.go
@@ -6,8 +6,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/heroiclabs/nakama-common/api"
 	"github.com/heroiclabs/nakama-common/runtime"
 	"github.com/stretchr/testify/mock"
+
 	"pkg.world.dev/world-engine/relay/nakama/mocks"
 )
 
@@ -131,3 +133,68 @@ func (l *FakeLogger) GetErrors() []string {
 
 // Ensure that FakeLogger implements runtime.Logger (this will produce a compile-time error if it doesn't)
 var _ runtime.Logger = (*FakeLogger)(nil)
+
+// FakeNakamaModule is a fake implementation of runtime.NakamaModule that ONLY implements the StorageRead and
+// StorageWrite methods. Under the hood, a map is used to map collectin/key/userID tuples onto the stored values.
+// Calling other methods on the NakamaModule interface will panic. In addition, searching for values (e.g. specifying
+// a collection, but no user ID) will not return the correct results.
+type FakeNakamaModule struct {
+	runtime.NakamaModule
+	store        map[keyTuple]string
+	errsToReturn []error
+}
+
+type keyTuple struct {
+	collection string
+	key        string
+	userID     string
+}
+
+func NewFakeNakamaModule() *FakeNakamaModule {
+	return &FakeNakamaModule{
+		store: map[keyTuple]string{},
+	}
+}
+
+// WithError modifies the FakeNakamaModule to return the given error the next time StorageRead or StorageWrite is
+// called.
+func (f *FakeNakamaModule) WithError(err error) *FakeNakamaModule {
+	f.errsToReturn = append(f.errsToReturn, err)
+	return f
+}
+
+func (f *FakeNakamaModule) StorageRead(_ context.Context, reads []*runtime.StorageRead) ([]*api.StorageObject, error) {
+	if len(f.errsToReturn) > 0 {
+		var err error
+		err, f.errsToReturn = f.errsToReturn[0], f.errsToReturn[1:]
+		return nil, err
+	}
+	var results []*api.StorageObject
+	for _, read := range reads {
+		key := keyTuple{read.Collection, read.Key, read.UserID}
+		value, ok := f.store[key]
+		if ok {
+			results = append(results, &api.StorageObject{
+				Collection: read.Collection,
+				Key:        read.Key,
+				UserId:     read.UserID,
+				Value:      value,
+			})
+		}
+	}
+	return results, nil
+}
+
+func (f *FakeNakamaModule) StorageWrite(_ context.Context, writes []*runtime.StorageWrite) (
+	[]*api.StorageObjectAck, error) {
+	if len(f.errsToReturn) > 0 {
+		var err error
+		err, f.errsToReturn = f.errsToReturn[0], f.errsToReturn[1:]
+		return nil, err
+	}
+	for _, write := range writes {
+		key := keyTuple{write.Collection, write.Key, write.UserID}
+		f.store[key] = write.Value
+	}
+	return nil, nil
+}


### PR DESCRIPTION
Closes: WORLD-808


## Overview

Create a "fake" version of NakamaModule and use it in some tests.

The fake implementation uses a map to store information. It's suitable for tests that write and read information to the DB and do not use any search functionality or versioning functionality.

This allows us to write tests that focus on public facing methods (i.e. rpc handlers). In addition, the sequence of database reads and writes don't need to be known ahead of time. Tests also look cleaner because the setup code only uses the public facing methods.

## Testing and Verifying

Unit tests have been modified to use the fake implementation. Some tests have been expanded to cover more edge cases.
