### PR TITLE
chore(cardinal): remove unused structs in CQL, define component getter function as type

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -183,7 +183,7 @@ linters-settings:
   nolintlint:
     # Exclude following linters from requiring an explanation.
     # Default: []
-    allow-no-explanation: [funlen, gocognit, lll]
+    allow-no-explanation: [ funlen, gocognit, lll ]
     # Enable to require an explanation of nonzero length after each nolint directive.
     # Default: false
     require-explanation: true
@@ -323,22 +323,22 @@ issues:
   max-same-issues: 50
 
   exclude-rules:
-    - path: cardinal/ecs/cql/
+    - path: cardinal/cql/
       text: "not compatible with reflect.StructTag.Get"
       linters:
         - govet
     - path: "mock/.*\\.go"
-      linters: [funlen]
+      linters: [ funlen ]
     - path: "build"
-      linters: [wrapcheck]
+      linters: [ wrapcheck ]
     - source: "^//\\s*go:generate\\s"
-      linters: [lll]
+      linters: [ lll ]
     - source: "(noinspection|TODO)"
-      linters: [godot]
+      linters: [ godot ]
     - source: "//noinspection"
-      linters: [gocritic]
+      linters: [ gocritic ]
     - source: "^\\s+if _, ok := err\\.\\([^.]+\\.InternalError\\); ok {"
-      linters: [errorlint]
+      linters: [ errorlint ]
     - path: "_test\\.go"
       linters:
         - bodyclose

--- a/cardinal/cql/cql.go
+++ b/cardinal/cql/cql.go
@@ -19,7 +19,7 @@ const (
 
 var operatorMap = map[string]cqlOperator{"&": opAnd, "|": opOr}
 
-type componentByName func(string) (types.ComponentMetadata, error)
+type componentByName func(string) (types.Component, error)
 
 // Capture basically tells the parser library how to transform a string token that's parsed into the operator type.
 func (o *cqlOperator) Capture(s []string) error {
@@ -171,7 +171,7 @@ func valueToComponentFilter(value *cqlValue, stringToComponent componentByName) 
 		if len(value.Exact.Components) == 0 {
 			return nil, eris.New("EXACT cannot have zero parameters")
 		}
-		components := make([]component.Component, 0, len(value.Exact.Components))
+		components := make([]types.Component, 0, len(value.Exact.Components))
 		for _, componentName := range value.Exact.Components {
 			comp, err := stringToComponent(componentName.Name)
 			if err != nil {
@@ -186,7 +186,7 @@ func valueToComponentFilter(value *cqlValue, stringToComponent componentByName) 
 		if len(value.Contains.Components) == 0 {
 			return nil, eris.New("CONTAINS cannot have zero parameters")
 		}
-		components := make([]component.Component, 0, len(value.Contains.Components))
+		components := make([]types.Component, 0, len(value.Contains.Components))
 		for _, componentName := range value.Contains.Components {
 			comp, err := stringToComponent(componentName.Name)
 			if err != nil {

--- a/cardinal/cql/cql.go
+++ b/cardinal/cql/cql.go
@@ -82,7 +82,6 @@ type cqlTerm struct {
 }
 
 // Display
-
 func (o cqlOperator) String() string {
 	switch o {
 	case opAnd:
@@ -158,9 +157,7 @@ var internalCQLParser = participle.MustBuild[cqlTerm]()
 // TODO: Msg is sum type is represented as a product type. There is a case where multiple properties are filled out.
 // Only one property may not be nil, The parser should prevent this from happening but for safety this should eventually
 // be checked.
-func valueToComponentFilter(value *cqlValue, stringToComponent componentByName) (
-	filter.ComponentFilter, error,
-) {
+func valueToComponentFilter(value *cqlValue, stringToComponent componentByName) (filter.ComponentFilter, error) {
 	if value.Not != nil { //nolint:gocritic,nestif // its fine.
 		resultFilter, err := valueToComponentFilter(value.Not.SubExpression, stringToComponent)
 		if err != nil {
@@ -208,10 +205,9 @@ func factorToComponentFilter(factor *cqlFactor, stringToComponent componentByNam
 	return valueToComponentFilter(factor.Base, stringToComponent)
 }
 
-func opFactorToComponentFilter(
-	opFactor *cqlOpFactor,
-	stringToComponent componentByName,
-) (*cqlOperator, filter.ComponentFilter, error) {
+func opFactorToComponentFilter(opFactor *cqlOpFactor, stringToComponent componentByName) (
+	*cqlOperator, filter.ComponentFilter, error,
+) {
 	resultFilter, err := factorToComponentFilter(opFactor.Factor, stringToComponent)
 	if err != nil {
 		return nil, nil, err
@@ -219,9 +215,7 @@ func opFactorToComponentFilter(
 	return &opFactor.Operator, resultFilter, nil
 }
 
-func termToComponentFilter(
-	term *cqlTerm, stringToComponent componentByName,
-) (filter.ComponentFilter, error) {
+func termToComponentFilter(term *cqlTerm, stringToComponent componentByName) (filter.ComponentFilter, error) {
 	if term.Left == nil {
 		return nil, eris.New("not enough values in expression")
 	}
@@ -246,10 +240,8 @@ func termToComponentFilter(
 	return acc, nil
 }
 
-func Parse(
-	cqlText string, stringToComponent componentByName,
-) (filter.ComponentFilter, error) {
-	term, err := internalCQLParser.ParseString("", cqlText)
+func Parse(cqlText string, stringToComponent componentByName) (filter.ComponentFilter, error) {
+	term, err := internalCQLParser.ParseString("failed to parse CQL string", cqlText)
 	if err != nil {
 		return nil, eris.Wrap(err, "")
 	}

--- a/cardinal/cql/cql.go
+++ b/cardinal/cql/cql.go
@@ -241,9 +241,9 @@ func termToComponentFilter(term *cqlTerm, stringToComponent componentByName) (fi
 }
 
 func Parse(cqlText string, stringToComponent componentByName) (filter.ComponentFilter, error) {
-	term, err := internalCQLParser.ParseString("failed to parse CQL string", cqlText)
+	term, err := internalCQLParser.ParseString("", cqlText)
 	if err != nil {
-		return nil, eris.Wrap(err, "")
+		return nil, eris.Wrap(err, "failed to parse CQL string")
 	}
 	resultFilter, err := termToComponentFilter(term, stringToComponent)
 	if err != nil {

--- a/cardinal/plugin_cql.go
+++ b/cardinal/plugin_cql.go
@@ -57,7 +57,7 @@ func queryCQL(ctx engine.Context, req *CQLQueryRequest) (*CQLQueryResponse, erro
 	cqlString := req.CQL
 
 	// getComponentByName is a wrapper function that casts component.ComponentMetadata from ctx.GetComponentByName
-	// to component.Component
+	// to types.Component
 	getComponentByName := func(name string) (types.Component, error) {
 		comp, err := ctx.GetComponentByName(name)
 		if err != nil {


### PR DESCRIPTION
## Overview

defines the GetComponentByName dependency explicitly, so we dont type out the function signature multiple times

removes unused structs

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
