### PR TITLE
feat(nakama): Add command line flag that allows for the adjustment of the outgoing …

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,13 +41,12 @@ services:
       - CARDINAL_NAMESPACE=TESTGAME
       - ENABLE_ALLOWLIST=${ENABLE_ALLOWLIST:-false}
       - DB_PASSWORD=${DB_PASSWORD:-development}
-      - OUTGOING_QUEUE_SIZE=${OUTGOING_QUEUE_SIZE:-64}
     entrypoint:
       - "/bin/sh"
       - "-ecx"
       - >
         /nakama/nakama migrate up --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama &&
-        exec /nakama/nakama --config /nakama/data/local.yml --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama --socket.outgoing_queue_size=$OUTGOING_QUEUE_SIZE
+        exec /nakama/nakama --config /nakama/data/local.yml --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama --socket.outgoing_queue_size=${OUTGOING_QUEUE_SIZE:-64}
     expose:
       - "7349"
       - "7350"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,12 +41,13 @@ services:
       - CARDINAL_NAMESPACE=TESTGAME
       - ENABLE_ALLOWLIST=${ENABLE_ALLOWLIST:-false}
       - DB_PASSWORD=${DB_PASSWORD:-development}
+      - OUTGOING_QUEUE_SIZE=${OUTGOING_QUEUE_SIZE:-64}
     entrypoint:
       - "/bin/sh"
       - "-ecx"
       - >
         /nakama/nakama migrate up --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama &&
-        exec /nakama/nakama --config /nakama/data/local.yml --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama
+        exec /nakama/nakama --config /nakama/data/local.yml --database.address root:$DB_PASSWORD@cockroachdb:26257/nakama --socket.outgoing_queue_size=$OUTGOING_QUEUE_SIZE
     expose:
       - "7349"
       - "7350"

--- a/starter-game-template/docker-compose.yml
+++ b/starter-game-template/docker-compose.yml
@@ -91,12 +91,13 @@ services:
       - CARDINAL_NAMESPACE=${CARDINAL_NAMESPACE}
       - DB_PASSWORD=${DB_PASSWORD:-very_unsafe_password_replace_me}
       - ENABLE_ALLOWLIST=${ENABLE_ALLOWLIST:-false}
+      - OUTGOING_QUEUE_SIZE=${OUTGOING_QUEUE_SIZE:-64}
     entrypoint:
       - "/bin/sh"
       - "-ecx"
       - >
         /nakama/nakama migrate up --database.address postgres:$$DB_PASSWORD@nakama-db:5432/nakama &&
-        exec /nakama/nakama --config /nakama/data/local.yml --database.address postgres:$$DB_PASSWORD@nakama-db:5432/nakama
+        exec /nakama/nakama --config /nakama/data/local.yml --database.address postgres:$$DB_PASSWORD@nakama-db:5432/nakama --socket.outgoing_queue_size=$OUTGOING_QUEUE_SIZE
     # Replace entrypoint with the following when using cockroachdb instead of postgres.
     #    entrypoint:
     #      - "/bin/sh"

--- a/starter-game-template/docker-compose.yml
+++ b/starter-game-template/docker-compose.yml
@@ -91,13 +91,12 @@ services:
       - CARDINAL_NAMESPACE=${CARDINAL_NAMESPACE}
       - DB_PASSWORD=${DB_PASSWORD:-very_unsafe_password_replace_me}
       - ENABLE_ALLOWLIST=${ENABLE_ALLOWLIST:-false}
-      - OUTGOING_QUEUE_SIZE=${OUTGOING_QUEUE_SIZE:-64}
     entrypoint:
       - "/bin/sh"
       - "-ecx"
       - >
         /nakama/nakama migrate up --database.address postgres:$$DB_PASSWORD@nakama-db:5432/nakama &&
-        exec /nakama/nakama --config /nakama/data/local.yml --database.address postgres:$$DB_PASSWORD@nakama-db:5432/nakama --socket.outgoing_queue_size=$OUTGOING_QUEUE_SIZE
+        exec /nakama/nakama --config /nakama/data/local.yml --database.address postgres:$$DB_PASSWORD@nakama-db:5432/nakama --socket.outgoing_queue_size=${OUTGOING_QUEUE_SIZE:-64}
     # Replace entrypoint with the following when using cockroachdb instead of postgres.
     #    entrypoint:
     #      - "/bin/sh"

--- a/starter-game-template/world.toml
+++ b/starter-game-template/world.toml
@@ -32,3 +32,6 @@ BLOCK_TIME="1s"
 
 [nakama]
 ENABLE_ALLOWLIST="false" # enable nakama's beta key feature. you can generate and claim beta keys by setting this to true
+# The number of undelivered notifications Nakama will allow before shutting down a connectino to a client.
+# See https://heroiclabs.com/docs/nakama/getting-started/configuration/#socket.outgoing_queue_size 
+OUTGOING_QUEUE_SIZE=64


### PR DESCRIPTION
…queue size

Closes: WORLD-922


## Overview

The [outgoing_queue_size](https://heroiclabs.com/docs/nakama/getting-started/configuration/#socket.outgoing_queue_size) config parameter specifies how many pending notifications are allowed for a connected client before Nakama decides the client is unresponsive (shutting down the connection). 

If many receipts/events are generated in a single tick, the burst of traffic could overload this queue even though both the client and Nakama can handle the traffic. 

This PR exposes the Nakama command line parameter so it can be modified via docker-compose/world.toml.

