### PR TITLE
feat: add namespace to /world endpoint

### DIFF
--- a/cardinal/server/handler/world.go
+++ b/cardinal/server/handler/world.go
@@ -11,6 +11,7 @@ import (
 )
 
 type GetWorldResponse struct {
+	Namespace  string        `json:"namespace"`
 	Components []FieldDetail `json:"components"` // list of component names
 	Messages   []FieldDetail `json:"messages"`
 	Queries    []FieldDetail `json:"queries"`
@@ -33,7 +34,7 @@ type FieldDetail struct {
 //	@Router			/world [get]
 func GetWorld(
 	components []types.ComponentMetadata, messages []types.Message,
-	queries []engine.Query,
+	queries []engine.Query, namespace string,
 ) func(*fiber.Ctx) error {
 	// Collecting name of all registered components
 	comps := make([]FieldDetail, 0, len(components))
@@ -63,12 +64,13 @@ func GetWorld(
 		queriesFields = append(queriesFields, FieldDetail{
 			Name:   query.Name(),
 			Fields: query.GetRequestFieldInformation(),
-			URL:    utils.GetTxURL(query.Group(), query.Name()),
+			URL:    utils.GetQueryURL(query.Group(), query.Name()),
 		})
 	}
 
 	return func(ctx *fiber.Ctx) error {
 		return ctx.JSON(GetWorldResponse{
+			Namespace:  namespace,
 			Components: comps,
 			Messages:   messagesFields,
 			Queries:    queriesFields,

--- a/cardinal/server/server.go
+++ b/cardinal/server/server.go
@@ -157,7 +157,7 @@ func (s *Server) setupRoutes(
 	s.app.Get("/events", handler.WebSocketEvents())
 
 	// Route: /world
-	s.app.Get("/world", handler.GetWorld(components, messages, queries))
+	s.app.Get("/world", handler.GetWorld(components, messages, queries, wCtx.Namespace()))
 
 	// Route: /...
 	s.app.Get("/health", handler.GetHealth())

--- a/cardinal/server/server_test.go
+++ b/cardinal/server/server_test.go
@@ -148,6 +148,7 @@ func (s *ServerTestSuite) TestGetWorld() {
 			return query.Name() == field.Name
 		}))
 	}
+	assert.Equal(s.T(), s.world.Namespace(), result.Namespace)
 }
 
 // TestSwaggerEndpointsAreActuallyCreated verifies the non-variable endpoints that are declared in the swagger.yml file


### PR DESCRIPTION
Closes: WORLD-976

## Overview

Add cardinal namespace to /world endpoint

## Brief Changelog

- modify return value and param for GetWorld func

## Testing and Verifying

- Adjust unit test to assert namespace
- Manually test the result

```
{
    "namespace": "world-1",
    "components": [
        {
            "name": "SignerComponent",
            "fields": {
                "AuthorizedAddresses": "[]string",
                "PersonaTag": "string",
                "SignerAddress": "string"
            }
        },
        {
            "name": "Player",
            "fields": {
                "Nickname": "string"
            }
        },
        {
            "name": "Health",
            "fields": {
                "HP": "int"
            }
        }
    ],
    "messages": [
        {
            "name": "create-persona",
            "fields": {
                "PersonaTag": "string",
                "SignerAddress": "string"
            },
            "url": "/tx/persona/create-persona"
        },
        {
            "name": "authorize-persona-address",
            "fields": {
                "Address": "string"
            },
            "url": "/tx/game/authorize-persona-address"
        },
        {
            "name": "create-player",
            "fields": {
                "Nickname": "string"
            },
            "url": "/tx/game/create-player"
        },
        {
            "name": "attack-player",
            "fields": {
                "TargetNickname": "string"
            },
            "url": "/tx/game/attack-player"
        }
    ],
    "queries": [
        {
            "name": "player-health",
            "fields": {
                "Nickname": "string"
            },
            "url": "/query/game/player-health"
        },
        {
            "name": "signer",
            "fields": {
                "PersonaTag": "string",
                "Tick": "uint64"
            },
            "url": "/query/persona/signer"
        },
        {
            "name": "state",
            "fields": {},
            "url": "/query/debug/state"
        },
        {
            "name": "list",
            "fields": {
                "StartTick": "uint64"
            },
            "url": "/query/receipts/list"
        }
    ]
}
```
