### PR TITLE
ci: add swagger check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
       - "docs/**"
 
 env:
-  GO_VERSION: 1.21.0
+  GO_VERSION: 1.22.1
 
 jobs:
   e2e:
@@ -76,6 +76,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: Setup Golang
+        uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          ## skip cache, use Namespace volume cache
+          cache: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Run swagger-check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,13 @@ jobs:
         with:
           fail_ci_if_error: true
           directory: "./"
+  swagger-check:
+    name: Swagger check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Run swagger-check
+        run: make swagger-check

--- a/cardinal/server/docs/docs.go
+++ b/cardinal/server/docs/docs.go
@@ -209,16 +209,14 @@ const docTemplate = `{
         },
         "/tx/game/{txType}": {
             "post": {
-                "description": "Submit a transaction to Cardinal\nCreate a Persona transaction to Cardinal",
+                "description": "Submit a transaction to Cardinal / Create a Persona transaction to Cardinal",
                 "consumes": [
-                    "application/json",
                     "application/json"
                 ],
                 "produces": [
-                    "application/json",
                     "application/json"
                 ],
-                "summary": "Create a Persona transaction to Cardinal",
+                "summary": "Submit a transaction to Cardinal",
                 "parameters": [
                     {
                         "type": "string",
@@ -255,16 +253,14 @@ const docTemplate = `{
         },
         "/tx/persona/create-persona": {
             "post": {
-                "description": "Submit a transaction to Cardinal\nCreate a Persona transaction to Cardinal",
+                "description": "Submit a transaction to Cardinal / Create a Persona transaction to Cardinal",
                 "consumes": [
-                    "application/json",
                     "application/json"
                 ],
                 "produces": [
-                    "application/json",
                     "application/json"
                 ],
-                "summary": "Create a Persona transaction to Cardinal",
+                "summary": "Submit a transaction to Cardinal",
                 "parameters": [
                     {
                         "description": "Transaction details",
@@ -403,6 +399,9 @@ const docTemplate = `{
                 },
                 "name": {
                     "description": "name of the message or query",
+                    "type": "string"
+                },
+                "url": {
                     "type": "string"
                 }
             }

--- a/cardinal/server/docs/swagger.json
+++ b/cardinal/server/docs/swagger.json
@@ -206,16 +206,14 @@
         },
         "/tx/game/{txType}": {
             "post": {
-                "description": "Submit a transaction to Cardinal\nCreate a Persona transaction to Cardinal",
+                "description": "Submit a transaction to Cardinal / Create a Persona transaction to Cardinal",
                 "consumes": [
-                    "application/json",
                     "application/json"
                 ],
                 "produces": [
-                    "application/json",
                     "application/json"
                 ],
-                "summary": "Create a Persona transaction to Cardinal",
+                "summary": "Submit a transaction to Cardinal",
                 "parameters": [
                     {
                         "type": "string",
@@ -252,16 +250,14 @@
         },
         "/tx/persona/create-persona": {
             "post": {
-                "description": "Submit a transaction to Cardinal\nCreate a Persona transaction to Cardinal",
+                "description": "Submit a transaction to Cardinal / Create a Persona transaction to Cardinal",
                 "consumes": [
-                    "application/json",
                     "application/json"
                 ],
                 "produces": [
-                    "application/json",
                     "application/json"
                 ],
-                "summary": "Create a Persona transaction to Cardinal",
+                "summary": "Submit a transaction to Cardinal",
                 "parameters": [
                     {
                         "description": "Transaction details",
@@ -400,6 +396,9 @@
                 },
                 "name": {
                     "description": "name of the message or query",
+                    "type": "string"
+                },
+                "url": {
                     "type": "string"
                 }
             }

--- a/cardinal/server/docs/swagger.yaml
+++ b/cardinal/server/docs/swagger.yaml
@@ -56,6 +56,8 @@ definitions:
       name:
         description: name of the message or query
         type: string
+      url:
+        type: string
     type: object
   handler.GetEndpointsResponse:
     properties:
@@ -257,10 +259,8 @@ paths:
     post:
       consumes:
       - application/json
-      - application/json
-      description: |-
-        Submit a transaction to Cardinal
-        Create a Persona transaction to Cardinal
+      description: Submit a transaction to Cardinal / Create a Persona transaction
+        to Cardinal
       parameters:
       - description: label of the transaction that wants to be submitted
         in: path
@@ -275,7 +275,6 @@ paths:
           $ref: '#/definitions/handler.Transaction'
       produces:
       - application/json
-      - application/json
       responses:
         "200":
           description: OK
@@ -285,15 +284,13 @@ paths:
           description: Invalid transaction request
           schema:
             type: string
-      summary: Create a Persona transaction to Cardinal
+      summary: Submit a transaction to Cardinal
   /tx/persona/create-persona:
     post:
       consumes:
       - application/json
-      - application/json
-      description: |-
-        Submit a transaction to Cardinal
-        Create a Persona transaction to Cardinal
+      description: Submit a transaction to Cardinal / Create a Persona transaction
+        to Cardinal
       parameters:
       - description: Transaction details
         in: body
@@ -303,7 +300,6 @@ paths:
           $ref: '#/definitions/handler.Transaction'
       produces:
       - application/json
-      - application/json
       responses:
         "200":
           description: OK
@@ -313,7 +309,7 @@ paths:
           description: Invalid transaction request
           schema:
             type: string
-      summary: Create a Persona transaction to Cardinal
+      summary: Submit a transaction to Cardinal
   /world:
     get:
       consumes:

--- a/cardinal/server/handler/cql.go
+++ b/cardinal/server/handler/cql.go
@@ -25,13 +25,13 @@ type CQLQueryResponse struct {
 }
 
 // PostCQL godoc
-// @Summary		Query the ecs with CQL (cardinal query language)
-// @Description	Query the ecs with CQL (cardinal query language)
-// @Accept		application/json
-// @Produce		application/json
-// @Param		cql	body		CQLQueryRequest	true	"cql (cardinal query language)"
-// @Success		200	{object}	CQLQueryResponse
-// @Router		/cql [post]
+//	@Summary		Query the ecs with CQL (cardinal query language)
+//	@Description	Query the ecs with CQL (cardinal query language)
+//	@Accept			application/json
+//	@Produce		application/json
+//	@Param			cql	body		CQLQueryRequest	true	"cql (cardinal query language)"
+//	@Success		200	{object}	CQLQueryResponse
+//	@Router			/cql [post]
 func PostCQL(provider servertypes.Provider) func(*fiber.Ctx) error { //nolint:gocognit // to refactor later
 	return func(ctx *fiber.Ctx) error {
 		req := new(CQLQueryRequest)

--- a/cardinal/server/handler/cql.go
+++ b/cardinal/server/handler/cql.go
@@ -25,6 +25,7 @@ type CQLQueryResponse struct {
 }
 
 // PostCQL godoc
+//
 //	@Summary		Query the ecs with CQL (cardinal query language)
 //	@Description	Query the ecs with CQL (cardinal query language)
 //	@Accept			application/json

--- a/cardinal/server/handler/tx.go
+++ b/cardinal/server/handler/tx.go
@@ -31,24 +31,21 @@ type Transaction = sign.Transaction
 // PostTransaction godoc
 //
 //	@Summary		Submit a transaction to Cardinal
-//	@Description	Submit a transaction to Cardinal
+//	@Description	Submit a transaction to Cardinal / Create a Persona transaction to Cardinal
 //	@Accept			application/json
 //	@Produce		application/json
-//	@Param			txType	path		string	true	"label of the transaction that wants to be submitted"
-//	@Success		200		{object}	PostTransactionResponse
-//	@Failure		400		{string}	string	"Invalid transaction request"
+//	@Success		200	{object}	PostTransactionResponse
+//	@Failure		400	{string}	string	"Invalid transaction request"
+//
+// PostTransaction with label godoc
+//
 //	@Router			/tx/game/{txType} [post]
+//	@Param			txType	path	string	true	"label of the transaction that wants to be submitted"
 //
 // PostTransaction with Persona godoc
 //
-//	@Summary		Create a Persona transaction to Cardinal
-//	@Description	Create a Persona transaction to Cardinal
-//	@Accept			application/json
-//	@Produce		application/json
-//	@Param			txBody	body		Transaction	true	"Transaction details"
-//	@Success		200		{object}	PostTransactionResponse
-//	@Failure		400		{string}	string	"Invalid transaction request"
 //	@Router			/tx/persona/create-persona [post]
+//	@Param			txBody	body	Transaction	true	"Transaction details"
 func PostTransaction(
 	provider servertypes.Provider, msgs map[string]map[string]types.Message, disableSigVerification bool,
 ) func(*fiber.Ctx) error {

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -92,14 +92,20 @@ swaggo-install:
 	go install github.com/swaggo/swag/cmd/swag@latest
 
 swagger:
+	$(MAKE) swaggo-install
 	swag init -g cardinal/server/server.go -o cardinal/server/docs/
 
 swagger-check:
 	$(MAKE) swaggo-install
 
-	echo "--> Generate latest Swagger specs"
-	mkdir -p /tmp/swagger-compare
-	swag init -g cardinal/server/server.go -o /tmp/swagger-compare
+	@echo "--> Generate latest Swagger specs"
+	mkdir -p .tmp/swagger
+	swag init -g cardinal/server/server.go -o .tmp/swagger
 
-	echo "--> Compare Swagger latest spec"
-	swagger-diff cardinal/server/docs/swagger.json /tmp/swagger-compare/swagger.json
+	@echo "--> Compare existing and latest Swagger specs"
+	docker run -it --rm -v ./:/local-repo ghcr.io/argus-labs/devops-infra-swagger-diff:2.0.0 \
+		/local-repo/cardinal/server/docs/swagger.json /local-repo/.tmp/swagger/swagger.json && \
+		echo "swagger-dif: no changes in swagger specs"
+
+	@echo "--> Cleanup"
+	rm -rf .tmp/swagger

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -85,6 +85,21 @@ unit-test-all:
 #################
 #   swagger	    #
 #################
+.PHONY: swaggo-install
+
+swaggo-install:
+	echo "--> Installing swaggo/swag cli"
+	go install github.com/swaggo/swag/cmd/swag@latest
+
 swagger:
 	swag init -g cardinal/server/server.go -o cardinal/server/docs/
 
+swagger-check:
+	$(MAKE) swaggo-install
+
+	echo "--> Generate latest Swagger specs"
+	mkdir -p /tmp/swagger-compare
+	swag init -g cardinal/server/server.go -o /tmp/swagger-compare
+
+	echo "--> Compare Swagger latest spec"
+	swagger-diff cardinal/server/docs/swagger.json /tmp/swagger-compare/swagger.json

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -105,7 +105,7 @@ swagger-check:
 	@echo "--> Compare existing and latest Swagger specs"
 	docker run --rm -v ./:/local-repo ghcr.io/argus-labs/devops-infra-swagger-diff:2.0.0 \
 		/local-repo/cardinal/server/docs/swagger.json /local-repo/.tmp/swagger/swagger.json && \
-		echo "swagger-dif: no changes in swagger specs"
+		echo "swagger-diff: no changes detected"
 
 	@echo "--> Cleanup"
 	rm -rf .tmp/swagger

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -103,7 +103,7 @@ swagger-check:
 	swag init -g cardinal/server/server.go -o .tmp/swagger
 
 	@echo "--> Compare existing and latest Swagger specs"
-	docker run -it --rm -v ./:/local-repo ghcr.io/argus-labs/devops-infra-swagger-diff:2.0.0 \
+	docker run --rm -v ./:/local-repo ghcr.io/argus-labs/devops-infra-swagger-diff:2.0.0 \
 		/local-repo/cardinal/server/docs/swagger.json /local-repo/.tmp/swagger/swagger.json && \
 		echo "swagger-dif: no changes in swagger specs"
 


### PR DESCRIPTION
Closes: WORLD-925

## Overview

Do Swagger specs check to make sure it doesn't change.

## Brief Changelog

- Add `make swagger-check`: perform a diff check between the existing and newly generated swagger specs from the latest changes.
- Add `make swaggo-install`: install swag-cli to generate swagger specs files.
- Add CI action to execute swagger-check on PR event. 
- Fix swaggo annotation issue on function with multiple API operations (`cardinal/server/handler/tx.go`, `PostTransaction`) 
--> Swaggo supports multiple `@Router` on a single function, but multiple defined annotations like `@Summary`, and `@Accept`,`@Produce` with same value causing a double and overridden and invalid swagger specification format. 
(I put the details in the review comments below https://github.com/Argus-Labs/world-engine/pull/698#discussion_r1532703826)

## Testing and Verifying

- Run `make swagger-check` locally, it will create temporary generated swagger files at `.tmp/swagger` directory, then do a comparison vs existing swagger spec files on `cardinal/server/docs/swagger.json`.
- If no changes are detected, the command will exit and print `swagger-diff: no changes detected`.
- If changes are detected, it will return an error message indicating the difference.

--> Example when an endpoint is missing & request params is different:

![image](https://github.com/Argus-Labs/world-engine/assets/29672212/a5b7a807-60e3-4bef-8a4d-3f9eb2ba6df8)
