### PR TITLE
feat: enable go-fiber tcp4 & tcp6 server, increase Redis conn dial timeout (Railway-related enhancement )

### DIFF
--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -39,7 +39,10 @@ func New(
 	wCtx engine.Context, messages []types.Message, queries []engine.Query, wsEventHandler func(conn *websocket.Conn),
 	opts ...Option,
 ) (*Server, error) {
-	app := fiber.New()
+	app := fiber.New(fiber.Config{
+		// Enable server listening on both ipv4 & ipv6 (default: ipv4 only)
+		Network: "tcp",
+	})
 	s := &Server{
 		app: app,
 		config: config{

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -42,6 +42,7 @@ import (
 
 const (
 	DefaultHistoricalTicksToStore = 10
+	RedisDialTimeOut              = 15
 )
 
 type World struct {
@@ -98,7 +99,6 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 	if err := cfg.Validate(); err != nil {
 		return nil, eris.Wrapf(err, "invalid configuration")
 	}
-
 	if err := setLogLevel(cfg.CardinalLogLevel); err != nil {
 		return nil, eris.Wrap(err, "")
 	}
@@ -108,10 +108,10 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 		serverOptions = append(serverOptions, server.WithPrettyPrint())
 	}
 	redisMetaStore := redis.NewRedisStorage(redis.Options{
-		Addr:     cfg.RedisAddress,
-		Password: cfg.RedisPassword,
-		DB:       0, // use default DB
-		DialTimeout: 15 * time.Second, // Increase startup dial timeout 
+		Addr:        cfg.RedisAddress,
+		Password:    cfg.RedisPassword,
+		DB:          0,                              // use default DB
+		DialTimeout: RedisDialTimeOut * time.Second, // Increase startup dial timeout
 	}, cfg.CardinalNamespace)
 
 	redisStore := gamestate.NewRedisPrimitiveStorage(redisMetaStore.Client)

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -111,6 +111,7 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 		Addr:     cfg.RedisAddress,
 		Password: cfg.RedisPassword,
 		DB:       0, // use default DB
+		DialTimeout: 15 * time.Second, // Increase startup dial timeout 
 	}, cfg.CardinalNamespace)
 
 	redisStore := gamestate.NewRedisPrimitiveStorage(redisMetaStore.Client)


### PR DESCRIPTION
Closes: WORLD-896

## Overview

- Minor enhancement for Railway-related deployment usecase

## Brief Changelog

- GoFiber by default only listen to tcp4 (ipv4), change that to listen on both tcp4 & tcp6 (Railway private networking only support ipv6) https://docs.railway.app/guides/private-networking#listen-on-ipv6
- Increase Redis conn dial timeout at startup to 15 seconds, there was a flaky startup connection encountered when deploying on Railway -- most likely caused by network initialization delay

## Testing and Verifying

- This change is a trivial rework/code cleanup without any test coverage.
