### PR TITLE
feat(cardinal): add endpoint that provides detail of components, messages, queries

### DIFF
--- a/cardinal/message/message.go
+++ b/cardinal/message/message.go
@@ -223,6 +223,11 @@ func (t *MessageType[In, Out]) DecodeEVMBytes(bz []byte) (any, error) {
 	return input, nil
 }
 
+// GetInFieldInformation returns a map of the fields of the message's "In" type and it's field types.
+func (t *MessageType[In, Out]) GetInFieldInformation() map[string]any {
+	return types.GetFieldInformation(reflect.TypeOf(new(In)).Elem())
+}
+
 // -------------------------- Options --------------------------
 
 type MessageOption[In, Out any] func(mt *MessageType[In, Out]) //nolint:revive // this is fine for now

--- a/cardinal/query.go
+++ b/cardinal/query.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"pkg.world.dev/world-engine/cardinal/abi"
 	"pkg.world.dev/world-engine/cardinal/message"
+	"pkg.world.dev/world-engine/cardinal/types"
 	"pkg.world.dev/world-engine/cardinal/types/engine"
 	"reflect"
 
@@ -198,6 +199,11 @@ func (r *QueryType[Request, Reply]) EncodeAsABI(input any) ([]byte, error) {
 		return nil, eris.Wrap(err, "")
 	}
 	return bz, nil
+}
+
+// GetRequestFieldInformation returns the field information for the request struct.
+func (r *QueryType[Request, Reply]) GetRequestFieldInformation() map[string]any {
+	return types.GetFieldInformation(reflect.TypeOf(new(Request)).Elem())
 }
 
 func validateQuery[Request any, Reply any](

--- a/cardinal/router/router_test.go
+++ b/cardinal/router/router_test.go
@@ -64,6 +64,10 @@ func (f *mockMsg) IsEVMCompatible() bool {
 	return f.evmCompat
 }
 
+func (f *mockMsg) GetInFieldInformation() map[string]any {
+	return map[string]any{"foo": "bar"}
+}
+
 func TestRouter_SendMessage_NonCompatibleEVMMessage(t *testing.T) {
 	rtr, provider := getTestRouterAndProvider(t)
 	msg := &mockMsg{evmCompat: false}

--- a/cardinal/server/docs/docs.go
+++ b/cardinal/server/docs/docs.go
@@ -49,6 +49,23 @@ const docTemplate = `{
                 }
             }
         },
+        "/debug/world": {
+            "get": {
+                "description": "Get field information of registered components, messages, queries",
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Get field information of registered components, messages, queries",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/handler.GetFieldsResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/query/debug/state": {
             "post": {
                 "description": "Displays the entire game state.",
@@ -466,6 +483,45 @@ const docTemplate = `{
                 }
             }
         },
+		"handler.GetFieldsResponse": {
+		  	"type": "object",
+		  	"properties": {
+				"components": {
+			  	"type": "array",
+			  	"items": {
+					"type": "string"
+			  }
+			},
+			"messages": {
+			  "type": "array",
+			  "items": {
+				"type": "object",
+				"properties": {
+				  "name": {
+					"type": "string"
+				  },
+				  "type": {
+					"type": "string"
+				  }
+				}
+			  }
+			},
+			"queries": {
+			  "type": "array",
+			  "items": {
+				"type": "object",
+				"properties": {
+				  "name": {
+					"type": "string"
+				  },
+				  "type": {
+					"type": "string"
+				  }
+				}
+			  }
+			}
+		  }
+		},
         "handler.PostTransactionResponse": {
             "type": "object",
             "properties": {

--- a/cardinal/server/docs/swagger.json
+++ b/cardinal/server/docs/swagger.json
@@ -46,6 +46,23 @@
         }
       }
     },
+    "/debug/world": {
+      "get": {
+        "description": "Get field information of registered components, messages, queries",
+        "produces": [
+          "application/json"
+        ],
+        "summary": "Get field information of registered components, messages, queries",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "schema": {
+              "$ref": "#/definitions/handler.GetFieldsResponse"
+            }
+          }
+        }
+      }
+    },
     "/query/debug/state": {
       "post": {
         "description": "Displays the entire game state.",
@@ -460,6 +477,45 @@
         },
         "isServerRunning": {
           "type": "boolean"
+        }
+      }
+    },
+    "handler.GetFieldsResponse": {
+      "type": "object",
+      "properties": {
+        "components": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "messages": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            }
+          }
+        },
+        "queries": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "type": {
+                "type": "string"
+              }
+            }
+          }
         }
       }
     },

