### PR TITLE
feat(cardinal): add property filtering capabilities to search.

### DIFF
--- a/cardinal/search/search.go
+++ b/cardinal/search/search.go
@@ -45,7 +45,7 @@ func NewSearch(wCtx engine.Context, filter filter.ComponentFilter) *Search {
 	}
 }
 
-func (s *Search) Filter(callback func(id types.EntityID) bool) *Search {
+func (s *Search) FilterSelect(callback func(id types.EntityID) bool) *Search {
 	s.filterFuncs = append(s.filterFuncs, callback)
 	return s
 }

--- a/cardinal/search/search.go
+++ b/cardinal/search/search.go
@@ -45,7 +45,7 @@ func NewSearch(wCtx engine.Context, filter filter.ComponentFilter) *Search {
 	}
 }
 
-func (s *Search) FilterSelect(callback func(id types.EntityID) bool) *Search {
+func (s *Search) Where(callback func(id types.EntityID) bool) *Search {
 	s.filterFuncs = append(s.filterFuncs, callback)
 	return s
 }

--- a/cardinal/search/search_test.go
+++ b/cardinal/search/search_test.go
@@ -103,7 +103,7 @@ func TestSearchExample(t *testing.T) {
 		assert.NilError(t, err, msg)
 		assert.Equal(t, tc.want, count, msg)
 	}
-	amount, err := cardinal.NewSearch(worldCtx, filter.Exact(Alpha{}, Beta{})).FilterSelect(func(_ types.EntityID) bool {
+	amount, err := cardinal.NewSearch(worldCtx, filter.Exact(Alpha{}, Beta{})).Where(func(_ types.EntityID) bool {
 		return false
 	}).Count()
 	assert.NilError(t, err)
@@ -113,11 +113,11 @@ func TestSearchExample(t *testing.T) {
 
 	err =
 		cardinal.NewSearch(worldCtx, filter.Exact(Alpha{})).
-			FilterSelect(func(_ types.EntityID) bool { return true }).
-			FilterSelect(func(_ types.EntityID) bool { return true }).
-			FilterSelect(func(_ types.EntityID) bool { return true }).
-			FilterSelect(func(_ types.EntityID) bool { return true }).
-			FilterSelect(func(_ types.EntityID) bool { return true }).
+			Where(func(_ types.EntityID) bool { return true }).
+			Where(func(_ types.EntityID) bool { return true }).
+			Where(func(_ types.EntityID) bool { return true }).
+			Where(func(_ types.EntityID) bool { return true }).
+			Where(func(_ types.EntityID) bool { return true }).
 			Each(func(id types.EntityID) bool {
 				comp, err := cardinal.GetComponent[Alpha](worldCtx, id)
 				assert.NilError(t, err)
@@ -131,7 +131,7 @@ func TestSearchExample(t *testing.T) {
 			})
 	assert.NilError(t, err)
 	amount, err = cardinal.NewSearch(worldCtx, filter.Exact(Alpha{})).
-		FilterSelect(func(id types.EntityID) bool {
+		Where(func(id types.EntityID) bool {
 			comp, err := cardinal.GetComponent[Alpha](worldCtx, id)
 			assert.NilError(t, err)
 			return comp.Name1 == "BLAH"

--- a/cardinal/search/search_test.go
+++ b/cardinal/search/search_test.go
@@ -103,7 +103,7 @@ func TestSearchExample(t *testing.T) {
 		assert.NilError(t, err, msg)
 		assert.Equal(t, tc.want, count, msg)
 	}
-	amount, err := cardinal.NewSearch(worldCtx, filter.Exact(Alpha{}, Beta{})).Filter(func(_ types.EntityID) bool {
+	amount, err := cardinal.NewSearch(worldCtx, filter.Exact(Alpha{}, Beta{})).FilterSelect(func(_ types.EntityID) bool {
 		return false
 	}).Count()
 	assert.NilError(t, err)
@@ -113,11 +113,11 @@ func TestSearchExample(t *testing.T) {
 
 	err =
 		cardinal.NewSearch(worldCtx, filter.Exact(Alpha{})).
-			Filter(func(_ types.EntityID) bool { return true }).
-			Filter(func(_ types.EntityID) bool { return true }).
-			Filter(func(_ types.EntityID) bool { return true }).
-			Filter(func(_ types.EntityID) bool { return true }).
-			Filter(func(_ types.EntityID) bool { return true }).
+			FilterSelect(func(_ types.EntityID) bool { return true }).
+			FilterSelect(func(_ types.EntityID) bool { return true }).
+			FilterSelect(func(_ types.EntityID) bool { return true }).
+			FilterSelect(func(_ types.EntityID) bool { return true }).
+			FilterSelect(func(_ types.EntityID) bool { return true }).
 			Each(func(id types.EntityID) bool {
 				comp, err := cardinal.GetComponent[Alpha](worldCtx, id)
 				assert.NilError(t, err)
@@ -131,7 +131,7 @@ func TestSearchExample(t *testing.T) {
 			})
 	assert.NilError(t, err)
 	amount, err = cardinal.NewSearch(worldCtx, filter.Exact(Alpha{})).
-		Filter(func(id types.EntityID) bool {
+		FilterSelect(func(id types.EntityID) bool {
 			comp, err := cardinal.GetComponent[Alpha](worldCtx, id)
 			assert.NilError(t, err)
 			return comp.Name1 == "BLAH"


### PR DESCRIPTION
Closes: WORLD-617

this allows users to use search like this with chained filters:

```go
amount, err = cardinal.NewSearch(worldCtx, filter.Exact(Alpha{})).
		FilterSelect(func(id types.EntityID) bool {
			comp, err := cardinal.GetComponent[Alpha](worldCtx, id)
			assert.NilError(t, err)
			return comp.Name1 == "BLAH"
		}).Count()
```

FilterSelects can be chained on top of a Search object an unlimited amount of times. This brings the search api more inline with functional programming paradigms where we have map, reduce, filter, and foreach. With golang, only filter and foreach are possible as chainable methods. Map/Reduce will require functions as they are generic. 

The secondary purpose for adding this feature is to pave the way for filters to be a compile target for High level CQL syntax that allows filtering components based off of properties. the new filterFuncs property contains target functions for compilation. While this CQL syntax doesn't exist yet, it could in the future. 

Typically this method `FilterSelect` is just called `Filter` in almost all programming languages and frameworks. However our ECS concept of `filters` collides with this name so I chose the term: `FilterSelect`. 

changes:
- added filterFuncs property to *Search
- modified Count() to take into account filterFuncs
- modified Each to take into account filterFuncs
- modified First to take into account filterFuncs
- added new FilterSelect method