### PR TITLE
fix(cardinal): Ensure a closed tickStart channel does not cause unbounded ticking, a…

### DIFF
--- a/cardinal/testutils/world.go
+++ b/cardinal/testutils/world.go
@@ -7,13 +7,15 @@ import (
 	"fmt"
 	"net"
 	"net/http"
-	"pkg.world.dev/world-engine/cardinal/persona/msg"
-	"pkg.world.dev/world-engine/cardinal/types"
-	"pkg.world.dev/world-engine/sign"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"pkg.world.dev/world-engine/sign"
+
+	"pkg.world.dev/world-engine/cardinal/persona/msg"
+	"pkg.world.dev/world-engine/cardinal/types"
 
 	"gotest.tools/v3/assert"
 
@@ -80,12 +82,15 @@ func NewTestFixture(t testing.TB, miniRedis *miniredis.Miniredis, opts ...cardin
 		startOnce:   &sync.Once{},
 		// Only register this method with t.Cleanup if the game server is actually started
 		doCleanup: func() {
-			close(startTickCh)
+			// First, make sure completed ticks will never be blocked
 			go func() {
 				for range doneTickCh { //nolint:revive // This pattern drains the channel until closed
 				}
 			}()
+			// Next, shut down the world
 			assert.NilError(t, world.Shutdown())
+			// The world is shut down; No more ticks will be started
+			close(startTickCh)
 		},
 	}
 

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -403,7 +403,10 @@ func (w *World) startGameLoop(ctx context.Context, tickStart <-chan time.Time, t
 	loop:
 		for {
 			select {
-			case <-tickStart:
+			case _, ok := <-tickStart:
+				if !ok {
+					panic("tickStart channel has been closed; tick rate is now unbounded.")
+				}
 				w.tickTheEngine(ctx, tickDone)
 				closeAllChannels(waitingChs)
 				waitingChs = waitingChs[:0]


### PR DESCRIPTION


## Overview

Fix flaky tests related to shutting down.

The shutdown sequence ins testutils was not correct. Closing the tickStart channel first caused the tick rate to become unbounded. Sometimes a new tick would be started, regardless of whether the test was expecting a new tick to start.

I've added a panic to the tick code that triggers if the start-tick channel is ever closed. A closed start-tick channel means the tick rate will be unbounded.

## Brief Changelog

- Panic when the tick rate becomes unbounded
- Reorder the testutils' TestFixture to make sure the tick rate stays bounded until the world has been shut down.
- Update a test to use tf.DoTick, and make sure the related system does not block forever.

## Testing and Verifying


Running this multiple times (10ish?) from the main branch should eventually time out.
`go test . --run=TestAddToPoolDuringTickDoesNotTimeout --count=100 --timeout=10s -v`

Checking out this branch and running the above command 10ish times should never time out.

