### PR TITLE
feat(cardinal): MessageEach refactor finalization.

### DIFF
--- a/cardinal/cardinal.go
+++ b/cardinal/cardinal.go
@@ -68,21 +68,6 @@ func RegisterComponent[T types.Component](w *World) error {
 	return nil
 }
 
-func getMessage[In any, Out any](wCtx engine.Context) (*message.MessageType[In, Out], error) {
-	var msg message.MessageType[In, Out]
-	msgType := reflect.TypeOf(msg)
-	tempRes, ok := wCtx.GetMessageByType(msgType)
-	if !ok {
-		return &msg, eris.Errorf("Could not find %s, Message may not be registered.", msg.Name())
-	}
-	var _ types.Message = &msg
-	res, ok := tempRes.(*message.MessageType[In, Out])
-	if !ok {
-		return &msg, eris.New("wrong type")
-	}
-	return res, nil
-}
-
 func MustRegisterComponent[T types.Component](w *World) {
 	err := RegisterComponent[T](w)
 	if err != nil {

--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -176,17 +176,18 @@ func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 	err := cardinal.RegisterSystems(
 		world,
 		func(wCtx engine.Context) error {
-			return cardinal.EachMessage[*ModifyScoreMsg, *EmptyMsgResult](wCtx, func(msData message.TxData[*ModifyScoreMsg]) (*EmptyMsgResult, error) {
-				ms := msData.Msg
-				err := cardinal.UpdateComponent[ScoreComponent](
-					wCtx, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
-						s.Score += ms.Amount
-						return s
-					},
-				)
-				assert.Check(t, err == nil)
-				return &EmptyMsgResult{}, nil
-			})
+			return cardinal.EachMessage[*ModifyScoreMsg, *EmptyMsgResult](wCtx,
+				func(msData message.TxData[*ModifyScoreMsg]) (*EmptyMsgResult, error) {
+					ms := msData.Msg
+					err := cardinal.UpdateComponent[ScoreComponent](
+						wCtx, ms.PlayerID, func(s *ScoreComponent) *ScoreComponent {
+							s.Score += ms.Amount
+							return s
+						},
+					)
+					assert.Check(t, err == nil)
+					return &EmptyMsgResult{}, nil
+				})
 		},
 	)
 	assert.NilError(t, err)

--- a/cardinal/engine_test.go
+++ b/cardinal/engine_test.go
@@ -108,14 +108,11 @@ func TestCannotWaitForNextTickAfterEngineIsShutDown(t *testing.T) {
 	err = cardinal.RegisterSystems(
 		world,
 		func(wCtx engine.Context) error {
-			tx, err := cardinal.GetMessage[FooIn, FooOut](wCtx)
-			assert.NilError(t, err)
-			tx.Each(
+			return cardinal.EachMessage[FooIn, FooOut](
 				wCtx, func(t message.TxData[FooIn]) (FooOut, error) {
 					return returnVal, returnErr
 				},
 			)
-			return nil
 		},
 	)
 	assert.NilError(t, err)
@@ -173,14 +170,11 @@ func TestEVMTxConsume(t *testing.T) {
 	var returnErr error
 	err = cardinal.RegisterSystems(world,
 		func(eCtx cardinal.WorldContext) error {
-			fooTx, err := cardinal.GetMessage[FooIn, FooOut](eCtx)
-			assert.NilError(t, err)
-			fooTx.Each(
+			return cardinal.EachMessage[FooIn, FooOut](
 				eCtx, func(t message.TxData[FooIn]) (FooOut, error) {
 					return returnVal, returnErr
 				},
 			)
-			return nil
 		},
 	)
 	assert.NilError(t, err)
@@ -457,15 +451,10 @@ func TestRecoverFromChain(t *testing.T) {
 
 	fooMessages := 0
 	err := cardinal.RegisterSystems(world, func(engineContext cardinal.WorldContext) error {
-		fooMessage, err := cardinal.GetMessage[fooMsg, fooMsgRes](engineContext)
-		if err != nil {
-			return err
-		}
-		fooMessage.Each(engineContext, func(t message.TxData[fooMsg]) (fooMsgRes, error) {
+		return cardinal.EachMessage[fooMsg, fooMsgRes](engineContext, func(t message.TxData[fooMsg]) (fooMsgRes, error) {
 			fooMessages++
 			return fooMsgRes{}, nil
 		})
-		return nil
 	})
 	assert.NilError(t, err)
 	fooMessage, err := cardinal.GetMessageFromWorld[fooMsg, fooMsgRes](world)

--- a/cardinal/example_messagetype_test.go
+++ b/cardinal/example_messagetype_test.go
@@ -32,28 +32,24 @@ func ExampleMessageType() {
 	}
 
 	err = cardinal.RegisterSystems(world, func(wCtx engine.Context) error {
-		MoveMsg, err := cardinal.GetMessage[MovePlayerMsg, MovePlayerResult](wCtx)
-		if err != nil {
-			return err
-		}
-		MoveMsg.Each(wCtx, func(txData message.TxData[MovePlayerMsg]) (MovePlayerResult, error) {
-			// handle the transaction
-			// ...
+		return cardinal.EachMessage[MovePlayerMsg, MovePlayerResult](wCtx,
+			func(txData message.TxData[MovePlayerMsg]) (MovePlayerResult, error) {
+				// handle the transaction
+				// ...
 
-			if err := errors.New("some error from a function"); err != nil {
-				// A returned non-nil error will be appended to this transaction's list of errors. Any existing
-				// transaction result will not be modified.
-				return MovePlayerResult{}, fmt.Errorf("problem processing transaction: %w", err)
-			}
+				if err := errors.New("some error from a function"); err != nil {
+					// A returned non-nil error will be appended to this transaction's list of errors. Any existing
+					// transaction result will not be modified.
+					return MovePlayerResult{}, fmt.Errorf("problem processing transaction: %w", err)
+				}
 
-			// Returning a nil error implies this transaction handling was successful, so this transaction result
-			// will be saved to the transaction receipt.
-			return MovePlayerResult{
-				FinalX: txData.Msg.DeltaX,
-				FinalY: txData.Msg.DeltaY,
-			}, nil
-		})
-		return nil
+				// Returning a nil error implies this transaction handling was successful, so this transaction result
+				// will be saved to the transaction receipt.
+				return MovePlayerResult{
+					FinalX: txData.Msg.DeltaX,
+					FinalY: txData.Msg.DeltaY,
+				}, nil
+			})
 	})
 	if err != nil {
 		panic(err)

--- a/cardinal/plugin_persona.go
+++ b/cardinal/plugin_persona.go
@@ -96,11 +96,7 @@ func AuthorizePersonaAddressSystem(wCtx engine.Context) error {
 	if err != nil {
 		return err
 	}
-	authorizePersonaAddressMsg, err := GetMessage[msg.AuthorizePersonaAddress, msg.AuthorizePersonaAddressResult](wCtx)
-	if err != nil {
-		return err
-	}
-	authorizePersonaAddressMsg.Each(
+	return EachMessage[msg.AuthorizePersonaAddress, msg.AuthorizePersonaAddressResult](
 		wCtx,
 		func(txData message.TxData[msg.AuthorizePersonaAddress]) (
 			result msg.AuthorizePersonaAddressResult, err error,
@@ -141,7 +137,6 @@ func AuthorizePersonaAddressSystem(wCtx engine.Context) error {
 			return result, nil
 		},
 	)
-	return nil
 }
 
 // -----------------------------------------------------------------------------
@@ -155,11 +150,7 @@ func RegisterPersonaSystem(wCtx engine.Context) error {
 	if err != nil {
 		return err
 	}
-	createPersonaMsg, err := GetMessage[msg.CreatePersona, msg.CreatePersonaResult](wCtx)
-	if err != nil {
-		return err
-	}
-	createPersonaMsg.Each(
+	return EachMessage[msg.CreatePersona, msg.CreatePersonaResult](
 		wCtx,
 		func(txData message.TxData[msg.CreatePersona]) (result msg.CreatePersonaResult, err error) {
 			txMsg := txData.Msg
@@ -198,8 +189,6 @@ func RegisterPersonaSystem(wCtx engine.Context) error {
 			return result, nil
 		},
 	)
-
-	return nil
 }
 
 // -----------------------------------------------------------------------------

--- a/cardinal/plugin_receipt_test.go
+++ b/cardinal/plugin_receipt_test.go
@@ -20,16 +20,12 @@ func TestReceiptsQuery(t *testing.T) {
 	err := cardinal.RegisterMessage[fooIn, fooOut](world, "foo")
 	assert.NilError(t, err)
 	err = cardinal.RegisterSystems(world, func(ctx cardinal.WorldContext) error {
-		fooMsg, err := cardinal.GetMessage[fooIn, fooOut](ctx)
-		assert.NilError(t, err)
-		fooMsg.Each(ctx, func(t message.TxData[fooIn]) (fooOut, error) {
+		return cardinal.EachMessage[fooIn, fooOut](ctx, func(t message.TxData[fooIn]) (fooOut, error) {
 			if ctx.CurrentTick()%2 == 0 {
 				return fooOut{Y: 4}, nil
 			}
-
 			return fooOut{}, errors.New("omg")
 		})
-		return nil
 	})
 	assert.NilError(t, err)
 	fooMsg, err := cardinal.GetMessageFromWorld[fooIn, fooOut](world)

--- a/cardinal/state_test.go
+++ b/cardinal/state_test.go
@@ -9,6 +9,7 @@ import (
 	"pkg.world.dev/world-engine/cardinal"
 	"pkg.world.dev/world-engine/cardinal/filter"
 	"pkg.world.dev/world-engine/cardinal/iterators"
+	"pkg.world.dev/world-engine/cardinal/message"
 	"pkg.world.dev/world-engine/cardinal/types"
 	"pkg.world.dev/world-engine/cardinal/types/engine"
 
@@ -314,14 +315,11 @@ func TestCanFindTransactionsAfterReloadingEngine(t *testing.T) {
 		err := cardinal.RegisterSystems(
 			world,
 			func(wCtx engine.Context) error {
-				someTx, err := cardinal.GetMessage[Msg, Result](wCtx)
-				if err != nil {
-					return err
-				}
-				for _, tx := range someTx.In(wCtx) {
+				someTx, err := testutils.GetMessage[Msg, Result](wCtx)
+				return cardinal.EachMessage[Msg, Result](wCtx, func(tx message.TxData[Msg]) (Result, error) {
 					someTx.SetResult(wCtx, tx.Hash, Result{})
-				}
-				return nil
+					return Result{}, err
+				})
 			},
 		)
 		assert.NilError(t, err)

--- a/cardinal/testutils/message.go
+++ b/cardinal/testutils/message.go
@@ -4,7 +4,10 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-engine/cardinal/message"
+	"pkg.world.dev/world-engine/cardinal/types"
+	"pkg.world.dev/world-engine/cardinal/types/engine"
 )
 
 func isStruct[T any]() bool {
@@ -38,4 +41,19 @@ func NewMessageType[In, Out any](
 		opt(msg)
 	}
 	return msg
+}
+
+func GetMessage[In any, Out any](wCtx engine.Context) (*message.MessageType[In, Out], error) {
+	var msg message.MessageType[In, Out]
+	msgType := reflect.TypeOf(msg)
+	tempRes, ok := wCtx.GetMessageByType(msgType)
+	if !ok {
+		return &msg, eris.Errorf("Could not find %s, Message may not be registered.", msg.Name())
+	}
+	var _ types.Message = &msg
+	res, ok := tempRes.(*message.MessageType[In, Out])
+	if !ok {
+		return &msg, eris.New("wrong type")
+	}
+	return res, nil
 }

--- a/cardinal/tick_test.go
+++ b/cardinal/tick_test.go
@@ -359,7 +359,7 @@ func TestCanRecoverTransactionsFromFailedSystemRun(t *testing.T) {
 				id := q.MustFirst()
 				entityPower, err := cardinal.GetComponent[PowerComp](wCtx, id)
 				assert.NilError(t, err)
-				powerTx, err := cardinal.GetMessage[PowerComp, PowerComp](wCtx)
+				powerTx, err := testutils.GetMessage[PowerComp, PowerComp](wCtx)
 				assert.NilError(t, err)
 				changes := powerTx.In(wCtx)
 				assert.Equal(t, 1, len(changes))

--- a/cardinal/world_context.go
+++ b/cardinal/world_context.go
@@ -3,11 +3,9 @@ package cardinal
 import (
 	"reflect"
 
-	"github.com/rotisserie/eris"
 	"github.com/rs/zerolog"
 	"pkg.world.dev/world-engine/cardinal/events"
 	"pkg.world.dev/world-engine/cardinal/gamestate"
-	"pkg.world.dev/world-engine/cardinal/message"
 	"pkg.world.dev/world-engine/cardinal/receipt"
 	"pkg.world.dev/world-engine/cardinal/types"
 	"pkg.world.dev/world-engine/cardinal/types/engine"
@@ -48,21 +46,6 @@ func NewReadOnlyWorldContext(world *World) engine.Context {
 		logger:   world.Logger,
 		readOnly: true,
 	}
-}
-
-func GetMessage[In any, Out any](wCtx engine.Context) (*message.MessageType[In, Out], error) {
-	var msg message.MessageType[In, Out]
-	msgType := reflect.TypeOf(msg)
-	tempRes, ok := wCtx.GetMessageByType(msgType)
-	if !ok {
-		return &msg, eris.Errorf("Could not find %s, Message may not be registered.", msg.Name())
-	}
-	var _ types.Message = &msg
-	res, ok := tempRes.(*message.MessageType[In, Out])
-	if !ok {
-		return &msg, eris.New("wrong type")
-	}
-	return res, nil
 }
 
 // interface guard

--- a/e2e/testgames/game/sys/join.go
+++ b/e2e/testgames/game/sys/join.go
@@ -14,11 +14,7 @@ var PlayerEntityID = make(map[string]types.EntityID)
 
 func Join(ctx cardinal.WorldContext) error {
 	logger := ctx.Logger()
-	joinMsg, err := cardinal.GetMessage[msg.JoinInput, msg.JoinOutput](ctx)
-	if err != nil {
-		return err
-	}
-	joinMsg.Each(
+	return cardinal.EachMessage[msg.JoinInput, msg.JoinOutput](
 		ctx, func(jtx message.TxData[msg.JoinInput]) (msg.JoinOutput, error) {
 			logger.Info().Msgf("got join transaction from: %s", jtx.Tx.PersonaTag)
 			entityID, err := cardinal.Create(ctx, comp.Location{}, comp.Player{})
@@ -40,5 +36,4 @@ func Join(ctx cardinal.WorldContext) error {
 			return msg.JoinOutput{Success: true}, nil
 		},
 	)
-	return nil
 }

--- a/e2e/testgames/game/sys/move.go
+++ b/e2e/testgames/game/sys/move.go
@@ -11,37 +11,33 @@ import (
 
 func Move(ctx cardinal.WorldContext) error {
 	logger := ctx.Logger()
-	moveMsg, err := cardinal.GetMessage[msg.MoveInput, msg.MoveOutput](ctx)
-	if err != nil {
-		return err
-	}
-	moveMsg.Each(ctx, func(mtx message.TxData[msg.MoveInput]) (msg.MoveOutput, error) {
-		logger.Info().Msgf("got move transaction from: %s", mtx.Tx.PersonaTag)
-		playerEntityID, ok := PlayerEntityID[mtx.Tx.PersonaTag]
-		if !ok {
-			return msg.MoveOutput{}, fmt.Errorf("player %s has not joined yet", mtx.Tx.PersonaTag)
-		}
-		var resultingLoc comp.Location
-		err := cardinal.UpdateComponent[comp.Location](ctx, playerEntityID,
-			func(location *comp.Location) *comp.Location {
-				switch mtx.Msg.Direction {
-				case "up":
-					location.Y++
-				case "down":
-					location.Y--
-				case "left":
-					location.X--
-				case "right":
-					location.X++
-				}
-				resultingLoc = *location
-				return location
-			})
-		if err != nil {
-			return msg.MoveOutput{}, err
-		}
-		logger.Info().Msgf("player %s now at (%d, %d)", mtx.Tx.PersonaTag, resultingLoc.X, resultingLoc.Y)
-		return msg.MoveOutput{X: resultingLoc.X, Y: resultingLoc.Y}, err
-	})
-	return nil
+	return cardinal.EachMessage[msg.MoveInput, msg.MoveOutput](ctx,
+		func(mtx message.TxData[msg.MoveInput]) (msg.MoveOutput, error) {
+			logger.Info().Msgf("got move transaction from: %s", mtx.Tx.PersonaTag)
+			playerEntityID, ok := PlayerEntityID[mtx.Tx.PersonaTag]
+			if !ok {
+				return msg.MoveOutput{}, fmt.Errorf("player %s has not joined yet", mtx.Tx.PersonaTag)
+			}
+			var resultingLoc comp.Location
+			err := cardinal.UpdateComponent[comp.Location](ctx, playerEntityID,
+				func(location *comp.Location) *comp.Location {
+					switch mtx.Msg.Direction {
+					case "up":
+						location.Y++
+					case "down":
+						location.Y--
+					case "left":
+						location.X--
+					case "right":
+						location.X++
+					}
+					resultingLoc = *location
+					return location
+				})
+			if err != nil {
+				return msg.MoveOutput{}, err
+			}
+			logger.Info().Msgf("player %s now at (%d, %d)", mtx.Tx.PersonaTag, resultingLoc.X, resultingLoc.Y)
+			return msg.MoveOutput{X: resultingLoc.X, Y: resultingLoc.Y}, err
+		})
 }


### PR DESCRIPTION
Closes: WORLD-888

- `GetMessage` is made private, and will after this be referred to as `getMessage`.
- `getMessage` is moved to `cardinal.go`
- `EachMessage` is used in unit tests where it is relevant
- `testutils.GetMessage` is created and it's a copy of `cardinal.getMessage`. `testutils.GetMessage` is to be used in unit tests.

- edit: getMessage has been removed. The logic is inlined into `EachMessage`. There is now only one `GetMessage` function and it lives in testutils. 