### PR TITLE
refactor(cardinal): clean up mock redis flow

### DIFF
--- a/.github/workflows/lint-go.yml
+++ b/.github/workflows/lint-go.yml
@@ -2,7 +2,7 @@ name: Lint
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [ opened, synchronize, reopened, ready_for_review ]
     paths-ignore:
       - "docs/**"
   push:
@@ -44,7 +44,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.56.2
-          args: --timeout=10m --concurrency 8 -v ${{ steps.go-dir.outputs.path }}
+          version: v1.57.1
+          args: --timeout=10m -v ${{ steps.go-dir.outputs.path }}
           ## skip cache, use Namespace volume cache
           skip-cache: true

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -113,7 +113,7 @@ linters-settings:
   nolintlint:
     # Exclude following linters from requiring an explanation.
     # Default: []
-    allow-no-explanation: [ funlen, gocognit, lll, exhaustruct, decorder ]
+    allow-no-explanation: [ funlen, gocognit, lll, exhaustruct, decorder, gomnd ]
     # Enable to require an explanation of nonzero length after each nolint directive.
     # Default: false
     require-explanation: true

--- a/cardinal/component/component_test.go
+++ b/cardinal/component/component_test.go
@@ -3,8 +3,6 @@ package component_test
 import (
 	"testing"
 
-	"github.com/alicebob/miniredis/v2"
-
 	"pkg.world.dev/world-engine/assert"
 	"pkg.world.dev/world-engine/cardinal"
 	"pkg.world.dev/world-engine/cardinal/iterators"
@@ -340,16 +338,13 @@ func (NewComponent) Name() string {
 }
 
 func TestRegisterComponent_ErrorOnSchemaMismatch(t *testing.T) {
-	// We create a miniredis instance to reuse across the two world instance
-	redis := miniredis.RunT(t)
-
 	// Create first world, this should work normally
-	tf1 := testutils.NewTestFixture(t, redis)
+	tf1 := testutils.NewTestFixture(t, nil)
 	world := tf1.World
 	assert.NilError(t, cardinal.RegisterComponent[OldComponent](world))
 
 	// Create second world, this should fail because the schema of the new component does not match the old component
-	tf2 := testutils.NewTestFixture(t, redis)
+	tf2 := testutils.NewTestFixture(t, tf1.Redis)
 	world = tf2.World
 	assert.ErrorContains(t, cardinal.RegisterComponent[NewComponent](world),
 		"component schema does not match target schema")

--- a/cardinal/ecs_test.go
+++ b/cardinal/ecs_test.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"testing"
 
-	"github.com/alicebob/miniredis/v2"
-
 	"pkg.world.dev/world-engine/assert"
 	"pkg.world.dev/world-engine/cardinal"
 	"pkg.world.dev/world-engine/cardinal/iterators"
@@ -100,21 +98,6 @@ func UpdateEnergySystem(wCtx engine.Context) error {
 		return errors.Join(errs...)
 	}
 	return nil
-}
-
-func TestSchemaChecking(t *testing.T) {
-	s := miniredis.RunT(t)
-
-	tf1 := testutils.NewTestFixture(t, s)
-	world1 := tf1.World
-	assert.NilError(t, cardinal.RegisterComponent[EnergyComponent](world1))
-	assert.NilError(t, cardinal.RegisterComponent[OwnableComponent](world1))
-	tf1.StartWorld()
-
-	tf2 := testutils.NewTestFixture(t, s)
-	world2 := tf2.World
-	assert.NilError(t, cardinal.RegisterComponent[OwnableComponent](world2))
-	assert.Assert(t, cardinal.RegisterComponent[AlteredEnergyComponent](world2) != nil)
 }
 
 func TestECS(t *testing.T) {

--- a/cardinal/errors_test.go
+++ b/cardinal/errors_test.go
@@ -6,8 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/alicebob/miniredis/v2"
-
 	"pkg.world.dev/world-engine/assert"
 	"pkg.world.dev/world-engine/cardinal"
 	"pkg.world.dev/world-engine/cardinal/component"
@@ -321,8 +319,7 @@ func TestQueriesDoNotPanicOnComponentHasNotBeenRegistered(t *testing.T) {
 }
 
 func TestGetComponentInQueryDoesNotPanicOnRedisError(t *testing.T) {
-	miniRedis := miniredis.RunT(t)
-	tf := testutils.NewTestFixture(t, miniRedis)
+	tf := testutils.NewTestFixture(t, nil)
 	world, tick := tf.World, tf.DoTick
 	assert.NilError(t, cardinal.RegisterComponent[Foo](world))
 
@@ -351,7 +348,7 @@ func TestGetComponentInQueryDoesNotPanicOnRedisError(t *testing.T) {
 	assert.NilError(t, err)
 
 	// Uhoh, redis is now broken.
-	miniRedis.Close()
+	tf.Redis.Close()
 
 	readOnlyWorldCtx := cardinal.NewReadOnlyWorldContext(world)
 	// This will fail with a redis connection error, and since we're in a Query, we should NOT panic

--- a/cardinal/example_messagetype_test.go
+++ b/cardinal/example_messagetype_test.go
@@ -21,7 +21,7 @@ type MovePlayerResult struct {
 }
 
 func ExampleMessageType() {
-	world, err := cardinal.NewMockWorld()
+	world, err := cardinal.NewWorld(cardinal.WithMockRedis())
 	if err != nil {
 		panic(err)
 	}

--- a/cardinal/option_test.go
+++ b/cardinal/option_test.go
@@ -19,7 +19,6 @@ func TestOptionFunctionSignatures(_ *testing.T) {
 	// public facing functions was changed.
 	cardinal.WithReceiptHistorySize(1)
 	cardinal.WithCustomLogger(zerolog.New(os.Stdout))
-	cardinal.WithCustomMockRedis(nil)
 	cardinal.WithPort("")
 	cardinal.WithPrettyLog() //nolint:staticcheck // not applicable.
 }

--- a/cardinal/server/event_test.go
+++ b/cardinal/server/event_test.go
@@ -36,7 +36,7 @@ func (Beta) Name() string { return "beta" }
 
 func TestEventsThroughSystems(t *testing.T) {
 	numberToTest := 5
-	tf := testutils.NewTestFixtureWithPort(t, nil, "1338", cardinal.WithDisableSignatureVerification())
+	tf := testutils.NewTestFixture(t, nil, cardinal.WithDisableSignatureVerification())
 	world, addr := tf.World, tf.BaseURL
 	assert.NilError(t, cardinal.RegisterMessage[SendEnergyTx, SendEnergyTxResult](world, "send-energy"))
 	counter1 := atomic.Int32{}

--- a/cardinal/system/manager.go
+++ b/cardinal/system/manager.go
@@ -93,7 +93,7 @@ func (m *Manager) registerSystems(isInit bool, systems ...System) error {
 func (m *Manager) RunSystems(wCtx engine.Context) error {
 	var systemsToRun []string
 	if wCtx.CurrentTick() == 0 {
-		//nolint:gocritic,appendAssign // We need to use the append function to concat
+		//nolint:gocritic // We need to use the append function to concat
 		systemsToRun = append(m.registeredInitSystems, m.registeredSystems...)
 	} else {
 		systemsToRun = m.registeredSystems

--- a/cardinal/tick_test.go
+++ b/cardinal/tick_test.go
@@ -3,8 +3,6 @@ package cardinal_test
 import (
 	"testing"
 
-	"github.com/alicebob/miniredis/v2"
-
 	"pkg.world.dev/world-engine/assert"
 	"pkg.world.dev/world-engine/cardinal"
 	"pkg.world.dev/world-engine/cardinal/search/filter"
@@ -28,8 +26,7 @@ func (ScalarComponentBeta) Name() string {
 }
 
 func TestTickHappyPath(t *testing.T) {
-	rs := miniredis.RunT(t)
-	tf1 := testutils.NewTestFixture(t, rs)
+	tf1 := testutils.NewTestFixture(t, nil)
 	world1 := tf1.World
 	assert.NilError(t, cardinal.RegisterComponent[EnergyComponent](world1))
 	tf1.StartWorld()
@@ -40,7 +37,7 @@ func TestTickHappyPath(t *testing.T) {
 
 	assert.Equal(t, uint64(10), world1.CurrentTick())
 
-	tf2 := testutils.NewTestFixture(t, rs)
+	tf2 := testutils.NewTestFixture(t, tf1.Redis)
 	world2 := tf2.World
 	assert.NilError(t, cardinal.RegisterComponent[EnergyComponent](world2))
 	tf2.StartWorld()

--- a/cardinal/world_test.go
+++ b/cardinal/world_test.go
@@ -38,7 +38,6 @@ func TestIfPanicMessageLogged(t *testing.T) {
 	bufLogger := zerolog.New(&buf)
 
 	world, err := NewWorld(
-		WithCustomMockRedis(miniRedis),
 		WithTickChannel(neverTick),
 		WithPort(getOpenPort(t)),
 		WithCustomLogger(bufLogger),

--- a/makefiles/ci.mk
+++ b/makefiles/ci.mk
@@ -2,21 +2,31 @@
 # golangci-lint #
 #################
 
-golangci_version=v1.56.2
+lint_version=v1.57.1
 
 lint-install:
-	@echo "--> Installing golangci-lint $(golangci_version)"
-	@go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(golangci_version)
-
+	@echo "--> Checking if golangci-lint $(lint_version) is installed"
+	@if [ $$(golangci-lint --version 2> /dev/null | awk '{print $$4}') != "$(lint_version)" ]; then \
+		echo "--> Installing golangci-lint $(lint_version)"; \
+		go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(lint_version); \
+	else \
+		echo "--> golangci-lint $(lint_version) is already installed"; \
+	fi
+	
 lint:
 	@$(MAKE) lint-install
 	@echo "--> Running linter"
-	@go list -f '{{.Dir}}/...' -m | xargs golangci-lint run  --timeout=10m --concurrency 8 -v
+	@go list -f '{{.Dir}}/...' -m | xargs golangci-lint run --timeout=10m -v
+
+lint-cardinal:
+	@$(MAKE) lint-install
+	@echo "--> Running linter only on ./cardinal"
+	@golangci-lint run cardinal/... --timeout=10m -v
 
 lint-fix:
 	@$(MAKE) lint-install
 	@echo "--> Running linter"
-	@go list -f '{{.Dir}}/...' -m | xargs golangci-lint run  --timeout=10m --fix --concurrency 8 -v
+	@go list -f '{{.Dir}}/...' -m | xargs golangci-lint run --timeout=10m --fix -v
 
 
 .PHONY: tidy


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

This PR cleans up the way we are we are using miniredis in the hope of fixing the flaky test.

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

- Remove `NewMockWorld` in favor of using a `WithMockRedis` option
- Let miniredis cleans up itself after tests using `miniredis.RunT(...)`
- Remove `World.cleanup` since we no longer have a use for it 
- Remove `TestSchemaChecking` as it does the same thing with `TestRegisterComponent_ErrorOnSchemaMismatch`
- `make lint` improvements
	- Check if the correct version of the linter is already before trying to install again
	- Remove the concurrency declaration that is preventing the CI from using all cores
	- Add `lint-cardinal` for scoped linting 

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->

- Updated tests accordingly