### PR TITLE
refactor(cardinal): replace world.SetRouter with an option

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -840,9 +840,7 @@ func TestShutdownViaSignal(t *testing.T) {
 func TestCallsRegisterGameShardOnStartup(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	rtr := mocks.NewMockRouter(ctrl)
-	tf := testutils.NewTestFixture(t, nil)
-	world := tf.World
-	world.SetRouter(rtr)
+	tf := testutils.NewTestFixture(t, nil, cardinal.WithCustomRouter(rtr))
 
 	rtr.EXPECT().Start().Times(1)
 	rtr.EXPECT().RegisterGameShard(gomock.Any()).Times(1)

--- a/cardinal/engine_test.go
+++ b/cardinal/engine_test.go
@@ -360,14 +360,15 @@ func TestWithoutRegistration(t *testing.T) {
 func TestTransactionsSentToRouterAfterTick(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	rtr := mocks.NewMockRouter(ctrl)
-	tf := testutils.NewTestFixture(t, nil)
+	tf := testutils.NewTestFixture(t, nil, cardinal.WithCustomRouter(rtr))
 	world := tf.World
-	world.SetRouter(rtr)
+
 	type fooMsg struct {
 		Bar string
 	}
 
 	type fooMsgRes struct{}
+
 	msgName := "foo"
 	err := cardinal.RegisterMessage[fooMsg, fooMsgRes](world, msgName, message.WithMsgEVMSupport[fooMsg, fooMsgRes]())
 	assert.NilError(t, err)
@@ -441,9 +442,8 @@ func TestRecoverFromChain(t *testing.T) {
 	rtr.EXPECT().Start().Times(1)
 	rtr.EXPECT().RegisterGameShard(gomock.Any()).Times(1)
 
-	tf := testutils.NewTestFixture(t, nil)
+	tf := testutils.NewTestFixture(t, nil, cardinal.WithCustomRouter(rtr))
 	world := tf.World
-	world.SetRouter(rtr)
 
 	type fooMsg struct{ I int }
 	type fooMsgRes struct{}

--- a/cardinal/option.go
+++ b/cardinal/option.go
@@ -10,6 +10,7 @@ import (
 
 	"pkg.world.dev/world-engine/cardinal/gamestate"
 	"pkg.world.dev/world-engine/cardinal/receipt"
+	"pkg.world.dev/world-engine/cardinal/router"
 	"pkg.world.dev/world-engine/cardinal/server"
 )
 
@@ -105,6 +106,14 @@ func WithCustomLogger(logger zerolog.Logger) WorldOption {
 	return WorldOption{
 		cardinalOption: func(_ *World) {
 			log.Logger = logger
+		},
+	}
+}
+
+func WithCustomRouter(rtr router.Router) WorldOption {
+	return WorldOption{
+		cardinalOption: func(world *World) {
+			world.router = rtr
 		},
 	}
 }

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -631,10 +631,6 @@ func (w *World) GetEventHub() *events.EventHub {
 	return w.eventHub
 }
 
-func (w *World) SetRouter(rtr router.Router) {
-	w.router = rtr
-}
-
 func (w *World) HandleEVMQuery(name string, abiRequest []byte) ([]byte, error) {
 	qry, err := w.GetQueryByName(name)
 	if err != nil {

--- a/cardinal/world_recovery_test.go
+++ b/cardinal/world_recovery_test.go
@@ -38,13 +38,11 @@ func TestWorldRecovery(t *testing.T) {
 		setEnvToCardinalProdMode(t)
 
 		g.BeforeEach(func() {
-			tf = testutils.NewTestFixture(t, nil)
-
 			controller = gomock.NewController(t)
 			router = mocks.NewMockRouter(controller)
+			tf = testutils.NewTestFixture(t, nil, cardinal.WithCustomRouter(router))
 
 			world = tf.World
-			world.SetRouter(router)
 			msgName := "foo"
 			err := cardinal.RegisterMessage[
 				fooMessage,


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

This PR removes `world.SetRouter` in favor of `WithCustomRouter` option which is consistent with the existing pattern, which also avoid violating the abstraction boundaries.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

- Remove `SetRouter`
- Adds `WithCustomRouter` option for injecting a custom router to World

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

- Tests updated accordingly
