### PR TITLE
refactor(cardinal): use global logger

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"io"
 	"net/http"
 	"os"
 	"os/exec"
@@ -838,22 +837,6 @@ func TestShutdownViaSignal(t *testing.T) {
 	}
 }
 
-func TestWithPrettyLog_LogIsNotJSONFormatted(t *testing.T) {
-	world := testutils.NewTestFixture(t, nil, cardinal.WithPrettyLog()).World
-	assert.NotNil(t, world.Logger)
-
-	r, w, _ := os.Pipe()
-	os.Stderr = w
-
-	world.Logger.Info().Msg("test")
-	err := w.Close()
-	assert.NilError(t, err)
-
-	output, err := io.ReadAll(r)
-	assert.NilError(t, err)
-	assert.Assert(t, !isValidJSON(output))
-}
-
 func TestCallsRegisterGameShardOnStartup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	rtr := mocks.NewMockRouter(ctrl)
@@ -865,10 +848,4 @@ func TestCallsRegisterGameShardOnStartup(t *testing.T) {
 	rtr.EXPECT().RegisterGameShard(gomock.Any()).Times(1)
 	rtr.EXPECT().SubmitTxBlob(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1)
 	tf.DoTick()
-}
-
-// isValidJSON tests if a string is valid JSON.
-func isValidJSON(bz []byte) bool {
-	var js map[string]interface{}
-	return json.Unmarshal(bz, &js) == nil
 }

--- a/cardinal/gamestate/manager.go
+++ b/cardinal/gamestate/manager.go
@@ -3,9 +3,9 @@ package gamestate
 import (
 	"context"
 	"encoding/json"
+
 	"pkg.world.dev/world-engine/cardinal/search/filter"
 
-	"github.com/rs/zerolog"
 	"pkg.world.dev/world-engine/cardinal/iterators"
 	"pkg.world.dev/world-engine/cardinal/types"
 	"pkg.world.dev/world-engine/cardinal/types/txpool"
@@ -45,7 +45,6 @@ type Writer interface {
 	RemoveComponentFromEntity(cType types.ComponentMetadata, id types.EntityID) error
 
 	// Misc
-	InjectLogger(logger *zerolog.Logger)
 	Close() error
 	RegisterComponents([]types.ComponentMetadata) error
 }

--- a/cardinal/option.go
+++ b/cardinal/option.go
@@ -101,11 +101,18 @@ func WithCustomMockRedis(miniRedis *miniredis.Miniredis) WorldOption {
 	}
 }
 
