### PR TITLE
refactor(cardinal): move query business logic to manager

### DIFF
--- a/cardinal/cardinal.go
+++ b/cardinal/cardinal.go
@@ -2,6 +2,7 @@ package cardinal
 
 import (
 	"errors"
+	"pkg.world.dev/world-engine/cardinal/query"
 	"reflect"
 	"strconv"
 
@@ -107,7 +108,7 @@ func RegisterQuery[Request any, Reply any](
 	w *World,
 	name string,
 	handler func(wCtx engine.Context, req *Request) (*Reply, error),
-	opts ...QueryOption[Request, Reply],
+	opts ...query.Option[Request, Reply],
 ) (err error) {
 	if w.worldStage.Current() != worldstage.Init {
 		return eris.Errorf(
@@ -117,19 +118,12 @@ func RegisterQuery[Request any, Reply any](
 		)
 	}
 
-	if _, ok := w.nameToQuery[name]; ok {
-		return eris.Errorf("query with name %s is already registered", name)
-	}
-
-	q, err := NewQueryType[Request, Reply](name, handler, opts...)
+	q, err := query.NewQueryType[Request, Reply](name, handler, opts...)
 	if err != nil {
 		return err
 	}
 
-	w.registeredQueries = append(w.registeredQueries, q)
-	w.nameToQuery[q.Name()] = q
-
-	return nil
+	return w.queryManager.RegisterQuery(name, q)
 }
 
 // Create creates a single entity in the world, and returns the id of the newly created entity.

--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -49,6 +49,10 @@ type Rawbodytx struct {
 	SignerAddress string `json:"signerAddress"`
 }
 
+type Health struct {
+	Value int
+}
+
 func (Health) Name() string { return "health" }
 
 type AddHealthToEntityTx struct {

--- a/cardinal/persona/persona_test.go
+++ b/cardinal/persona/persona_test.go
@@ -56,8 +56,8 @@ func TestCreatePersonaTransactionAutomaticallyCreated(t *testing.T) {
 
 	wantTag := "CoolMage"
 	wantAddress := "123_456"
-	createPersonaMsg, err := cardinal.GetMessageFromWorld[msg.CreatePersona, msg.CreatePersonaResult](world)
-	assert.NilError(t, err)
+	createPersonaMsg, ok := world.GetMessageByName("create-persona")
+	assert.True(t, ok)
 	tf.AddTransaction(
 		createPersonaMsg.ID(), msg.CreatePersona{
 			PersonaTag:    wantTag,
@@ -173,9 +173,8 @@ func TestCanAuthorizeAddress(t *testing.T) {
 	tf.CreatePersona(wantTag, wantSigner)
 
 	wantAddr := "0xd5e099c71b797516c10ed0f0d895f429c2781142"
-	authorizePersonaAddressMsg, err :=
-		cardinal.GetMessageFromWorld[msg.AuthorizePersonaAddress, msg.AuthorizePersonaAddressResult](world)
-	assert.NilError(t, err)
+	authorizePersonaAddressMsg, ok := world.GetMessageByName("authorize-persona-address")
+	assert.True(t, ok)
 	tf.AddTransaction(
 		authorizePersonaAddressMsg.ID(),
 		msg.AuthorizePersonaAddress{

--- a/cardinal/plugin_debug.go
+++ b/cardinal/plugin_debug.go
@@ -3,6 +3,7 @@ package cardinal
 import (
 	"github.com/goccy/go-json"
 	"pkg.world.dev/world-engine/cardinal/filter"
+	"pkg.world.dev/world-engine/cardinal/query"
 	"pkg.world.dev/world-engine/cardinal/types"
 	"pkg.world.dev/world-engine/cardinal/types/engine"
 )
@@ -27,7 +28,7 @@ func (p *debugPlugin) Register(world *World) error {
 func (p *debugPlugin) RegisterQueries(world *World) error {
 	err := RegisterQuery[DebugStateRequest, DebugStateResponse](world, "state",
 		queryDebugState,
-		WithCustomQueryGroup[DebugStateRequest, DebugStateResponse]("debug"))
+		query.WithCustomQueryGroup[DebugStateRequest, DebugStateResponse]("debug"))
 	if err != nil {
 		return err
 	}

--- a/cardinal/plugin_persona.go
+++ b/cardinal/plugin_persona.go
@@ -2,6 +2,7 @@ package cardinal
 
 import (
 	"errors"
+	querylib "pkg.world.dev/world-engine/cardinal/query"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -49,7 +50,7 @@ func (p *personaPlugin) Register(world *World) error {
 func (p *personaPlugin) RegisterQueries(world *World) error {
 	err := RegisterQuery[query.PersonaSignerQueryRequest, query.PersonaSignerQueryResponse](world, "signer",
 		query.PersonaSignerQuery,
-		WithCustomQueryGroup[query.PersonaSignerQueryRequest, query.PersonaSignerQueryResponse]("persona"))
+		querylib.WithCustomQueryGroup[query.PersonaSignerQueryRequest, query.PersonaSignerQueryResponse]("persona"))
 	if err != nil {
 		return err
 	}

--- a/cardinal/plugin_receipt.go
+++ b/cardinal/plugin_receipt.go
@@ -1,6 +1,7 @@
 package cardinal
 
 import (
+	"pkg.world.dev/world-engine/cardinal/query"
 	"pkg.world.dev/world-engine/cardinal/types/engine"
 )
 
@@ -24,7 +25,7 @@ func (p *receiptPlugin) Register(world *World) error {
 func (p *receiptPlugin) RegisterQueries(world *World) error {
 	err := RegisterQuery[ListTxReceiptsRequest, ListTxReceiptsResponse](world, "list",
 		queryReceipts,
-		WithCustomQueryGroup[ListTxReceiptsRequest, ListTxReceiptsResponse]("receipts"))
+		query.WithCustomQueryGroup[ListTxReceiptsRequest, ListTxReceiptsResponse]("receipts"))
 	if err != nil {
 		return err
 	}

--- a/cardinal/plugin_receipt_test.go
+++ b/cardinal/plugin_receipt_test.go
@@ -18,7 +18,8 @@ func TestReceiptsQuery(t *testing.T) {
 	world := tf.World
 	type fooIn struct{}
 	type fooOut struct{ Y int }
-	err := cardinal.RegisterMessage[fooIn, fooOut](world, "foo")
+	msgName := "foo"
+	err := cardinal.RegisterMessage[fooIn, fooOut](world, msgName)
 	assert.NilError(t, err)
 	wantErrorMessage := "THIS_ERROR_MESSAGE_SHOULD_BE_IN_THE_RECEIPT"
 	err = cardinal.RegisterSystems(world, func(ctx cardinal.WorldContext) error {
@@ -30,8 +31,8 @@ func TestReceiptsQuery(t *testing.T) {
 		})
 	})
 	assert.NilError(t, err)
-	fooMsg, err := cardinal.GetMessageFromWorld[fooIn, fooOut](world)
-	assert.NilError(t, err)
+	fooMsg, ok := world.GetMessageByName(msgName)
+	assert.Assert(t, ok)
 	_, txHash1 := world.AddTransaction(fooMsg.ID(), fooIn{}, &sign.Transaction{PersonaTag: "ty"})
 	tf.DoTick()
 	_, txHash2 := world.AddTransaction(fooMsg.ID(), fooIn{}, &sign.Transaction{PersonaTag: "ty"})

--- a/cardinal/query/manager.go
+++ b/cardinal/query/manager.go
@@ -1,0 +1,55 @@
+package query
+
+import (
+	"github.com/rotisserie/eris"
+	"pkg.world.dev/world-engine/cardinal/types/engine"
+)
+
+type Manager struct {
+	registeredQueries map[string]engine.Query
+}
+
+func NewManager() *Manager {
+	return &Manager{
+		registeredQueries: make(map[string]engine.Query),
+	}
+}
+
+// RegisterQuery registers a query with the query manager.
+// There can only be one query with a given name.
+func (m *Manager) RegisterQuery(name string, query engine.Query) error {
+	// Check that the query is not already registered
+	if err := m.isQueryNameUnique(name); err != nil {
+		return err
+	}
+
+	// Register the query
+	m.registeredQueries[name] = query
+
+	return nil
+}
+
+// GetRegisteredQueries returns all the registered queries.
+func (m *Manager) GetRegisteredQueries() []engine.Query {
+	registeredQueries := make([]engine.Query, 0, len(m.registeredQueries))
+	for _, query := range m.registeredQueries {
+		registeredQueries = append(registeredQueries, query)
+	}
+	return registeredQueries
+}
+
+// GetQueryByName returns a query corresponding to its name.
+func (m *Manager) GetQueryByName(name string) (engine.Query, error) {
+	query, ok := m.registeredQueries[name]
+	if !ok {
+		return nil, eris.Errorf("query %q is not registered", name)
+	}
+	return query, nil
+}
+
+func (m *Manager) isQueryNameUnique(name string) error {
+	if _, ok := m.registeredQueries[name]; ok {
+		return eris.Errorf("query %q is already registered", name)
+	}
+	return nil
+}

--- a/cardinal/query/query_test.go
+++ b/cardinal/query/query_test.go
@@ -1,7 +1,8 @@
-package cardinal_test
+package query_test
 
 import (
 	"errors"
+	"pkg.world.dev/world-engine/cardinal/query"
 	"testing"
 
 	"pkg.world.dev/world-engine/cardinal"
@@ -16,6 +17,10 @@ import (
 
 type Health struct {
 	Value int
+}
+
+func (h Health) Name() string {
+	return "health"
 }
 
 type QueryHealthRequest struct {
@@ -68,7 +73,7 @@ func TestNewQueryTypeWithEVMSupport(t *testing.T) {
 		) (*FooReply, error) {
 			return &FooReply{}, errors.New("this function should never get called")
 		},
-		cardinal.WithQueryEVMSupport[FooReq, FooReply](),
+		query.WithQueryEVMSupport[FooReq, FooReply](),
 	)
 }
 
@@ -150,7 +155,7 @@ func TestQueryEVM(t *testing.T) {
 		) (*FooReply, error) {
 			return &expectedReply, nil
 		},
-		cardinal.WithQueryEVMSupport[FooRequest, FooReply](),
+		query.WithQueryEVMSupport[FooRequest, FooReply](),
 	)
 
 	assert.NilError(t, err)

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -41,6 +41,8 @@ type MoveMessageOutput struct {
 	Location LocationComponent
 }
 
+var moveMsgName = "move"
+
 type QueryLocationRequest struct {
 	Persona string
 }
@@ -82,12 +84,12 @@ func (s *ServerTestSuite) TestCanClaimPersonaSendGameTxAndQueryGame() {
 	s.setupWorld()
 	s.fixture.DoTick()
 	personaTag := s.CreateRandomPersona()
-	moveMessage, err := cardinal.GetMessageFromWorld[MoveMsgInput, MoveMessageOutput](s.world)
-	s.Require().NoError(err)
+	moveMessage, ok := s.world.GetMessageByName(moveMsgName)
+	s.Require().True(ok)
 	s.runTx(personaTag, moveMessage, MoveMsgInput{Direction: "up"})
 	res := s.fixture.Post("query/game/location", QueryLocationRequest{Persona: personaTag})
 	var loc LocationComponent
-	err = json.Unmarshal([]byte(s.readBody(res.Body)), &loc)
+	err := json.Unmarshal([]byte(s.readBody(res.Body)), &loc)
 	s.Require().NoError(err)
 	s.Require().Equal(loc, LocationComponent{0, 1})
 }
@@ -200,8 +202,8 @@ func (s *ServerTestSuite) TestCanSendTxWithoutSigVerification() {
 		PersonaTag: persona,
 		Body:       msgBz,
 	}
-	moveMessage, err := cardinal.GetMessageFromWorld[MoveMsgInput, MoveMessageOutput](s.world)
-	s.Require().NoError(err)
+	moveMessage, ok := s.world.GetMessageByName(moveMsgName)
+	s.Require().True(ok)
 	url := "/tx/game/" + moveMessage.Name()
 	res := s.fixture.Post(url, tx)
 	s.Require().Equal(fiber.StatusOK, res.StatusCode, s.readBody(res.Body))
@@ -245,8 +247,8 @@ func (s *ServerTestSuite) TestMissingSignerAddressIsOKWhenSigVerificationIsDisab
 	s.setupWorld(cardinal.WithDisableSignatureVerification())
 	s.fixture.DoTick()
 	unclaimedPersona := "some-persona"
-	moveMessage, err := cardinal.GetMessageFromWorld[MoveMsgInput, MoveMessageOutput](s.world)
-	assert.NilError(t, err)
+	moveMessage, ok := s.world.GetMessageByName(moveMsgName)
+	assert.True(t, ok)
 	// This persona tag does not have a signer address, but since signature verification is disabled it should
 	// encounter no errors
 	s.runTx(unclaimedPersona, moveMessage, MoveMsgInput{Direction: "up"})
@@ -258,8 +260,8 @@ func (s *ServerTestSuite) TestSignerAddressIsRequiredWhenSigVerificationIsDisabl
 	s.setupWorld()
 	s.fixture.DoTick()
 	unclaimedPersona := "some-persona"
-	moveMessage, err := cardinal.GetMessageFromWorld[MoveMsgInput, MoveMessageOutput](s.world)
-	assert.NilError(t, err)
+	moveMessage, ok := s.world.GetMessageByName(moveMsgName)
+	assert.True(t, ok)
 	payload := MoveMsgInput{Direction: "up"}
 	tx, err := sign.NewTransaction(s.privateKey, unclaimedPersona, s.world.Namespace().String(), s.nonce, payload)
 	assert.NilError(t, err)
@@ -302,7 +304,7 @@ func (s *ServerTestSuite) setupWorld(opts ...cardinal.WorldOption) {
 	s.world = s.fixture.World
 	err := cardinal.RegisterComponent[LocationComponent](s.world)
 	s.Require().NoError(err)
-	err = cardinal.RegisterMessage[MoveMsgInput, MoveMessageOutput](s.world, "move")
+	err = cardinal.RegisterMessage[MoveMsgInput, MoveMessageOutput](s.world, moveMsgName)
 	s.Require().NoError(err)
 	personaToPosition := make(map[string]types.EntityID)
 	err = cardinal.RegisterSystems(s.world, func(context engine.Context) error {

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/rand"
 	"net/http"
+	"pkg.world.dev/world-engine/cardinal/query"
 	"slices"
 	"strings"
 	"testing"
@@ -230,7 +231,7 @@ func (s *ServerTestSuite) TestQueryCustomGroup() {
 			called = true
 			return &SomeResponse{}, nil
 		},
-		cardinal.WithCustomQueryGroup[SomeRequest, SomeResponse](group),
+		query.WithCustomQueryGroup[SomeRequest, SomeResponse](group),
 	)
 	s.Require().NoError(err)
 	s.fixture.DoTick()

--- a/cardinal/state_test.go
+++ b/cardinal/state_test.go
@@ -313,7 +313,8 @@ func TestCanFindTransactionsAfterReloadingEngine(t *testing.T) {
 	for reload := 0; reload < 5; reload++ {
 		tf := testutils.NewTestFixture(t, redisStore)
 		world := tf.World
-		assert.NilError(t, cardinal.RegisterMessage[Msg, Result](world, "some-msg"))
+		msgName := "some-msg"
+		assert.NilError(t, cardinal.RegisterMessage[Msg, Result](world, msgName))
 		err := cardinal.RegisterSystems(
 			world,
 			func(wCtx engine.Context) error {
@@ -328,8 +329,8 @@ func TestCanFindTransactionsAfterReloadingEngine(t *testing.T) {
 		tf.StartWorld()
 
 		relevantTick := world.CurrentTick()
-		someTx, err := cardinal.GetMessageFromWorld[Msg, Result](world)
-		assert.NilError(t, err)
+		someTx, ok := world.GetMessageByName(msgName)
+		assert.Assert(t, ok)
 		for i := 0; i < 3; i++ {
 			_ = tf.AddTransaction(someTx.ID(), Msg{}, testutils.UniqueSignature())
 		}

--- a/cardinal/tick_test.go
+++ b/cardinal/tick_test.go
@@ -350,7 +350,8 @@ func TestCanRecoverTransactionsFromFailedSystemRun(t *testing.T) {
 
 		assert.NilError(t, cardinal.RegisterComponent[PowerComp](world))
 
-		assert.NilError(t, cardinal.RegisterMessage[PowerComp, PowerComp](world, "change_power"))
+		msgName := "change_power"
+		assert.NilError(t, cardinal.RegisterMessage[PowerComp, PowerComp](world, msgName))
 
 		err := cardinal.RegisterSystems(
 			world,
@@ -391,10 +392,10 @@ func TestCanRecoverTransactionsFromFailedSystemRun(t *testing.T) {
 			assert.NilError(t, err)
 			return power.Val
 		}
-		powerTx, err := cardinal.GetMessageFromWorld[PowerComp, PowerComp](world)
+		powerTx, ok := world.GetMessageByName(msgName)
 		if isBuggyIteration {
 			// perform a few ticks that will not result in an error
-			assert.NilError(t, err)
+			assert.True(t, ok)
 			tf.AddTransaction(powerTx.ID(), PowerComp{1000})
 			assert.NilError(t, world.Tick(context.Background(), uint64(time.Now().Unix())))
 			tf.AddTransaction(powerTx.ID(), PowerComp{1000})

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"pkg.world.dev/world-engine/cardinal/query"
 	"reflect"
 	"strings"
 	"sync/atomic"
@@ -59,14 +60,13 @@ type World struct {
 	msgManager       *message.Manager
 	systemManager    *system.Manager
 	componentManager *component.Manager
+	queryManager     *query.Manager
 
-	namespace         Namespace
-	redisStorage      *redis.Storage
-	entityStore       gamestate.Manager
-	tick              *atomic.Uint64
-	timestamp         *atomic.Uint64
-	nameToQuery       map[string]engine.Query
-	registeredQueries []engine.Query
+	namespace    Namespace
+	redisStorage *redis.Storage
+	entityStore  gamestate.Manager
+	tick         *atomic.Uint64
+	timestamp    *atomic.Uint64
 
 	evmTxReceipts map[string]EVMTxReceipt
 
@@ -123,6 +123,7 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 		msgManager:       message.NewManager(),
 		systemManager:    system.NewManager(),
 		componentManager: component.NewManager(&redisMetaStore),
+		queryManager:     query.NewManager(),
 
 		// Imported from engine
 		redisStorage:  &redisMetaStore,
@@ -130,7 +131,6 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 		namespace:     Namespace(cfg.CardinalNamespace),
 		tick:          &atomic.Uint64{},
 		timestamp:     new(atomic.Uint64),
-		nameToQuery:   make(map[string]engine.Query),
 		txPool:        txpool.New(),
 		Logger:        &log.Logger,
 		evmTxReceipts: make(map[string]EVMTxReceipt),
@@ -361,7 +361,8 @@ func (w *World) StartGame() error {
 	// Create server
 	// We can't do this is in NewWorld() because the server needs to know the registered messages
 	// and register queries first. We can probably refactor this though.
-	w.server, err = server.New(NewReadOnlyWorldContext(w), w.GetRegisteredComponents(), w.ListMessages(), w.ListQueries(),
+	w.server, err = server.New(NewReadOnlyWorldContext(w), w.GetRegisteredComponents(), w.ListMessages(),
+		w.ListQueries(),
 		w.eventHub.NewWebSocketEventHandler(),
 		w.serverOptions...)
 	if err != nil {
@@ -453,7 +454,7 @@ func (w *World) emitResourcesWarnings() {
 	if len(w.msgManager.GetRegisteredMessages()) == 0 {
 		w.Logger.Warn().Msg("No messages registered.")
 	}
-	if len(w.registeredQueries) == 0 {
+	if len(w.queryManager.GetRegisteredQueries()) == 0 {
 		w.Logger.Warn().Msg("No queries registered.")
 	}
 	if len(w.systemManager.GetRegisteredSystemNames()) == 0 {
@@ -505,7 +506,7 @@ func (w *World) Shutdown() error {
 	return nil
 }
 
-func (w *World) ListQueries() []engine.Query   { return w.registeredQueries }
+func (w *World) ListQueries() []engine.Query   { return w.queryManager.GetRegisteredQueries() }
 func (w *World) ListMessages() []types.Message { return w.msgManager.GetRegisteredMessages() }
 
 func setLogLevel(levelStr string) error {
@@ -626,10 +627,7 @@ func (w *World) Namespace() Namespace {
 }
 
 func (w *World) GetQueryByName(name string) (engine.Query, error) {
-	if q, ok := w.nameToQuery[name]; ok {
-		return q, nil
-	}
-	return nil, eris.Errorf("query with name %s not found", name)
+	return w.queryManager.GetQueryByName(name)
 }
 
 func (w *World) GetMessageByName(name string) (types.Message, bool) {

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -9,7 +9,6 @@ import (
 	"os"
 	"os/signal"
 	"pkg.world.dev/world-engine/cardinal/query"
-	"reflect"
 	"strings"
 	"sync/atomic"
 	"syscall"
@@ -192,21 +191,6 @@ func NewMockWorld(opts ...WorldOption) (*World, error) {
 		return world, err
 	}
 	return world, nil
-}
-
-func GetMessageFromWorld[In any, Out any](world *World) (*message.MessageType[In, Out], error) {
-	var msg message.MessageType[In, Out]
-	msgType := reflect.TypeOf(msg)
-	tempRes, ok := world.GetMessageManager().GetMessageByType(msgType)
-	if !ok {
-		return &msg, eris.Errorf("Could not find %s, Message may not be registered.", msg.Name())
-	}
-	var _ types.Message = &msg
-	res, ok := tempRes.(*message.MessageType[In, Out])
-	if !ok {
-		return &msg, eris.New("wrong type")
-	}
-	return res, nil
 }
 
 func (w *World) CurrentTick() uint64 {

--- a/cardinal/world_recovery_test.go
+++ b/cardinal/world_recovery_test.go
@@ -2,6 +2,7 @@ package cardinal_test
 
 import (
 	"github.com/franela/goblin"
+	"pkg.world.dev/world-engine/cardinal/types"
 
 	"testing"
 
@@ -31,7 +32,7 @@ func TestWorldRecovery(t *testing.T) {
 		var controller *gomock.Controller
 		var router *mocks.MockRouter
 		var world *cardinal.World
-		var fooTx *message.MessageType[fooMessage, fooResponse]
+		var fooTx types.Message
 
 		// Set CARDINAL_MODE to production so that RecoverFromChain() is called
 		setEnvToCardinalProdMode(t)
@@ -44,15 +45,17 @@ func TestWorldRecovery(t *testing.T) {
 
 			world = tf.World
 			world.SetRouter(router)
+			msgName := "foo"
 			err := cardinal.RegisterMessage[
 				fooMessage,
 				fooResponse](
 				world,
-				"foo",
+				msgName,
 				message.WithMsgEVMSupport[fooMessage, fooResponse]())
 			g.Assert(err).IsNil()
-			fooTx, err = cardinal.GetMessageFromWorld[fooMessage, fooResponse](world)
-			g.Assert(err).IsNil()
+			var ok bool
+			fooTx, ok = world.GetMessageByName(msgName)
+			g.Assert(ok).IsTrue()
 		})
 
 		g.Describe("If there is recovery data", func() {

--- a/e2e/testgames/game/query/location.go
+++ b/e2e/testgames/game/query/location.go
@@ -5,6 +5,7 @@ import (
 	"github.com/argus-labs/world-engine/example/tester/game/comp"
 	"github.com/argus-labs/world-engine/example/tester/game/sys"
 	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/query"
 )
 
 type LocationRequest struct {
@@ -37,5 +38,5 @@ func RegisterLocationQuery(world *cardinal.World) error {
 				Y: loc.Y,
 			}, nil
 		},
-		cardinal.WithQueryEVMSupport[LocationRequest, LocationReply]())
+		query.WithQueryEVMSupport[LocationRequest, LocationReply]())
 }


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

Move all the query business logic to a `query` package with the manager pattern. This places the final key piece on the cardinal package refactor.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

- Creates `query` package with a manager that manages query registrations
- Extract `queryToName` and `registeredQueries` struct from World and consolidates them to `registerQueries` map in the `query.Manager` struct.
- Move `cardinal/query.go` and `cardinal/query_test.go` to `/cardinal/query/...`
- [Breaking] `cardinal.WithQueryEVMSupport` is now `query.WithQueryEVMSupport` similar to message

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

- All existing test passes