### PR TITLE
refactor(cardinal): rename ListMessages/Queries to GetRegisteredMessages/Queries

### DIFF
--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -102,8 +102,8 @@ func (s *ServerTestSuite) TestCanListEndpoints() {
 	var result handler.GetEndpointsResponse
 	err := json.Unmarshal([]byte(s.readBody(res.Body)), &result)
 	s.Require().NoError(err)
-	msgs := s.world.ListMessages()
-	queries := s.world.ListQueries()
+	msgs := s.world.GetRegisteredMessages()
+	queries := s.world.GetRegisteredQueries()
 
 	s.Require().Len(msgs, len(result.TxEndpoints))
 	s.Require().Len(queries, len(result.QueryEndpoints))
@@ -126,8 +126,8 @@ func (s *ServerTestSuite) TestGetWorld() {
 	err := json.Unmarshal([]byte(s.readBody(res.Body)), &result)
 	s.Require().NoError(err)
 	comps := s.world.GetRegisteredComponents()
-	msgs := s.world.ListMessages()
-	queries := s.world.ListQueries()
+	msgs := s.world.GetRegisteredMessages()
+	queries := s.world.GetRegisteredQueries()
 
 	s.Require().Len(comps, len(result.Components))
 	s.Require().Len(msgs, len(result.Messages))

--- a/cardinal/testutils/testutils.go
+++ b/cardinal/testutils/testutils.go
@@ -65,7 +65,7 @@ func AddTransactionToWorldByAnyTransaction(
 	value any,
 	tx *sign.Transaction,
 ) {
-	txs := world.ListMessages()
+	txs := world.GetRegisteredMessages()
 	txID := cardinalTx.ID()
 	found := false
 	for _, tx := range txs {


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

Self explanatory, for naming consistentcy

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

- Rename ListMessages -> GetRegisteredMessages
- Rename ListQueries -> GetRegisteredQueries

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

- N/A