### PR TITLE
docs: typos on cql queries

### DIFF
--- a/docs/cardinal/game/cql.mdx
+++ b/docs/cardinal/game/cql.mdx
@@ -88,8 +88,8 @@ Operators in CQL do not have any intrinsic precedence. All expressions are consu
 - Example: `A & B | C & D | F`  is equivalent to `( ( A & B ) | C ) & D ) | F)`
 
 You can use parenthesis to specify and change precedence in CQL.
-- Example: `EXACT(legComponent) | (!CONTAIN(healthComponent) & !CONTAIN(attackComponent))`
+- Example: `EXACT(legComponent) | (!CONTAINS(healthComponent) & !CONTAINS(attackComponent))`
 - The above is a query for either an entity with only a leg component or an entity that does not have a health component and also does not have an attack component.
 
-- Example: `(EXACT(legComponent) | !CONTAIN(healthComponent)) & !CONTAIN(attackComponent)`
+- Example: `(EXACT(legComponent) | !CONTAINS(healthComponent)) & !CONTAINS(attackComponent)`
 - The above is the same query but with precedence changed. Now it is querying an entity with either exactly one leg component or does not have a health component. Additionally that entity must not ever contain a attack component.


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

Some of the examples used `CONTAIN` instead of `CONTAINS`.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
