### PR TITLE
docs: remove explicit language about main.go in World docs

### DIFF
--- a/docs/cardinal/game/world/overview.mdx
+++ b/docs/cardinal/game/world/overview.mdx
@@ -3,11 +3,11 @@ title: 'Overview'
 description: 'How to create and manage your Cardinal world'
 ---
 
-In Cardinal, the `main.go` file is used as the entry point for your game shard implementation. This is where you will initialize your world and register your component, message, query, and system to it.
+In Cardinal, the `World` serves as the central hub for registering components, messages, queries, and systems. This is where you define and configure the elements that drive your game's functionality, as well as kick off the game's loop-driven runtime.
 
 ## Example
 
-A typical `main.go` file will look like this:
+Typical `World` usage looks like this:
 
 ```go main.go
 package main
@@ -59,7 +59,7 @@ func main() {
 		system.PlayerSpawnerSystem,
 	))
 
-	// Start the game shard
+	// Start the game shard runtime. This method blocks the thread of execution.
 	Must(w.StartGame())
 }
 

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -93,7 +93,7 @@
       "pages": [
         "cardinal/game/project-structure",
         {
-          "group": "World (main.go)",
+          "group": "World",
           "pages": [
             "cardinal/game/world/overview",
             "cardinal/game/world/api-reference"


### PR DESCRIPTION
## Overview

removes the explicitness around `main.go` in the `World/Overview` section of the docs. This is now only suggested by the example code, instead of implying requirement. 

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
