### PR TITLE
refactor(cardinal): eliminate generics from message registration to manager

### DIFF
--- a/cardinal/cardinal.go
+++ b/cardinal/cardinal.go
@@ -101,7 +101,17 @@ func RegisterMessage[In any, Out any](world *World, name string, opts ...message
 			worldstage.Init,
 		)
 	}
-	return message.RegisterMessageOnManager[In, Out](world.GetMessageManager(), name, opts...)
+
+	// Create the message type
+	msgType := message.NewMessageType[In, Out](name, opts...)
+
+	// Register the message with the manager
+	err := world.msgManager.RegisterMessage(name, msgType, reflect.TypeOf(*msgType))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func RegisterQuery[Request any, Reply any](

--- a/cardinal/message/manager.go
+++ b/cardinal/message/manager.go
@@ -1,11 +1,10 @@
 package message
 
 import (
-	"reflect"
-	"slices"
-
+	"errors"
 	"github.com/rotisserie/eris"
 	"pkg.world.dev/world-engine/cardinal/types"
+	"reflect"
 )
 
 type Manager struct {
@@ -16,44 +15,28 @@ type Manager struct {
 
 func NewManager() *Manager {
 	return &Manager{
-		registeredMessagesByType: map[reflect.Type]types.Message{},
 		registeredMessages:       map[string]types.Message{},
+		registeredMessagesByType: map[reflect.Type]types.Message{},
 		nextMessageID:            1,
 	}
 }
 
-func (m *Manager) registerMessagesByName(msgs ...types.Message) error {
-	// Iterate through all the messages and check if they are already registered.
-	// This is done before registering any of the messages to ensure that all are registered or none of them are.
-	msgNames := make([]string, 0, len(msgs))
-	for _, msg := range msgs {
-		// Check for duplicate message names within the list of messages to be registered
-		if slices.Contains(msgNames, msg.Name()) {
-			return eris.Errorf("duplicate message %q in slice", msg.Name())
-		}
-
-		// Checks if the message is already previously registered.
-		// This will terminate the registration of all messages if any of them are already registered.
-		if err := m.isMessageNameUnique(msg); err != nil {
-			return err
-		}
-
-		// If the message is not already registered, add it to the list of message names.
-		msgNames = append(msgNames, msg.Name())
+func (m *Manager) RegisterMessage(name string, msgType types.Message, msgReflectType reflect.Type) error {
+	// Checks if the message is already previously registered.
+	if err := errors.Join(m.isMessageNameUnique(name), m.isMessageTypeUnique(msgReflectType)); err != nil {
+		return err
 	}
 
-	// Iterate through all the messages and register them one by one.
-	for _, msg := range msgs {
-		// Set EntityID on message
-		err := msg.SetID(m.nextMessageID)
-		if err != nil {
-			return eris.Errorf("failed to set EntityID on message %q", msg.Name())
-		}
-
-		// Register message
-		m.registeredMessages[msg.Name()] = msg
-		m.nextMessageID++
+	// Set the message ID.
+	// TODO(scott): we should probably deprecate this and just decide whether we want to use name or ID.
+	err := msgType.SetID(m.nextMessageID)
+	if err != nil {
+		return eris.Errorf("failed to set id on message %q", msgType.Name())
 	}
+
+	m.registeredMessages[name] = msgType
+	m.registeredMessagesByType[msgReflectType] = msgType
+	m.nextMessageID++
 
 	return nil
 }
@@ -89,32 +72,20 @@ func (m *Manager) GetMessageByType(mType reflect.Type) (types.Message, bool) {
 	return msg, ok
 }
 
-func (m *Manager) registerMessageByType(mType reflect.Type, message types.Message) error {
-	_, ok := m.registeredMessagesByType[mType]
-	if ok {
-		return eris.New("A message of this type has already been registered")
-	}
-	m.registeredMessagesByType[mType] = message
-	return nil
-}
-
 // isMessageNameUnique checks if the message name already exist in messages map.
-func (m *Manager) isMessageNameUnique(tx types.Message) error {
-	_, ok := m.registeredMessages[tx.Name()]
+func (m *Manager) isMessageNameUnique(msgName string) error {
+	_, ok := m.registeredMessages[msgName]
 	if ok {
-		return eris.Errorf("message %q is already registered", tx.Name())
+		return eris.Errorf("message %q is already registered", msgName)
 	}
 	return nil
 }
 
-// RegisterMessageOnManager registers a single message on a manager. You do not need to provide the message type
-// You just need to provide the input and Output parameters
-func RegisterMessageOnManager[In any, Out any](manager *Manager, name string, opts ...MessageOption[In, Out]) error {
-	msgType := newMessageType[In, Out](name, opts...)
-	err := manager.registerMessagesByName(msgType)
-	if err != nil {
-		return err
+// isMessageTypeUnique checks if the message type name already exist in messages map.
+func (m *Manager) isMessageTypeUnique(msgReflectType reflect.Type) error {
+	_, ok := m.registeredMessagesByType[msgReflectType]
+	if ok {
+		return eris.Errorf("message type %q is already registered", msgReflectType)
 	}
-	typeValueOfMessageType := reflect.TypeOf(*msgType)
-	return manager.registerMessageByType(typeValueOfMessageType, msgType)
+	return nil
 }

--- a/cardinal/message/message.go
+++ b/cardinal/message/message.go
@@ -40,10 +40,10 @@ func isStruct[T any]() bool {
 		inKind == reflect.Struct
 }
 
-// newMessageType creates a new message type. It accepts two generic type parameters: the first for the message input,
+// NewMessageType creates a new message type. It accepts two generic type parameters: the first for the message input,
 // which defines the data needed to make a state transition, and the second for the message output, commonly used
 // for the results of a state transition.
-func newMessageType[In, Out any](
+func NewMessageType[In, Out any](
 	name string,
 	opts ...MessageOption[In, Out],
 ) *MessageType[In, Out] {

--- a/cardinal/message/message_test.go
+++ b/cardinal/message/message_test.go
@@ -22,13 +22,13 @@ func TestIfNewMessageWillPanic(t *testing.T) {
 	type NotStruct []int
 	type AStruct struct{}
 	assert.Panics(t, func() {
-		newMessageType[NotStruct, AStruct]("random")
+		NewMessageType[NotStruct, AStruct]("random")
 	})
 	assert.Panics(t, func() {
-		newMessageType[AStruct, NotStruct]("random")
+		NewMessageType[AStruct, NotStruct]("random")
 	})
 	assert.NotPanics(t, func() {
-		newMessageType[AStruct, AStruct]("random")
+		NewMessageType[AStruct, AStruct]("random")
 	})
 }
 
@@ -44,9 +44,9 @@ func TestReadTypeNotStructs(t *testing.T) {
 			assert.Assert(t, panicValue == nil)
 		}()
 
-		newMessageType[*ModifyScoreMsg, *EmptyMsgResult]("modify_score2")
+		NewMessageType[*ModifyScoreMsg, *EmptyMsgResult]("modify_score2")
 	}()
-	newMessageType[string, string]("modify_score1")
+	NewMessageType[string, string]("modify_score1")
 }
 
 func TestCanEncodeDecodeEVMTransactions(t *testing.T) {
@@ -58,7 +58,7 @@ func TestCanEncodeDecodeEVMTransactions(t *testing.T) {
 
 	msg := FooMsg{1, 2, "foo"}
 	// set up the Message.
-	iMsg := newMessageType[FooMsg, EmptyMsgResult]("FooMsg",
+	iMsg := NewMessageType[FooMsg, EmptyMsgResult]("FooMsg",
 		WithMsgEVMSupport[FooMsg, EmptyMsgResult]())
 	bz, err := iMsg.ABIEncode(msg)
 	assert.NilError(t, err)
@@ -75,7 +75,7 @@ func TestCanEncodeDecodeEVMTransactions(t *testing.T) {
 
 func TestCannotDecodeEVMBeforeSetEVM(t *testing.T) {
 	type foo struct{}
-	msg := newMessageType[foo, EmptyMsgResult]("foo")
+	msg := NewMessageType[foo, EmptyMsgResult]("foo")
 	_, err := msg.DecodeEVMBytes([]byte{})
 	assert.ErrorIs(t, err, ErrEVMTypeNotSet)
 }
@@ -97,7 +97,7 @@ func TestNewTransactionPanicsIfNoName(t *testing.T) {
 	type Foo struct{}
 	require.Panics(
 		t, func() {
-			newMessageType[Foo, Foo]("")
+			NewMessageType[Foo, Foo]("")
 		},
 	)
 }


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

There is a lot of inconsistency with how the message manager is implemented with the rest of the managers (query, system, etc). This refactor fixes on of them.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

- Eliminate the bulk message registration from the message manager, which will never be used anyway.
- Eliminate the generics `RegisterMessageWithManager` function that is inconsistent with the rest of the manager registration pattern.


## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
