### PR TITLE
fix(e2edb): add redis-tools to test_nakama container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: "3"
 services:
   cockroachdb:
     # Only use cockroachdb single-node clusters for non-production environment
@@ -18,7 +18,7 @@ services:
       - "26257:26257"
       - "8080:8080"
     healthcheck:
-      test: [ "CMD", "curl", "-f", "http://localhost:8080/health?ready=1" ]
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health?ready=1"]
       interval: 3s
       timeout: 3s
       retries: 5
@@ -51,7 +51,7 @@ services:
       - "7350"
       - "7351"
     healthcheck:
-      test: [ "CMD", "/nakama/nakama", "healthcheck" ]
+      test: ["CMD", "/nakama/nakama", "healthcheck"]
       interval: 20s
       timeout: 10s
       retries: 5
@@ -153,6 +153,7 @@ services:
         condition: service_healthy
     environment:
       - NAKAMA_ADDRESS=http://nakama:7350
+      - REDIS_PASSWORD=${REDIS_PASSWORD}
     networks:
       - world-engine
 

--- a/e2e/testclients/e2etestclient/Dockerfile
+++ b/e2e/testclients/e2etestclient/Dockerfile
@@ -1,5 +1,11 @@
 FROM golang:1.21
 
+RUN set -eux; \
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+    redis-tools; \
+    rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 
 COPY . .

--- a/e2e/testclients/e2etestclient/testsuite_test.go
+++ b/e2e/testclients/e2etestclient/testsuite_test.go
@@ -19,7 +19,8 @@ import (
 
 func flushRedis(t *testing.T) {
 	t.Cleanup(func() {
-		cmd := exec.Command("docker", "exec", "redis", "redis-cli", "FLUSHALL")
+		redisPassword := os.Getenv(REDIS_PASSWORD)
+		cmd := exec.Command("redis-cli", "-h", "redis","-p","6379","-a",redisPassword, "FLUSHALL")
 		if err := cmd.Run(); err != nil {
 			t.Fatalf("Failed to flush Redis: %v", err)
 		}

--- a/e2e/testclients/e2etestclient/testsuite_test.go
+++ b/e2e/testclients/e2etestclient/testsuite_test.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os/exec"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -19,7 +20,7 @@ import (
 
 func flushRedis(t *testing.T) {
 	t.Cleanup(func() {
-		redisPassword := os.Getenv(REDIS_PASSWORD)
+		redisPassword := os.Getenv("REDIS_PASSWORD")
 		cmd := exec.Command("redis-cli", "-h", "redis","-p","6379","-a",redisPassword, "FLUSHALL")
 		if err := cmd.Run(); err != nil {
 			t.Fatalf("Failed to flush Redis: %v", err)


### PR DESCRIPTION
Closes: WORLD-780

## Overview

- Part of this PR https://github.com/Argus-Labs/world-engine/pull/650, adding redis-cli tools to E2E test container

## Brief Changelog

- install redis-tools to container
- adjust redis flush command

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
