### PR TITLE
refactor(cardinal): refactor server to use provider pattern

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -718,13 +718,13 @@ func TestCreatePersona(t *testing.T) {
 
 func TestNewWorld(t *testing.T) {
 	tf := testutils.NewTestFixture(t, nil)
-	assert.Equal(t, string(tf.World.Namespace()), cardinal.DefaultNamespace)
+	assert.Equal(t, tf.World.Namespace(), cardinal.DefaultNamespace)
 }
 
 func TestNewWorldWithCustomNamespace(t *testing.T) {
 	t.Setenv("CARDINAL_NAMESPACE", "custom-namespace")
 	tf := testutils.NewTestFixture(t, nil)
-	assert.Equal(t, string(tf.World.Namespace()), "custom-namespace")
+	assert.Equal(t, tf.World.Namespace(), "custom-namespace")
 }
 
 func TestCanQueryInsideSystem(t *testing.T) {

--- a/cardinal/engine_test.go
+++ b/cardinal/engine_test.go
@@ -280,7 +280,7 @@ func TestSetNamespace(t *testing.T) {
 	t.Setenv("CARDINAL_NAMESPACE", namespace)
 	tf := testutils.NewTestFixture(t, nil)
 	world := tf.World
-	assert.Equal(t, world.Namespace().String(), namespace)
+	assert.Equal(t, world.Namespace(), namespace)
 }
 
 func TestWithoutRegistration(t *testing.T) {

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"os"
+	servertypes "pkg.world.dev/world-engine/cardinal/server/types"
 	"pkg.world.dev/world-engine/cardinal/types"
 	"pkg.world.dev/world-engine/cardinal/types/engine"
 	"sync/atomic"
@@ -36,7 +37,7 @@ type Server struct {
 
 // New returns an HTTP server with handlers for all QueryTypes and MessageTypes.
 func New(
-	wCtx engine.Context, components []types.ComponentMetadata, messages []types.Message,
+	provider servertypes.Provider, wCtx engine.Context, components []types.ComponentMetadata, messages []types.Message,
 	queries []engine.Query, wsEventHandler func(conn *websocket.Conn),
 	opts ...Option,
 ) (*Server, error) {
@@ -58,7 +59,7 @@ func New(
 
 	// Enable CORS
 	app.Use(cors.New())
-	setupRoutes(app, wCtx, messages, queries, wsEventHandler, s.config, components)
+	setupRoutes(app, provider, wCtx, messages, queries, wsEventHandler, s.config, components)
 
 	return s, nil
 }
@@ -98,7 +99,8 @@ func (s *Server) Shutdown() error {
 // @consumes		application/json
 // @produces		application/json
 func setupRoutes(
-	app *fiber.App, wCtx engine.Context, messages []types.Message, queries []engine.Query,
+	app *fiber.App, provider servertypes.Provider, wCtx engine.Context, messages []types.Message,
+	queries []engine.Query,
 	wsEventHandler func(conn *websocket.Conn),
 	cfg config, components []types.ComponentMetadata,
 ) {
@@ -154,5 +156,5 @@ func setupRoutes(
 
 	// Route: /tx/...
 	tx := app.Group("/tx")
-	tx.Post("/:group/:name", handler.PostTransaction(msgIndex, wCtx, cfg.isSignatureVerificationDisabled))
+	tx.Post("/:group/:name", handler.PostTransaction(provider, msgIndex, cfg.isSignatureVerificationDisabled))
 }

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -263,7 +263,7 @@ func (s *ServerTestSuite) TestSignerAddressIsRequiredWhenSigVerificationIsDisabl
 	moveMessage, ok := s.world.GetMessageByName(moveMsgName)
 	assert.True(t, ok)
 	payload := MoveMsgInput{Direction: "up"}
-	tx, err := sign.NewTransaction(s.privateKey, unclaimedPersona, s.world.Namespace().String(), s.nonce, payload)
+	tx, err := sign.NewTransaction(s.privateKey, unclaimedPersona, s.world.Namespace(), s.nonce, payload)
 	assert.NilError(t, err)
 
 	// This request should fail because signature verification is enabled, and we have not yet
@@ -274,7 +274,7 @@ func (s *ServerTestSuite) TestSignerAddressIsRequiredWhenSigVerificationIsDisabl
 
 // Creates a transaction with the given message, and runs it in a tick.
 func (s *ServerTestSuite) runTx(personaTag string, msg types.Message, payload any) {
-	tx, err := sign.NewTransaction(s.privateKey, personaTag, s.world.Namespace().String(), s.nonce, payload)
+	tx, err := sign.NewTransaction(s.privateKey, personaTag, s.world.Namespace(), s.nonce, payload)
 	s.Require().NoError(err)
 	res := s.fixture.Post(utils.GetTxURL(msg.Group(), msg.Name()), tx)
 	s.Require().Equal(fiber.StatusOK, res.StatusCode, s.readBody(res.Body))
@@ -289,7 +289,7 @@ func (s *ServerTestSuite) createPersona(personaTag string) {
 		PersonaTag:    personaTag,
 		SignerAddress: s.signerAddr,
 	}
-	tx, err := sign.NewSystemTransaction(s.privateKey, s.world.Namespace().String(), s.nonce, createPersonaTx)
+	tx, err := sign.NewSystemTransaction(s.privateKey, s.world.Namespace(), s.nonce, createPersonaTx)
 	s.Require().NoError(err)
 	res := s.fixture.Post(utils.GetTxURL("persona", "create-persona"), tx)
 	s.Require().Equal(fiber.StatusOK, res.StatusCode, s.readBody(res.Body))

--- a/cardinal/server/types/provider.go
+++ b/cardinal/server/types/provider.go
@@ -1,0 +1,13 @@
+package types
+
+import (
+	"pkg.world.dev/world-engine/cardinal/types"
+	"pkg.world.dev/world-engine/sign"
+)
+
+type Provider interface {
+	UseNonce(signerAddress string, nonce uint64) error
+	GetSignerForPersonaTag(personaTag string, tick uint64) (addr string, err error)
+	AddTransaction(id types.MessageID, v any, sig *sign.Transaction) (uint64, types.TxHash)
+	Namespace() string
+}

--- a/cardinal/types/engine/context.go
+++ b/cardinal/types/engine/context.go
@@ -37,7 +37,6 @@ type Context interface {
 	GetTransactionReceiptsForTick(tick uint64) ([]receipt.Receipt, error)
 	ReceiptHistorySize() uint64
 	AddTransaction(id types.MessageID, v any, sig *sign.Transaction) (uint64, types.TxHash)
-	UseNonce(signerAddress string, nonce uint64) error
 	IsWorldReady() bool
 	StoreReader() gamestate.Reader
 	StoreManager() gamestate.Manager

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -37,6 +37,7 @@ import (
 
 	"pkg.world.dev/world-engine/cardinal/gamestate"
 	"pkg.world.dev/world-engine/cardinal/server"
+	servertypes "pkg.world.dev/world-engine/cardinal/server/types"
 	"pkg.world.dev/world-engine/cardinal/statsd"
 	"pkg.world.dev/world-engine/cardinal/worldstage"
 )
@@ -82,6 +83,7 @@ type World struct {
 }
 
 var _ router.Provider = &World{}
+var _ servertypes.Provider = &World{}
 
 // NewWorld creates a new World object using Redis as the storage layer.
 func NewWorld(opts ...WorldOption) (*World, error) {
@@ -345,7 +347,7 @@ func (w *World) StartGame() error {
 	// Create server
 	// We can't do this is in NewWorld() because the server needs to know the registered messages
 	// and register queries first. We can probably refactor this though.
-	w.server, err = server.New(NewReadOnlyWorldContext(w), w.GetRegisteredComponents(), w.GetRegisteredMessages(),
+	w.server, err = server.New(w, NewReadOnlyWorldContext(w), w.GetRegisteredComponents(), w.GetRegisteredMessages(),
 		w.GetRegisteredQueries(),
 		w.eventHub.NewWebSocketEventHandler(),
 		w.serverOptions...)
@@ -603,8 +605,8 @@ func (w *World) UseNonce(signerAddress string, nonce uint64) error {
 	return w.redisStorage.UseNonce(signerAddress, nonce)
 }
 
-func (w *World) Namespace() Namespace {
-	return w.namespace
+func (w *World) Namespace() string {
+	return string(w.namespace)
 }
 
 func (w *World) GameStateManager() gamestate.Manager {

--- a/cardinal/world_context.go
+++ b/cardinal/world_context.go
@@ -1,6 +1,7 @@
 package cardinal
 
 import (
+	"pkg.world.dev/world-engine/cardinal/worldstage"
 	"reflect"
 
 	"github.com/rs/zerolog"
@@ -9,7 +10,6 @@ import (
 	"pkg.world.dev/world-engine/cardinal/types"
 	"pkg.world.dev/world-engine/cardinal/types/engine"
 	"pkg.world.dev/world-engine/cardinal/types/txpool"
-	"pkg.world.dev/world-engine/cardinal/worldstage"
 	"pkg.world.dev/world-engine/sign"
 )
 
@@ -110,7 +110,7 @@ func (ctx *worldContext) ReceiptHistorySize() uint64 {
 }
 
 func (ctx *worldContext) Namespace() string {
-	return string(ctx.world.namespace)
+	return ctx.world.Namespace()
 }
 
 func (ctx *worldContext) AddTransaction(id types.MessageID, v any, sig *sign.Transaction) (uint64, types.TxHash) {
@@ -135,10 +135,6 @@ func (ctx *worldContext) StoreReader() gamestate.Reader {
 		return sm.ToReadOnly()
 	}
 	return sm
-}
-
-func (ctx *worldContext) UseNonce(signerAddress string, nonce uint64) error {
-	return ctx.world.UseNonce(signerAddress, nonce)
 }
 
 func (ctx *worldContext) IsWorldReady() bool {


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

Right now we are using `engine.Context` as an omnibus way to pass around random stuff from World throughout the codebase that significantly explodes its surface area.

This refactor contains the first cut refactor to use the provider pattern, which allows us to eliminate `UseNonce` from `engine.Context` 

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

- Create Provider for package `server` that expose world functionality that it needs
- Remove `UseNonce` from `engine.Context`
- `world.Namespace()` now returns string type

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

- N/A