### PR TITLE
feat(DO NOT MERGE): kv store interface proposal

### DIFF
--- a/cardinal/storage/newstorage/example/nonce/storage.go
+++ b/cardinal/storage/newstorage/example/nonce/storage.go
@@ -1,0 +1,41 @@
+package nonce
+
+import (
+	"github.com/redis/go-redis/v9"
+
+	"pkg.world.dev/world-engine/cardinal/storage/newstorage"
+	redisstore "pkg.world.dev/world-engine/cardinal/storage/newstorage/redis"
+)
+
+type NextNonceStorage interface {
+	UseNonce(signerAddress string, nonce uint64) error
+}
+
+type nonceStorage struct {
+	kv newstorage.KVStore[string, uint64]
+}
+
+func NewNonceStorage(opts *redis.Options) NextNonceStorage {
+	return &nonceStorage{
+		kv: redisstore.NewRedisStorage[string, uint64](opts),
+	}
+}
+
+func (n *nonceStorage) UseNonce(signerAddress string, nonce uint64) error {
+	key := "NONCE-" + signerAddress
+	batch := n.kv.NewBatch()
+
+	// Queue a set operation to be executed in a Redis transaction when Commit is called.
+	err := batch.Set(key, nonce)
+	if err != nil {
+		return err
+	}
+
+	// Commit the batch to Redis
+	err = batch.Commit()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cardinal/storage/newstorage/kv.go
+++ b/cardinal/storage/newstorage/kv.go
@@ -1,0 +1,48 @@
+package newstorage
+
+// KVStore is a generic key-value store interface with batch operations.
+type KVStore[K comparable, V any] interface {
+	// KVStore exposed a batch system for write operations.
+	// Where it executes multiple operations in a single transaction.
+
+	NewBatch() KVBatch[K, V]
+	NewReadBatch() KVReadBatch[K, V]
+
+	// KVStore also provides a direct reader and writer that
+	// executes a single operation at a time.
+
+	kvReader[K, V]
+	kvWriter[K, V]
+
+	// Close closes the underlying connection to the store.
+	Close() error
+}
+
+// KVBatch is an abstraction interface for a batch of KVStore operations.
+// This interface must have transaction isolation guarantees to avoid dirty reads and deadlocks.
+// KVBatch is needed for write operations.
+type KVBatch[K comparable, V any] interface {
+	kvReader[K, V]
+	kvWriter[K, V]
+	IsDiscarded() bool
+	Discard() error
+	Commit() error
+}
+
+// KVReadBatch is an abstraction interface for a batch of KVStore read operations.
+// This interface must have transaction isolation guarantees to avoid dirty reads .
+// KVBatch is preferred when you only need to read from the store.
+type KVReadBatch[K comparable, V any] interface {
+	kvReader[K, V]
+	Discard() error
+}
+
+type kvReader[K comparable, V any] interface {
+	Has(key K) (bool, error)
+	Get(key K) (*V, error)
+}
+
+type kvWriter[K comparable, V any] interface {
+	Set(key K, value V) error
+	Delete(key K) error
+}

--- a/cardinal/storage/newstorage/redis/batch.go
+++ b/cardinal/storage/newstorage/redis/batch.go
@@ -1,0 +1,107 @@
+package redis
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rotisserie/eris"
+
+	"pkg.world.dev/world-engine/cardinal/storage/newstorage"
+)
+
+var _ newstorage.KVBatch[any, any] = &batch[any, any]{}
+var _ newstorage.KVReadBatch[any, any] = &batch[any, any]{}
+
+type batch[K comparable, V any] struct {
+	pipe        redis.Pipeliner
+	isDiscarded bool
+}
+
+// IsDiscarded returns true if the batch has been discarded.
+// No more operations can be performed on a discarded batch.
+func (r *batch[K, V]) IsDiscarded() bool {
+	return r.isDiscarded
+}
+
+// Has returns true if the key exists in the Redis store.
+// As a part of the batch, this operation receives transaction isolation guarantees.
+// That means dirty reads are not possible.
+func (r *batch[K, V]) Has(_ K) (bool, error) {
+	if err := r.checkBatchNotDiscarded(); err != nil {
+		return false, err
+	}
+	return false, eris.New("not implemented")
+}
+
+// Get obtains the value of a key from the Redis store.
+// As a part of the batch, this operation receives transaction isolation guarantees.
+// That means dirty reads are not possible.
+func (r *batch[K, V]) Get(key K) (*V, error) {
+	if err := r.checkBatchNotDiscarded(); err != nil {
+		return nil, err
+	}
+
+	value, err := r.pipe.Do(context.Background(), "get", fmt.Sprintf("%v", key)).Result()
+	if err != nil {
+		return nil, err
+	}
+	return value.(*V), nil
+}
+
+// Set queues a set operation to be executed in a Redis transaction when Commit is called.
+func (r *batch[K, V]) Set(key K, value V) error {
+	if err := r.checkBatchNotDiscarded(); err != nil {
+		return err
+	}
+
+	_, err := r.pipe.Set(context.Background(), fmt.Sprintf("%v", key), value, 0).Result()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Delete queues a delete operation to be executed in a Redis transaction when Commit is called.
+func (r *batch[K, V]) Delete(_ K) error {
+	if err := r.checkBatchNotDiscarded(); err != nil {
+		return err
+	}
+	return eris.New("not implemented")
+}
+
+// Discard discards the batch and prevents it from being used anymore
+func (r *batch[K, V]) Discard() error {
+	if err := r.checkBatchNotDiscarded(); err != nil {
+		return err
+	}
+
+	r.pipe.Discard()
+	r.isDiscarded = true
+	return nil
+}
+
+// Commit the tranasction to redis
+func (r *batch[K, V]) Commit() error {
+	if err := r.checkBatchNotDiscarded(); err != nil {
+		return err
+	}
+
+	// Commit the transaction
+	_, err := r.pipe.Exec(context.Background())
+	if err != nil {
+		return err
+	}
+
+	// Mark the batch as discarded so it can't be used anymore
+	r.isDiscarded = true
+
+	return nil
+}
+
+func (r *batch[K, V]) checkBatchNotDiscarded() error {
+	if r.isDiscarded {
+		return eris.New("batch is already discarded")
+	}
+	return nil
+}

--- a/cardinal/storage/newstorage/redis/store.go
+++ b/cardinal/storage/newstorage/redis/store.go
@@ -1,0 +1,73 @@
+package redis
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+	"github.com/rotisserie/eris"
+
+	"pkg.world.dev/world-engine/cardinal/storage/newstorage"
+)
+
+var _ newstorage.KVStore[string, any] = &Store[string, any]{}
+
+type Store[K comparable, V any] struct {
+	client *redis.Client
+}
+
+func NewRedisStorage[K comparable, V any](opts *redis.Options) *Store[K, V] {
+	return &Store[K, V]{
+		client: redis.NewClient(opts),
+	}
+}
+
+func (r *Store[K, V]) NewBatch() newstorage.KVBatch[K, V] {
+	return &batch[K, V]{
+		pipe:        r.client.TxPipeline(),
+		isDiscarded: false,
+	}
+}
+
+func (r *Store[K, V]) NewReadBatch() newstorage.KVReadBatch[K, V] {
+	return &batch[K, V]{
+		pipe:        r.client.TxPipeline(),
+		isDiscarded: false,
+	}
+}
+
+func (r *Store[K, V]) Has(_ K) (bool, error) {
+	return false, eris.New("not implemented")
+}
+
+func (r *Store[K, V]) Get(key K) (*V, error) {
+	value, err := r.client.Do(context.Background(), "get", fmt.Sprintf("%v", key)).Result()
+	if err != nil {
+		if errors.Is(err, redis.Nil) {
+			return nil, eris.Wrap(err, "key does not exists")
+		}
+		return nil, err
+	}
+	return value.(*V), nil
+}
+
+func (r *Store[K, V]) Set(key K, value V) error {
+	_, err := r.client.Set(context.Background(), fmt.Sprintf("%v", key), value, 0).Result()
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (r *Store[K, V]) Delete(_ K) error {
+	return eris.New("not implemented")
+}
+
+func (r *Store[K, V]) Close() error {
+	err := r.client.Close()
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

This PR contains a proposal for the KVStore interface and a partial example implementation for Redis and NonceStorage.

The 3 main interface is:
- `KVStore` - a generic key-value store interface with supports for batch operations. A KVStore can be backed by any KV-like storage system both in-memory (go map, redis, go-memdb, bunt, etc) and persistent (badger, pebble, sqlite, etc).
- `KVBatch` - an abstraction interface for a batch of KVStore operations that is executed with transaction isolation providing guarantees against dirty reads and deadlocks.
- `KVReadBatch` - a read-only version of `KVBatch`

For the full example, see the code in diff.

Here's an example snippet of how `NonceStorage` would look like when implemented with `KVStore` backed by Redis:

```go
package nonce

import (
	"github.com/redis/go-redis/v9"

	"pkg.world.dev/world-engine/cardinal/storage/newstorage"
	redis2 "pkg.world.dev/world-engine/cardinal/storage/newstorage/redis"
)

type NextNonceStorage interface {
	UseNonce(signerAddress string, nonce uint64) error
}

type nonceStorage struct {
	kv newstorage.KVStore[string, uint64]
}

func NewNonceStorage(opts *redis.Options) NextNonceStorage {
	return &nonceStorage{
		kv: redis2.NewRedisStorage[string, uint64](opts),
	}
}

func (n *nonceStorage) UseNonce(signerAddress string, nonce uint64) error {
	key := "NONCE-" + signerAddress
	batch := n.kv.NewBatch()

	// Queue a set operation to be executed in a Redis transaction when Commit is called.
	err := batch.Set(key, nonce)
	if err != nil {
		return err
	}

	// Commit the batch to Redis
	err = batch.Commit()
	if err != nil {
		return err
	}

	return nil
}
```

