### PR TITLE
refactor(cardinal): remove GetMessageManager

### DIFF
--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -305,10 +305,6 @@ func (w *World) doTick(ctx context.Context, timestamp uint64) (err error) {
 	return nil
 }
 
-func (w *World) GetMessageManager() *message.Manager {
-	return w.msgManager
-}
-
 // StartGame starts running the world game loop. Each time a message arrives on the tickChannel, a world tick is
 // attempted. In addition, an HTTP server (listening on the given port) is created so that game messages can be sent
 // to this world. After StartGame is called, RegisterComponent, registerMessagesByName,

--- a/cardinal/world_context.go
+++ b/cardinal/world_context.go
@@ -1,10 +1,12 @@
 package cardinal
 
 import (
-	"pkg.world.dev/world-engine/cardinal/worldstage"
 	"reflect"
 
+	"pkg.world.dev/world-engine/cardinal/worldstage"
+
 	"github.com/rs/zerolog"
+
 	"pkg.world.dev/world-engine/cardinal/gamestate"
 	"pkg.world.dev/world-engine/cardinal/receipt"
 	"pkg.world.dev/world-engine/cardinal/types"
@@ -64,7 +66,7 @@ func (ctx *worldContext) Logger() *zerolog.Logger {
 }
 
 func (ctx *worldContext) GetMessageByType(mType reflect.Type) (types.Message, bool) {
-	return ctx.world.GetMessageManager().GetMessageByType(mType)
+	return ctx.world.msgManager.GetMessageByType(mType)
 }
 
 func (ctx *worldContext) SetLogger(logger zerolog.Logger) {


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

This PR removes `GetMessageManager` that exposes an internal private struct field which leads to abstraction violation.

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

- Remove `GetMessageManager`

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

- N/A