--- a/cardinal/server/docs/swagger.yaml
+++ b/cardinal/server/docs/swagger.yaml
@@ -87,6 +87,31 @@ definitions:
       isServerRunning:
         type: boolean
     type: object
+  handler.GetFieldsResponse:
+    properties:
+      components:
+        type: array
+        items:
+          type: string
+      messages:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            type:
+              type: string
+      queries:
+        type: array
+        items:
+          type: object
+          properties:
+            name:
+              type: string
+            type:
+              type: string
+    type: object
   handler.PostTransactionResponse:
     properties:
       tick:
@@ -139,6 +164,17 @@ paths:
           schema:
             $ref: '#/definitions/handler.GetHealthResponse'
       summary: Get information on status of world-engine
+  /debug/world:
+    get:
+      description: Get field information of registered components, messages, queries
+      produces:
+        - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/handler.GetFieldsResponse'
+      summary: Get field information of registered components, messages, queries
   /query/debug/state:
     post:
       description: Displays the entire game state.

--- a/cardinal/server/handler/debug.go
+++ b/cardinal/server/handler/debug.go
@@ -1,0 +1,64 @@
+package handler
+
+import (
+	"github.com/gofiber/fiber/v2"
+	"pkg.world.dev/world-engine/cardinal/types"
+	"pkg.world.dev/world-engine/cardinal/types/engine"
+)
+
+type GetDebugWorldResponse struct {
+	Components []string      `json:"components"` // list of component names
+	Messages   []FieldDetail `json:"messages"`
+	Queries    []FieldDetail `json:"queries"`
+}
+
+type FieldDetail struct {
+	Name   string         `json:"name"`   // name of the message or query
+	Fields map[string]any `json:"fields"` // variable name and type
+}
+
+// GetDebugWorld godoc
+//
+//	@Summary		Get field information of registered components, messages, queries
+//	@Description	Get field information of registered components, messages, queries
+//	@Accept			application/json
+//	@Produce		application/json
+//	@Success		200	{object}	GetFieldsResponse	"Field information of registered components, messages, queries"
+//	@Failure		400	{string}	string				""
+//	@Router			/debug/world [get]
+func GetDebugWorld(components []types.ComponentMetadata, messages []types.Message,
+	queries []engine.Query) func(*fiber.Ctx) error {
+	// Collecting name of all registered components
+	comps := make([]string, 0, len(components))
+	for _, component := range components {
+		comps = append(comps, component.Name())
+	}
+
+	// Collecting the structure of all messages
+	messagesFields := make([]FieldDetail, 0, len(messages))
+	for _, message := range messages {
+		// Extracting the fields of the message
+		messagesFields = append(messagesFields, FieldDetail{
+			Name:   message.Name(),
+			Fields: message.GetInFieldInformation(),
+		})
+	}
+
+	// Collecting the structure of all queries
+	queriesFields := make([]FieldDetail, 0, len(queries))
+	for _, query := range queries {
+		// Extracting the fields of the query
+		queriesFields = append(queriesFields, FieldDetail{
+			Name:   query.Name(),
+			Fields: query.GetRequestFieldInformation(),
+		})
+	}
+
+	return func(ctx *fiber.Ctx) error {
+		return ctx.JSON(GetDebugWorldResponse{
+			Components: comps,
+			Messages:   messagesFields,
+			Queries:    queriesFields,
+		})
+	}
+}

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -36,7 +36,8 @@ type Server struct {
 
 // New returns an HTTP server with handlers for all QueryTypes and MessageTypes.
 func New(
-	wCtx engine.Context, messages []types.Message, queries []engine.Query, wsEventHandler func(conn *websocket.Conn),
+	wCtx engine.Context, components []types.ComponentMetadata, messages []types.Message,
+	queries []engine.Query, wsEventHandler func(conn *websocket.Conn),
 	opts ...Option,
 ) (*Server, error) {
 	app := fiber.New(fiber.Config{
@@ -57,7 +58,7 @@ func New(
 
 	// Enable CORS
 	app.Use(cors.New())
-	setupRoutes(app, wCtx, messages, queries, wsEventHandler, s.config)
+	setupRoutes(app, wCtx, messages, queries, wsEventHandler, s.config, components)
 
 	return s, nil
 }
@@ -99,7 +100,7 @@ func (s *Server) Shutdown() error {
 func setupRoutes(
 	app *fiber.App, wCtx engine.Context, messages []types.Message, queries []engine.Query,
 	wsEventHandler func(conn *websocket.Conn),
-	cfg config,
+	cfg config, components []types.ComponentMetadata,
 ) {
 	// TODO(scott): we should refactor this such that we only dependency inject these maps
 	//  instead of having to dependency inject the entire engine.
@@ -137,6 +138,9 @@ func setupRoutes(
 	// Route: /events/
 	app.Use("/events", handler.WebSocketUpgrader)
 	app.Get("/events", handler.WebSocketEvents(wsEventHandler))
+
+	// Route: /debug/world
+	app.Get("/debug/world", handler.GetDebugWorld(components, messages, queries))
 
 	// Route: /...
 	app.Get("/health", handler.GetHealth())

--- a/cardinal/types/engine/query.go
+++ b/cardinal/types/engine/query.go
@@ -20,4 +20,6 @@ type Query interface {
 	EncodeAsABI(any) ([]byte, error)
 	// IsEVMCompatible reports if the query is able to be sent from the EVM.
 	IsEVMCompatible() bool
+	// GetRequestFieldInformation returns a map of the fields of the query's request type and their types.
+	GetRequestFieldInformation() map[string]any
 }

--- a/cardinal/types/message.go
+++ b/cardinal/types/message.go
@@ -15,6 +15,9 @@ type Message interface {
 	ABIEncode(any) ([]byte, error)
 	// IsEVMCompatible reports if this message can be sent from the EVM.
 	IsEVMCompatible() bool
+
+	// GetInFieldInformation returns a map of the fields of the message's "In" type and it's field types.
+	GetInFieldInformation() map[string]any
 }
 
 // MessageID represents a message's id.

--- a/cardinal/types/util.go
+++ b/cardinal/types/util.go
@@ -1,0 +1,24 @@
+package types
+
+import "reflect"
+
+// GetFieldInformation returns a map of the fields of a struct and their types.
+func GetFieldInformation(t reflect.Type) map[string]any {
+	if t.Kind() != reflect.Struct {
+		return nil
+	}
+
+	fieldMap := make(map[string]any)
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		if field.Type.Kind() == reflect.Struct {
+			fieldMap[field.Name] = GetFieldInformation(field.Type)
+		} else {
+			fieldMap[field.Name] = field.Type.Name()
+		}
+	}
+
+	return fieldMap
+}

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -369,7 +369,7 @@ func (w *World) StartGame() error {
 	// Create server
 	// We can't do this is in NewWorld() because the server needs to know the registered messages
 	// and register queries first. We can probably refactor this though.
-	w.server, err = server.New(NewReadOnlyWorldContext(w), w.ListMessages(), w.ListQueries(),
+	w.server, err = server.New(NewReadOnlyWorldContext(w), w.GetRegisteredComponents(), w.ListMessages(), w.ListQueries(),
 		w.eventHub.NewWebSocketEventHandler(),
 		w.serverOptions...)
 	if err != nil {


### PR DESCRIPTION
Closes: WORLD-876

## Overview

Add GET endpoint `/debug/world` that provides detail of components, messages, queries

## Brief Changelog

- added 1 enpointd GET `/debug/world`
- added func to get field detail using reflect

## Testing and Verifying

- added unit test
- test run using sgt and got this response

```
{
    "components": [
        "SignerComponent",
        "Player",
        "Health"
    ],
    "messages": [
        {
            "name": "attack-player",
            "fields": {
                "TargetNickname": "string"
            }
        },
        {
            "name": "create-persona",
            "fields": {
                "PersonaTag": "string",
                "SignerAddress": "string"
            }
        },
        {
            "name": "authorize-persona-address",
            "fields": {
                "Address": "string"
            }
        },
        {
            "name": "create-player",
            "fields": {
                "Nickname": "string"
            }
        }
    ],
    "queries": [
        {
            "name": "signer",
            "fields": {
                "PersonaTag": "string",
                "Tick": "uint64"
            }
        },
        {
            "name": "state",
            "fields": {}
        },
        {
            "name": "cql",
            "fields": {
                "CQL": "string"
            }
        },
        {
            "name": "list",
            "fields": {
                "StartTick": "uint64"
            }
        },
        {
            "name": "player-health",
            "fields": {
                "Nickname": "string"
            }
        }
    ]
}
```
