### PR TITLE
refactor(cardinal): make NewWorldContextForTick private

### DIFF
--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -146,7 +146,8 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 	}
 
 	if cfg.CardinalMode == RunModeProd {
-		world.router, err = router.New(cfg.CardinalNamespace, cfg.BaseShardSequencerAddress, cfg.BaseShardQueryAddress, world)
+		world.router, err = router.New(cfg.CardinalNamespace, cfg.BaseShardSequencerAddress, cfg.BaseShardQueryAddress,
+			world)
 		if err != nil {
 			return nil, err
 		}
@@ -243,7 +244,7 @@ func (w *World) Tick(ctx context.Context) error {
 	w.timestamp.Store(uint64(startTime.Unix()))
 
 	// Create the engine context to inject into systems
-	wCtx := NewWorldContextForTick(w, txQueue)
+	wCtx := newWorldContextForTick(w, txQueue)
 
 	// Run all registered systems.
 	// This will run the registered init systems if the current tick is 0

--- a/cardinal/world_context.go
+++ b/cardinal/world_context.go
@@ -19,7 +19,7 @@ type worldContext struct {
 	readOnly bool
 }
 
-func NewWorldContextForTick(world *World, txQueue *txpool.TxQueue) engine.Context {
+func newWorldContextForTick(world *World, txQueue *txpool.TxQueue) engine.Context {
 	return &worldContext{
 		world:    world,
 		txQueue:  txQueue,


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

`NewWorldContextForTick` is a public function when it's intended only for internal use. This PR makes the function private.

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

- Make NewWorldContextForTick private

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

- N/A