### PR TITLE
feat(cardinal): on ecb change typeToComponent to use PrimitiveStorage Interface.

### DIFF
--- a/cardinal/gamestate/ecb.go
+++ b/cardinal/gamestate/ecb.go
@@ -24,7 +24,7 @@ type EntityCommandBuffer struct {
 
 	compValues         PrimitiveStorage[compKey]
 	compValuesToDelete PrimitiveStorage[compKey]
-	typeToComponent    map[types.ComponentID]types.ComponentMetadata
+	typeToComponent    PrimitiveStorage[types.ComponentID]
 
 	activeEntities map[types.ArchetypeID]activeEntities
 
@@ -72,9 +72,13 @@ func NewEntityCommandBuffer(storage PrimitiveStorage[string]) (*EntityCommandBuf
 }
 
 func (m *EntityCommandBuffer) RegisterComponents(comps []types.ComponentMetadata) error {
-	m.typeToComponent = map[types.ComponentID]types.ComponentMetadata{}
+	m.typeToComponent = NewMapStorage[types.ComponentID, types.ComponentMetadata]()
+	ctx := context.Background()
 	for _, comp := range comps {
-		m.typeToComponent[comp.ID()] = comp
+		err := m.typeToComponent.Set(ctx, comp.ID(), comp)
+		if err != nil {
+			return err
+		}
 	}
 
 	return m.loadArchIDs()

--- a/cardinal/gamestate/read_only.go
+++ b/cardinal/gamestate/read_only.go
@@ -21,7 +21,7 @@ var (
 
 type readOnlyManager struct {
 	storage         PrimitiveStorage[string]
-	typeToComponent map[types.ComponentID]types.ComponentMetadata
+	typeToComponent PrimitiveStorage[types.ComponentID]
 	archIDToComps   map[types.ArchetypeID][]types.ComponentMetadata
 }
 


### PR DESCRIPTION
Closes: WORLD-883

Straight forward. changes one section of the ecb to use PrimitiveStorage instead of Map. I'm just going to do this one here as it was already in flight before I had a talk with Scott about the alternative implementation. 

We may want to go with PrimitiveStorage[K, V] which is more type safe and involves a lot of changes so I'm going to wait until we have that discussion with everyone before doing any more of these PRs related to decoupling ECB from a concrete storage type. 