### PR TITLE
fix(e2e): clean all containers at the end of e2e test rounds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     # Only use cockroachdb single-node clusters for non-production environment
     image: cockroachdb/cockroach:latest-v23.1
     command: start-single-node --insecure --store=attrs=ssd,path=/var/lib/cockroach/,size=20%
-    restart: "no"
+    restart:  unless-stopped
     environment:
       - COCKROACH_DATABASE=nakama
       - COCKROACH_USER=root
@@ -141,7 +141,7 @@ services:
       - "6379:6379"
     networks:
       - world-engine
-    restart: always
+    restart: unless-stopped
 
   test_nakama:
     container_name: test_nakama

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 version: '3'
 services:
   cockroachdb:
+    container_name: cockroachdb
     # Only use cockroachdb single-node clusters for non-production environment
     image: cockroachdb/cockroach:latest-v23.1
     command: start-single-node --insecure --store=attrs=ssd,path=/var/lib/cockroach/,size=20%
@@ -131,6 +132,7 @@ services:
       - world-engine
 
   redis:
+    container_name: redis
     image: redis:latest
     command: redis-server --save ""
     environment:

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -12,8 +12,8 @@ e2e-nakama:
 		cd $(ROOT_DIR); \
 	)
 
-	@docker compose up --build game nakama test_nakama --abort-on-container-exit --exit-code-from test_nakama --attach test_nakama
-	@docker compose down -v
+	@docker compose --project-name e2e up --build game nakama test_nakama --abort-on-container-exit --exit-code-from test_nakama --attach test_nakama
+	@docker compose --project-name e2e down -v --remove-orphans --timeout 0
 
 e2e-benchmark:
 	$(foreach dir, $(DIRS_E2E_BENCHMARK), \

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -13,6 +13,7 @@ e2e-nakama:
 	)
 
 	@docker compose up --build game nakama test_nakama --abort-on-container-exit --exit-code-from test_nakama --attach test_nakama
+	@docker compose down -v
 
 e2e-benchmark:
 	$(foreach dir, $(DIRS_E2E_BENCHMARK), \

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -12,7 +12,7 @@ e2e-nakama:
 		cd $(ROOT_DIR); \
 	)
 
-	@docker compose up --build game nakama test_nakama --abort-on-container-exit --exit-code-from test_nakama
+	@docker compose up --build game nakama test_nakama --abort-on-container-exit --exit-code-from test_nakama 2>&1 | grep test_nakama
 	@docker compose down --volumes -v
 
 e2e-benchmark:

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -12,7 +12,7 @@ e2e-nakama:
 		cd $(ROOT_DIR); \
 	)
 
-	@docker compose up --build --abort-on-container-exit --exit-code-from test_nakama --attach test_nakama
+	@docker compose up --build game nakama redis cockroachdb test_nakama --abort-on-container-exit --exit-code-from test_nakama --attach test_nakama
 	@docker compose down --volume -v
 
 e2e-benchmark:

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -12,8 +12,8 @@ e2e-nakama:
 		cd $(ROOT_DIR); \
 	)
 
-	@docker compose up --build game nakama redis cockroachdb test_nakama --abort-on-container-exit --exit-code-from test_nakama --attach test_nakama
-	@docker compose down --volume -v
+	@docker compose up --build game nakama test_nakama --abort-on-container-exit --exit-code-from test_nakama
+	@docker compose down --volumes -v
 
 e2e-benchmark:
 	$(foreach dir, $(DIRS_E2E_BENCHMARK), \

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -12,8 +12,8 @@ e2e-nakama:
 		cd $(ROOT_DIR); \
 	)
 
-	@docker compose --project-name e2e up --build game nakama test_nakama --abort-on-container-exit --exit-code-from test_nakama --attach test_nakama
-	@docker compose --project-name e2e down -v --remove-orphans --timeout 0
+	@docker compose up --build --abort-on-container-exit --exit-code-from test_nakama --attach test_nakama
+	@docker compose down --volume -v
 
 e2e-benchmark:
 	$(foreach dir, $(DIRS_E2E_BENCHMARK), \


### PR DESCRIPTION
Closes: WORLD-928

## Overview

This is a simple change that uses `docker compose down -v` to shutdown all the containers at the end of each nakama e2e test run and delete their volumes. This means each new run will start with clean state but also will not require any image redownloading.
