### PR TITLE
refactor(cardinal): clean up logs pretty printing

### DIFF
--- a/cardinal/server/option.go
+++ b/cardinal/server/option.go
@@ -1,11 +1,5 @@
 package server
 
-import (
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"os"
-)
-
 type Option func(s *Server)
 
 // WithPort allows the server to run on a specified port.
@@ -19,12 +13,6 @@ func WithPort(port string) Option {
 func DisableSignatureVerification() Option {
 	return func(s *Server) {
 		s.config.isSignatureVerificationDisabled = true
-	}
-}
-
-func WithPrettyPrint() Option {
-	return func(_ *Server) {
-		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	}
 }
 

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -89,7 +89,9 @@ type World struct {
 var _ router.Provider = &World{}
 var _ servertypes.Provider = &World{}
 
-// NewWorld creates a new World object using Redis as the storage layer.
+// NewWorld creates a new World object using Redis as the storage layer
+//
+//nolint:funlen
 func NewWorld(opts ...WorldOption) (*World, error) {
 	serverOptions, cardinalOptions := separateOptions(opts)
 
@@ -102,10 +104,12 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 		return nil, eris.Wrap(err, "")
 	}
 
-	log.Logger.Info().Msgf("Starting a new Cardinal world in %s mode", cfg.CardinalMode)
 	if cfg.CardinalMode == RunModeDev {
-		serverOptions = append(serverOptions, server.WithPrettyPrint())
+		// Enable pretty printing of logs in development mode.
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 	}
+	log.Logger.Info().Msgf("Starting a new Cardinal world in %s mode", cfg.CardinalMode)
+
 	redisMetaStore := redis.NewRedisStorage(redis.Options{
 		Addr:        cfg.RedisAddress,
 		Password:    cfg.RedisPassword,
@@ -130,7 +134,6 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 		componentManager: component.NewManager(&redisMetaStore),
 		queryManager:     query.NewManager(),
 
-		// Imported from engine
 		redisStorage:  &redisMetaStore,
 		entityStore:   entityCommandBuffer,
 		namespace:     Namespace(cfg.CardinalNamespace),


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

This PR removes the server `WithPrettyPrint` option since the `log.Logger` would only need to be overwritten once from world.go. Additionally, this reorders a log to make sure its pretty printed.

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

 - Remove `server.WithPrettyPrint`
- Reorder bootup sequence logs in `cardinal.NewWorld`

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
- N/A
