### PR TITLE
feat(cardinal): EachMessage design proposal

### DIFF
--- a/cardinal/cardinal.go
+++ b/cardinal/cardinal.go
@@ -74,6 +74,15 @@ func MustRegisterComponent[T types.Component](w *World) {
 	}
 }
 
+func EachMessage[In any, Out any](wCtx engine.Context, fn func(message.TxData[In]) (Out, error)) error {
+	msg, err := GetMessage[In, Out](wCtx)
+	if err != nil {
+		return err
+	}
+	msg.Each(wCtx, fn)
+	return nil
+}
+
 func RegisterMessage[In any, Out any](world *World, name string, opts ...message.MessageOption[In, Out]) error {
 	if world.worldStage.Current() != worldstage.Init {
 		return eris.Errorf(

--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -66,11 +66,7 @@ func TestForEachTransaction(t *testing.T) {
 	assert.NilError(t, cardinal.RegisterMessage[SomeMsgRequest, SomeMsgResponse](world, "some_msg"))
 
 	err := cardinal.RegisterSystems(world, func(wCtx engine.Context) error {
-		someMsg, err := cardinal.GetMessage[SomeMsgRequest, SomeMsgResponse](wCtx)
-		if err != nil {
-			return err
-		}
-		someMsg.Each(wCtx, func(t message.TxData[SomeMsgRequest]) (result SomeMsgResponse, err error) {
+		return cardinal.EachMessage[SomeMsgRequest, SomeMsgResponse](wCtx, func(t message.TxData[SomeMsgRequest]) (result SomeMsgResponse, err error) {
 			if t.Msg.GenerateError {
 				return result, errors.New("some error")
 			}
@@ -78,7 +74,6 @@ func TestForEachTransaction(t *testing.T) {
 				Successful: true,
 			}, nil
 		})
-		return nil
 	})
 	assert.NilError(t, err)
 	tf.StartWorld()

--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -66,14 +66,15 @@ func TestForEachTransaction(t *testing.T) {
 	assert.NilError(t, cardinal.RegisterMessage[SomeMsgRequest, SomeMsgResponse](world, "some_msg"))
 
 	err := cardinal.RegisterSystems(world, func(wCtx engine.Context) error {
-		return cardinal.EachMessage[SomeMsgRequest, SomeMsgResponse](wCtx, func(t message.TxData[SomeMsgRequest]) (result SomeMsgResponse, err error) {
-			if t.Msg.GenerateError {
-				return result, errors.New("some error")
-			}
-			return SomeMsgResponse{
-				Successful: true,
-			}, nil
-		})
+		return cardinal.EachMessage[SomeMsgRequest, SomeMsgResponse](wCtx,
+			func(t message.TxData[SomeMsgRequest]) (result SomeMsgResponse, err error) {
+				if t.Msg.GenerateError {
+					return result, errors.New("some error")
+				}
+				return SomeMsgResponse{
+					Successful: true,
+				}, nil
+			})
 	})
 	assert.NilError(t, err)
 	tf.StartWorld()


### PR DESCRIPTION
Closes: WORLD-885

- new function `EachMessage[In any, Out any](wCtx, fn func().....)`
- changed unit test to use EachMessage

This design proposal was suggested by @jerargus. 

Basically during his proposal I didn't realize how simple it would be to implement. It's actually a feature change that only needs to go on top of our existing changes. It's actually a trivial change. 

Overall this change should replace MessageType usage in systems all together and reduce the amount of code a user uses. The downside of this change is that it becomes a bit inconsistent with our usage of Each. We now have Each methods everywhere and suddenly for Messages we have an EachMessage thing which isn't even a method but a function out of nowhere. 

It makes it inconsistent with Components especially. 

This PR is a Design Doc, a design proposal. It doesn't have to go up. If you like the direction this goes please approve. I'll probably want to see everyones approval before this goes up. 

If this is approved a subsequent PR will rewrite all unit tests and make GetMessages private. 