### PR TITLE
chore(evm): bump version of forked polaris EVM

### DIFF
--- a/evm/go.mod
+++ b/evm/go.mod
@@ -12,7 +12,7 @@ replace (
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 	github.com/syndtr/goleveldb => github.com/syndtr/goleveldb v1.0.1-0.20210819022825-2ae1ddf74ef7
 
-	pkg.berachain.dev/polaris/cosmos => github.com/argus-labs/polaris/cosmos v1.0.0-hooks
+	pkg.berachain.dev/polaris/cosmos => github.com/argus-labs/polaris/cosmos v1.0.4-hooks
 	pkg.berachain.dev/polaris/eth => github.com/argus-labs/polaris/eth v1.0.0-hooks
 )
 

--- a/evm/go.sum
+++ b/evm/go.sum
@@ -307,8 +307,8 @@ github.com/apache/thrift v0.12.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb
 github.com/apache/thrift v0.13.0/go.mod h1:cp2SuWMxlEZw2r+iP2GNCdIi4C1qmUzdZFSVb+bacwQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
-github.com/argus-labs/polaris/cosmos v1.0.0-hooks h1:dOPOPX+iEDbiLPQBvHlocOjA9AQ7YyRu7m+zawOd6kM=
-github.com/argus-labs/polaris/cosmos v1.0.0-hooks/go.mod h1:TZiZK/WGG9Hl4QzW9vjBn7u75QjvoTZId+FUhUFDeAQ=
+github.com/argus-labs/polaris/cosmos v1.0.4-hooks h1:XYv2m2/oUWqkCXhYavdRNCRfJRps9kYEhGfxEG7cEdc=
+github.com/argus-labs/polaris/cosmos v1.0.4-hooks/go.mod h1:fYG4X358ZsUpa5pln07LCZtNvc91igEyDMQ0YjaFry0=
 github.com/argus-labs/polaris/eth v1.0.0-hooks h1:gKUOAO9k2xPqfYyeHI7DfPNLia76vuPR4zQHVr1fYtI=
 github.com/argus-labs/polaris/eth v1.0.0-hooks/go.mod h1:CH0uJJxVi6Sx9mTfBu2u9rwl7frH1fnSuc098wTPCPk=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=

--- a/go.work.sum
+++ b/go.work.sum
@@ -632,6 +632,7 @@ github.com/apache/arrow/go/v12 v12.0.1/go.mod h1:weuTY7JvTG/HDPtMQxEUp7pU73vkLWM
 github.com/apache/thrift v0.13.0 h1:5hryIiq9gtn+MiLVn0wP37kb/uTeRZgN08WoCsAhIhI=
 github.com/apache/thrift v0.16.0 h1:qEy6UW60iVOlUy+b9ZR0d5WzUWYGOo4HfopoyBaNmoY=
 github.com/apache/thrift v0.16.0/go.mod h1:PHK3hniurgQaNMZYaCLEqXKsYK8upmhPbmdP2FXSqgU=
+github.com/argus-labs/polaris/cosmos v1.0.4-hooks/go.mod h1:fYG4X358ZsUpa5pln07LCZtNvc91igEyDMQ0YjaFry0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e h1:QEF07wC0T1rKkctt1RINW/+RMTVmiwxETico2l3gxJA=
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6 h1:G1bPvciwNyF7IUmKXNt9Ak3m6u9DE1rF+RmtIkBpVdA=
 github.com/armon/go-metrics v0.4.0/go.mod h1:E6amYzXo6aW1tqzoZGT755KkbgrJsSdpwZ+3JqfkOG4=


### PR DESCRIPTION
## Overview

apparently adding prints to polaris EVM's PrepareProposal prevents some sort of race condition that was causing a panic?? idk. it doesnt panic anymore though ??? at the cost of some ugly logs but ill take it..

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
