### PR TITLE
perf(cardinal): faster search.

### DIFF
--- a/cardinal/component/component_test.go
+++ b/cardinal/component/component_test.go
@@ -1,11 +1,12 @@
 package component_test
 
 import (
+	"testing"
+
 	"github.com/alicebob/miniredis/v2"
 	"pkg.world.dev/world-engine/cardinal/filter"
 	"pkg.world.dev/world-engine/cardinal/iterators"
 	"pkg.world.dev/world-engine/cardinal/types"
-	"testing"
 
 	"pkg.world.dev/world-engine/cardinal/testutils"
 
@@ -201,8 +202,10 @@ func TestComponents(t *testing.T) {
 
 	for _, tt := range tests {
 		componentsForArchID := storeManager.GetComponentTypesForArchID(tt.archID)
+		matchComponent := filter.CreateComponentMatcher(
+			types.ConvertComponentMetadatasToComponents(componentsForArchID))
 		for _, comp := range tt.comps {
-			ok := filter.MatchComponent(types.ConvertComponentMetadatasToComponents(componentsForArchID), comp)
+			ok := matchComponent(comp)
 			if !ok {
 				t.Errorf("the archetype EntityID %d should contain the component %d", tt.archID, comp.ID())
 			}

--- a/cardinal/filter/contains.go
+++ b/cardinal/filter/contains.go
@@ -14,8 +14,10 @@ func Contains(components ...types.Component) ComponentFilter {
 }
 
 func (f *contains) MatchesComponents(components []types.Component) bool {
+
+	matchComponent := CreateComponentMatcher(components)
 	for _, componentType := range f.components {
-		if !MatchComponent(components, componentType) {
+		if !matchComponent(componentType) {
 			return false
 		}
 	}

--- a/cardinal/filter/contains.go
+++ b/cardinal/filter/contains.go
@@ -14,7 +14,6 @@ func Contains(components ...types.Component) ComponentFilter {
 }
 
 func (f *contains) MatchesComponents(components []types.Component) bool {
-
 	matchComponent := CreateComponentMatcher(components)
 	for _, componentType := range f.components {
 		if !matchComponent(componentType) {

--- a/cardinal/filter/exact.go
+++ b/cardinal/filter/exact.go
@@ -19,8 +19,9 @@ func (f exact) MatchesComponents(components []types.Component) bool {
 	if len(components) != len(f.components) {
 		return false
 	}
+	matchComponent := CreateComponentMatcher(f.components)
 	for _, componentType := range components {
-		if !MatchComponent(f.components, componentType) {
+		if !matchComponent(componentType) {
 			return false
 		}
 	}

--- a/cardinal/filter/helper.go
+++ b/cardinal/filter/helper.go
@@ -18,16 +18,16 @@ func MatchComponentMetadata(
 	return false
 }
 
-// MatchComponent returns true if the given slice of components contains the given component.
-// Components are the same if they have the same Name.
-func MatchComponent(
-	components []types.Component,
-	cType types.Component,
-) bool {
-	for _, c := range components {
-		if cType.Name() == c.Name() {
-			return true
-		}
+// CreateComponentMatcher creates a function given a slice of components. This function will
+// take a parameter that is a single component and return true if it is in the slice of components
+// or false otherwise
+func CreateComponentMatcher(components []types.Component) func(types.Component) bool {
+	mapStringToComponent := make(map[string]types.Component, len(components))
+	for _, component := range components {
+		mapStringToComponent[component.Name()] = component
 	}
-	return false
+	return func(cType types.Component) bool {
+		_, ok := mapStringToComponent[cType.Name()]
+		return ok
+	}
 }

--- a/cardinal/state_test.go
+++ b/cardinal/state_test.go
@@ -106,7 +106,8 @@ func TestArchetypeIDIsConsistentAfterSaveAndLoad(t *testing.T) {
 	assert.NilError(t, err)
 	wantComps := world1.GameStateManager().GetComponentTypesForArchID(wantID)
 	assert.Equal(t, 1, len(wantComps))
-	assert.Check(t, filter.MatchComponent(types.ConvertComponentMetadatasToComponents(wantComps), oneNum))
+	matchComponent := filter.CreateComponentMatcher(types.ConvertComponentMetadatasToComponents(wantComps))
+	assert.Check(t, matchComponent(oneNum))
 
 	assert.NilError(t, world1.Tick(context.Background(), uint64(time.Now().Unix())))
 
@@ -121,7 +122,8 @@ func TestArchetypeIDIsConsistentAfterSaveAndLoad(t *testing.T) {
 	assert.NilError(t, err)
 	gotComps := world2.GameStateManager().GetComponentTypesForArchID(gotID)
 	assert.Equal(t, 1, len(gotComps))
-	assert.Check(t, filter.MatchComponent(types.ConvertComponentMetadatasToComponents(gotComps), twoNum))
+	matchComponent = filter.CreateComponentMatcher(types.ConvertComponentMetadatasToComponents(gotComps))
+	assert.Check(t, matchComponent(twoNum))
 
 	// Archetype indices should be the same across save/load cycles
 	assert.Equal(t, wantID, gotID)


### PR DESCRIPTION
Closes: WORLD-878

Search is bounded by this:
    # archetypes: A
    # components per archetype C
    # number of components in a filter query F
    O(ACF)
    if A == C == F == N then the upper bound is O(N^3)
    
This change mitigates the runtime to O(N^2) by saving it to a map. For small N this change is actually slower slightly. For large N this change is significantly faster. A future PR can have the system detect the length of the query and the length of the amount of components and dynamically decide on linear search or map. 

Overall though this is just a slight change as cacheing takes over after the first time Each is called on a search. This just decreases start up time and new searches that aren't cached. For a large amount of archetypes, components and large queries the slow down can hiccup and block the main loop. 

There is an alternative implementation here where on EXACT and CONTAINS, components can be stored on a map instead of an array. The problem with this is it moves a cost of O(N) to query instantiation as the map has to be built every time you call Exact or Contains. While doing this is more "elegant" this change will be unexpected to the user as they expect costly operations to happen on Each, not on constructing the query. 


