### PR TITLE
ci: nits bump version, optimize runner, fix docs preview instruction

### DIFF
--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -5,15 +5,12 @@ on:
     types: [opened]
     paths:
       - docs/**
-  push:
-    branches:
-      - main
 jobs:
   mintlify-preview-instructions:
     name: Mintlify Preview Instructions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@v7
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   go-lint:
     name: Go
-    runs-on: namespace-profile-linux-8vcpu-16gb-cached
+    runs-on: namespace-profile-linux-4vcpu-8gb-cached
     env:
       GO_VERSION: 1.21.0
     steps:

--- a/.github/workflows/starter-template-sync.yaml
+++ b/.github/workflows/starter-template-sync.yaml
@@ -15,8 +15,8 @@ jobs:
       starter-game-template: ${{ steps.changes.outputs.starter-game-template }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+        uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: changes
         with:
           filters: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Run Unit Test
         run: make unit-test-all
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@v4
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,7 +40,7 @@ jobs:
           docker compose logs
   unit-test-coverage:
     name: Unit & Coverage
-    runs-on: namespace-profile-linux-8vcpu-16gb-cached
+    runs-on: namespace-profile-linux-4vcpu-8gb-cached
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes: WORLD-XXX


## Overview

- bump ci action version
- optimize namespace runner usage (minimize ci queue)
- fix docs preview instruction failed on main branch 


## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
