### PR TITLE
ci: fix relay/nakama code coverage 

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -43,6 +43,7 @@ ignore:
   - "**/*.abigen.go"
   - "**/*.rlpgen.go"
   - "**/*.mock.go"
+  - "**/mock_*.go"
   - "**/proto"
   - "build/"
   - "cmd/"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -45,6 +45,5 @@ ignore:
   - "**/*.mock.go"
   - "**/proto"
   - "build/"
-  - "relay/"
   - "cmd/"
   - "evm/precompile"

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -22,7 +22,7 @@ coverage:
   status:
     project:
       default:
-        threshold: 2%
+        threshold: 5%
         # target: 50%
         # flags:
         #   - unit


### PR DESCRIPTION
Closes: WORLD-926


## Overview

- As mentioned by @pyrofolium , there has been a significant drop in code coverage after upgrading the Go version to 1.22, particularly affecting the `relay/nakama` package.
- It appears that the change in code coverage is not directly related to the Go upgrade. However, I've noticed that the code detected by coverage tools in the `relay/nakama` package has drastically changed. It's unclear whether this is a bug or if there is some cached data causing the issue.
- One of the major jumps in coverage comes from the generated mocks package, which should have been filtered out

Before:
<img width="1163" alt="image" src="https://github.com/Argus-Labs/world-engine/assets/29672212/bed58e89-6d68-42dd-b600-d55568ce99c2">


After:
<img width="1163" alt="image" src="https://github.com/Argus-Labs/world-engine/assets/29672212/6bdbdbcf-58ab-4111-87d2-da2252feb888">


^^ There's 9000 new tracked lines from generated mocks packages alone

## Brief Changelog

- Filter out generated mocks files

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
