### PR TITLE
chore: remove CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,0 @@
-# Default reviewers. The users below will be requested to review every pull request.
-* @argus-labs/Architects


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

I propose we remove CODEOWNERS that assigns everyone/anyone to review a PR. I don't think this is working for the following reason:
The current process makes PR review slower
There is ambiguity on who is responsible for reviewing a certain PR when everyone thinks "oh its fine someone else will review the PR". In reality, everyone thought the same thing, so no PR gets reviewed.
It's very spammy on github notifs, which creates tendency for people to ignore GH notifications altogether -> making PR review slower.
The current process implies that anyone's PR review is ok, resulting with PRs getting merged with low quality reviews (i.e. feature PRs getting merged despite not fulfilling the feature requirement, implementations ignoring existing established code patterns, etc).
After parsing through PR approval history, it's clear to me that there is tendency for those who doesn't have much context/understanding/involvement of a certain part of the codebase to just LGTM changes until someone who is more involved in that part of the codebase and has more opinion of the design choice rejects the PR for various valid reasons.
Proposed new PR review process:
Each PR should be reviewed by 2 people (recommended) or 1 person (minimum)
If 2 person:
1 reviewer should be the person who is directly involved with the part of the codebase modified. The Github PR UI will automatically suggest this on the "Reviewers" section on the right sidebar.
1 reviewer should be a person who is deeply familiar with the feature requirement/proposed the task OR any relevant senior engineer.
If 1 person:
This should generally be avoided unless the PR is really basic (i.e. config, ci, nits, etc)
1 reviewer should be the person who is directly involved with the part of the codebase modified.

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
