### PR TITLE
docs: use correct function name for setting TickChannel WorldOption

### DIFF
--- a/docs/cardinal/game/world/api-reference.mdx
+++ b/docs/cardinal/game/world/api-reference.mdx
@@ -102,7 +102,7 @@ func WithTickChannel(ch <-chan time.Time) WorldOption
 
 ```go
 // option to make ticks happen every 500 milliseconds.
-opt := WithLoopInterval(time.Tick(500*time.Millisecond))
+opt := WithTickChannel(time.Tick(500*time.Millisecond))
 ```
 
 ## RegisterSystems


### PR DESCRIPTION
## Overview
updates the typo in the docs that uses the wrong option name for setting TickChannel.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