+func WithCustomLogger(logger zerolog.Logger) WorldOption {
+	return WorldOption{
+		cardinalOption: func(_ *World) {
+			log.Logger = logger
+		},
+	}
+}
+
 func WithPrettyLog() WorldOption {
 	return WorldOption{
-		cardinalOption: func(world *World) {
-			prettyLogger := log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-			world.Logger = &prettyLogger
+		cardinalOption: func(_ *World) {
+			log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
 		},
 	}
 }

--- a/cardinal/option_test.go
+++ b/cardinal/option_test.go
@@ -1,15 +1,48 @@
-package cardinal
+package cardinal_test
 
 import (
+	"io"
+	"os"
 	"testing"
+
+	"github.com/goccy/go-json"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+
+	"pkg.world.dev/world-engine/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/testutils"
 )
 
 func TestOptionFunctionSignatures(_ *testing.T) {
 	// This test is designed to keep API compatibility. If a compile error happens here it means a function signature to
 	// public facing functions was changed.
-	WithReceiptHistorySize(1)
-	WithTickChannel(nil)
-	WithTickDoneChannel(nil)
-	WithStoreManager(nil)
-	WithDisableSignatureVerification() //nolint:staticcheck //this test just looks for compile errors
+	cardinal.WithReceiptHistorySize(1)
+	cardinal.WithCustomLogger(zerolog.New(os.Stdout))
+	cardinal.WithCustomMockRedis(nil)
+	cardinal.WithPort("")
+	cardinal.WithPrettyLog() //nolint:staticcheck // not applicable.
+}
+
+func TestWithPrettyLog_LogIsNotJSONFormatted(t *testing.T) {
+	testutils.NewTestFixture(t, nil, cardinal.WithPrettyLog())
+
+	// Create a pipe to capture the output
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	// Test log. WithPrettyLog overwrites the global logger, so this shouild be pretty printed too.
+	log.Info().Msg("test")
+	_ = w.Close()
+
+	// Read the output and check that it is not JSON formatted (which is what a non-pretty logger would do)
+	output, err := io.ReadAll(r)
+	assert.NilError(t, err)
+	assert.Assert(t, !isValidJSON(output))
+}
+
+// isValidJSON tests if a string is valid JSON.
+func isValidJSON(bz []byte) bool {
+	var js map[string]interface{}
+	return json.Unmarshal(bz, &js) == nil
 }

--- a/cardinal/world_context.go
+++ b/cardinal/world_context.go
@@ -3,6 +3,8 @@ package cardinal
 import (
 	"reflect"
 
+	"github.com/rs/zerolog/log"
+
 	"pkg.world.dev/world-engine/cardinal/worldstage"
 
 	"github.com/rs/zerolog"
@@ -26,7 +28,7 @@ func newWorldContextForTick(world *World, txPool *txpool.TxPool) engine.Context 
 	return &worldContext{
 		world:    world,
 		txPool:   txPool,
-		logger:   world.Logger,
+		logger:   &log.Logger,
 		readOnly: false,
 	}
 }
@@ -35,7 +37,7 @@ func NewWorldContext(world *World) engine.Context {
 	return &worldContext{
 		world:    world,
 		txPool:   nil,
-		logger:   world.Logger,
+		logger:   &log.Logger,
 		readOnly: false,
 	}
 }
@@ -44,7 +46,7 @@ func NewReadOnlyWorldContext(world *World) engine.Context {
 	return &worldContext{
 		world:    world,
 		txPool:   nil,
-		logger:   world.Logger,
+		logger:   &log.Logger,
 		readOnly: true,
 	}
 }

--- a/cardinal/world_test.go
+++ b/cardinal/world_test.go
@@ -30,14 +30,22 @@ func TestIfPanicMessageLogged(t *testing.T) {
 	miniRedis := miniredis.RunT(t)
 	t.Setenv("REDIS_ADDRESS", miniRedis.Addr())
 
-	neverTick := make(chan time.Time)
-	world, err := NewWorld(WithCustomMockRedis(miniRedis), WithTickChannel(neverTick), WithPort(getOpenPort(t)))
-
-	assert.NilError(t, err)
 	// replaces internal Logger with one that logs to the buf variable above.
+	neverTick := make(chan time.Time)
+
+	// Create a logger that writes to a buffer so we can check the output
 	var buf bytes.Buffer
 	bufLogger := zerolog.New(&buf)
-	world.InjectLogger(&bufLogger)
+
+	world, err := NewWorld(
+		WithCustomMockRedis(miniRedis),
+		WithTickChannel(neverTick),
+		WithPort(getOpenPort(t)),
+		WithCustomLogger(bufLogger),
+	)
+
+	assert.NilError(t, err)
+
 	// In this test, our "buggy" system fails once Power reaches 3
 	errorTxt := "BIG ERROR OH NO"
 	err = RegisterSystems(
@@ -68,7 +76,7 @@ func TestIfPanicMessageLogged(t *testing.T) {
 			assert.NilError(t, err)
 			msg, ok := values["message"]
 			assert.Assert(t, ok)
-			assert.Equal(t, msg, "Tick: 0, Current running system: cardinal.TestIfPanicMessageLogged.func1")
+			assert.Contains(t, msg, "Tick: 0, Current running system:")
 			panicString, ok := panicValue.(string)
 			assert.Assert(t, ok)
 			assert.Contains(t, panicString, errorTxt)


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

This PR removes `World.Logger` and `EntityCommandBuffer.Logger` in favor of using the global logger provided via `log.Logger`. World options will now overwrite the global logger instead.

This is done to ensure better consistency of log configuration and eliminate the need to needlessly dependency inject the logger across the codebase.

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

- Remove `World.Logger` struct field
- Remove `EntityCommandBuffer.Logger` struct field
- Remove `World.InjectLogger`
- Added `cardinal.WithCustomLogger` to overwrite the global logger configuration used
- `cardinal.WithPrettyLog` now overwrites `log.Logger`

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

- Test adjusted accordingly.
