### PR TITLE
fix(cardinal): Fix flaky TestWorldLogger

### DIFF
--- a/cardinal/log/log.go
+++ b/cardinal/log/log.go
@@ -1,7 +1,10 @@
 package log
 
 import (
+	"sort"
+
 	"github.com/rs/zerolog"
+
 	"pkg.world.dev/world-engine/cardinal/types"
 )
 
@@ -21,9 +24,13 @@ func loadComponentIntoArrayLogger(
 }
 
 func loadComponentsToEvent(zeroLoggerEvent *zerolog.Event, target Loggable) *zerolog.Event {
-	zeroLoggerEvent.Int("total_components", len(target.GetRegisteredComponents()))
+	components := target.GetRegisteredComponents()
+	sort.Slice(components, func(i, j int) bool {
+		return components[i].ID() < components[j].ID()
+	})
+	zeroLoggerEvent.Int("total_components", len(components))
 	arrayLogger := zerolog.Arr()
-	for _, _component := range target.GetRegisteredComponents() {
+	for _, _component := range components {
 		arrayLogger = loadComponentIntoArrayLogger(_component, arrayLogger)
 	}
 	return zeroLoggerEvent.Array("components", arrayLogger)


### PR DESCRIPTION
Closes: WORLD-890

## Overview

The array of components in this log was in a random order because map iteration was used to generate it. 

Code has been updated to ensure components are logged in ascending ID order. 

An alternative fix here would be to update the test to ignore out-of-order components, however I think making sure the components are in a predicable order (as well as the order that they were registered) is useful.

## Testing and Verifying

from world-engine/cardinal/log run:

`go test -run=TestWorldLogger --count=20`

