### PR TITLE
refactor(cardinal): make world config more robust

### DIFF
--- a/cardinal/config.go
+++ b/cardinal/config.go
@@ -1,8 +1,15 @@
 package cardinal
 
 import (
+	"net"
+	"os"
+	"slices"
+	"strings"
+
 	"github.com/JeremyLoy/config"
 	"github.com/rotisserie/eris"
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 )
 
 const (
@@ -17,6 +24,14 @@ const (
 	DefaultLogLevel      = "info"
 	DefaultStatsdAddress = "localhost:8125"
 )
+
+var validLogLevels = []string{
+	zerolog.DebugLevel.String(),
+	zerolog.InfoLevel.String(),
+	zerolog.WarnLevel.String(),
+	zerolog.ErrorLevel.String(),
+	zerolog.Disabled.String(),
+}
 
 var defaultConfig = WorldConfig{
 	RedisAddress:              DefaultRedisAddress,
@@ -33,39 +48,108 @@ var defaultConfig = WorldConfig{
 type RunMode string
 
 type WorldConfig struct {
-	RedisAddress              string  `config:"REDIS_ADDRESS"`
-	RedisPassword             string  `config:"REDIS_PASSWORD"`
-	CardinalNamespace         string  `config:"CARDINAL_NAMESPACE"`
-	CardinalMode              RunMode `config:"CARDINAL_MODE"`
-	BaseShardSequencerAddress string  `config:"BASE_SHARD_SEQUENCER_ADDRESS"`
-	BaseShardQueryAddress     string  `config:"BASE_SHARD_QUERY_ADDRESS"`
-	CardinalLogLevel          string  `config:"CARDINAL_LOG_LEVEL"`
-	StatsdAddress             string  `config:"STATSD_ADDRESS"`
-	TraceAddress              string  `config:"TRACE_ADDRESS"`
+	// Cardinal
+	CardinalMode      RunMode `config:"CARDINAL_MODE"`
+	CardinalNamespace string  `config:"CARDINAL_NAMESPACE"`
+	CardinalLogLevel  string  `config:"CARDINAL_LOG_LEVEL"`
+
+	// Redis
+	RedisAddress  string `config:"REDIS_ADDRESS"`
+	RedisPassword string `config:"REDIS_PASSWORD"`
+
+	// Shard networking
+	BaseShardSequencerAddress string `config:"BASE_SHARD_SEQUENCER_ADDRESS"`
+	BaseShardQueryAddress     string `config:"BASE_SHARD_QUERY_ADDRESS"`
+
+	// Telemetry
+	StatsdAddress string `config:"STATSD_ADDRESS"`
+	TraceAddress  string `config:"TRACE_ADDRESS"`
 }
 
-func (w WorldConfig) Validate() error {
-	if w.CardinalMode != RunModeProd {
-		return nil
+func loadWorldConfig() (*WorldConfig, error) {
+	cfg := defaultConfig
+
+	// Load config from environment variables
+	if err := config.FromEnv().To(&cfg); err != nil {
+		return nil, eris.Wrap(err, "Failed to load config")
 	}
-	if w.RedisPassword == "" {
-		return eris.New("REDIS_PASSWORD is required in production")
+
+	// Validate config
+	if err := cfg.Validate(); err != nil {
+		return nil, eris.Wrap(err, "Invalid config")
 	}
-	if w.CardinalNamespace == DefaultNamespace {
-		return eris.New("CARDINAL_NAMESPACE cannot be the default value in production to avoid replay attack")
+
+	// Set logger config
+	if err := cfg.setLogger(); err != nil {
+		return nil, eris.Wrap(err, "Failed to set log level")
 	}
-	if w.BaseShardSequencerAddress == "" || w.BaseShardQueryAddress == "" {
-		return eris.New("must supply BASE_SHARD_SEQUENCER_ADDRESS and BASE_SHARD_QUERY_ADDRESS for production " +
-			"mode Cardinal worlds")
+
+	return &cfg, nil
+}
+
+func (w *WorldConfig) Validate() error {
+	// Validate run mode
+	if w.CardinalMode != RunModeProd && w.CardinalMode != RunModeDev {
+		return eris.Errorf("CARDINAL_MODE must be either %q or %q", RunModeProd, RunModeDev)
 	}
+
+	// Validate production mode configs
+	if w.CardinalMode == RunModeProd {
+		// Validate that Redis password is set
+		if w.RedisPassword == "" {
+			return eris.New("REDIS_PASSWORD must be set in production mode")
+		}
+		// Validate shard networking config
+		if _, _, err := net.SplitHostPort(w.BaseShardSequencerAddress); err != nil {
+			return eris.Wrap(err, "BASE_SHARD_SEQUENCER_ADDRESS must follow the format <host>:<port>")
+		}
+		if _, _, err := net.SplitHostPort(w.BaseShardQueryAddress); err != nil {
+			return eris.Wrap(err, "BASE_SHARD_QUERY_ADDRESS must follow the format <host>:<port>")
+		}
+	}
+
+	// Validate Cardinal configs
+	if err := Namespace(w.CardinalNamespace).Validate(w.CardinalMode); err != nil {
+		return eris.Wrap(err, "CARDINAL_NAMESPACE is not a valid namespace")
+	}
+	if w.CardinalLogLevel == "" || !slices.Contains(validLogLevels, w.CardinalLogLevel) {
+		return eris.New("CARDINAL_LOG_LEVEL must be one of the following: " + strings.Join(validLogLevels, ", "))
+	}
+
+	// Validate Redis address
+	if _, _, err := net.SplitHostPort(w.RedisAddress); err != nil {
+		return eris.New("REDIS_ADDRESS must follow the format <host>:<port>")
+	}
+
+	// Validate telemetry config
+	if w.StatsdAddress != "" {
+		if _, _, err := net.SplitHostPort(w.StatsdAddress); err != nil {
+			return eris.New("STATSD_ADDRESS must follow the format <host>:<port>")
+		}
+	}
+	if w.TraceAddress != "" {
+		if _, _, err := net.SplitHostPort(w.TraceAddress); err != nil {
+			return eris.New("TRACE_ADDRESS must follow the format <host>:<port>")
+		}
+	}
+
 	return nil
 }
 
-func getWorldConfig() WorldConfig {
-	cfg := defaultConfig
-	err := config.FromEnv().To(&cfg)
+func (w *WorldConfig) setLogger() error {
+	// Parse the log level
+	level, err := zerolog.ParseLevel(w.CardinalLogLevel)
 	if err != nil {
-		panic(err)
+		return eris.Wrap(err, "CARDINAL_LOG_LEVEL is not a valid log level")
 	}
-	return cfg
+
+	// Set global logger level
+	zerolog.SetGlobalLevel(level)
+
+	// Enable pretty logging in development mode
+	if w.CardinalMode == RunModeDev {
+		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
+	}
+
+	return nil
 }

--- a/cardinal/config_test.go
+++ b/cardinal/config_test.go
@@ -6,18 +6,20 @@ import (
 	"pkg.world.dev/world-engine/assert"
 )
 
-func TestConfigDefaults(t *testing.T) {
-	cfg := getWorldConfig()
-	assert.Equal(t, cfg, defaultConfig)
+func TestWorldConfig_Defaults(t *testing.T) {
+	cfg, err := loadWorldConfig()
+	assert.NilError(t, err)
+	assert.Equal(t, defaultConfig, *cfg)
 }
 
-func TestConfigLoadsFromEnv(t *testing.T) {
+func TestWorldConfig_LoadFromEnv(t *testing.T) {
 	wantCfg := WorldConfig{
-		RedisAddress:              "foo",
+		RedisAddress:              "localhost:6379",
 		RedisPassword:             "bar",
 		CardinalNamespace:         "baz",
 		CardinalMode:              RunModeProd,
-		BaseShardSequencerAddress: "moo",
+		BaseShardSequencerAddress: "localhost:8080",
+		BaseShardQueryAddress:     "localhost:8081",
 		CardinalLogLevel:          DefaultLogLevel,
 		StatsdAddress:             DefaultStatsdAddress,
 	}
@@ -26,13 +28,15 @@ func TestConfigLoadsFromEnv(t *testing.T) {
 	t.Setenv("CARDINAL_NAMESPACE", wantCfg.CardinalNamespace)
 	t.Setenv("CARDINAL_MODE", string(wantCfg.CardinalMode))
 	t.Setenv("BASE_SHARD_SEQUENCER_ADDRESS", wantCfg.BaseShardSequencerAddress)
+	t.Setenv("BASE_SHARD_Query_ADDRESS", wantCfg.BaseShardQueryAddress)
 
-	gotCfg := getWorldConfig()
+	gotCfg, err := loadWorldConfig()
+	assert.NilError(t, err)
 
-	assert.Equal(t, wantCfg, gotCfg)
+	assert.Equal(t, wantCfg, *gotCfg)
 }
 
-func TestValidateConfig(t *testing.T) {
+func TestWorldConfig_Validate(t *testing.T) {
 	testCases := []struct {
 		name    string
 		cfg     WorldConfig
@@ -62,10 +66,12 @@ func TestValidateConfig(t *testing.T) {
 			name: "prod with all required values",
 			cfg: WorldConfig{
 				CardinalMode:              RunModeProd,
-				RedisPassword:             "foo",
+				CardinalLogLevel:          DefaultLogLevel,
 				CardinalNamespace:         "foo",
-				BaseShardQueryAddress:     "bar",
-				BaseShardSequencerAddress: "baz",
+				RedisAddress:              "localhost:6379",
+				RedisPassword:             "foo",
+				BaseShardQueryAddress:     "localhost:8081",
+				BaseShardSequencerAddress: "localhost:8080",
 			},
 			wantErr: false,
 		},

--- a/cardinal/engine_test.go
+++ b/cardinal/engine_test.go
@@ -425,12 +425,11 @@ func TestTransactionsSentToRouterAfterTick(t *testing.T) {
 // for Cardinal to be able to run in Production Mode.
 func setEnvToCardinalProdMode(t *testing.T) {
 	t.Setenv("CARDINAL_MODE", string(cardinal.RunModeProd))
-
-	t.Setenv("REDIS_ADDRESS", "foo")
+	t.Setenv("REDIS_ADDRESS", "localhost:6379")
 	t.Setenv("REDIS_PASSWORD", "bar")
 	t.Setenv("CARDINAL_NAMESPACE", "baz")
-	t.Setenv("BASE_SHARD_SEQUENCER_ADDRESS", "moo")
-	t.Setenv("BASE_SHARD_QUERY_ADDRESS", "oom")
+	t.Setenv("BASE_SHARD_SEQUENCER_ADDRESS", "localhost:8080")
+	t.Setenv("BASE_SHARD_QUERY_ADDRESS", "localhost:8081")
 }
 
 func TestRecoverFromChain(t *testing.T) {

--- a/cardinal/namespace.go
+++ b/cardinal/namespace.go
@@ -1,8 +1,32 @@
 package cardinal
 
-// Namespace is a unique identifier for a world.
+import (
+	"regexp"
+
+	"github.com/rotisserie/eris"
+)
+
+var (
+	regexAlphanumeric = regexp.MustCompile(`^[a-zA-Z0-9-]+$`)
+)
+
+// Namespace is a unique identifier for a world used for posting to the data availability layer and to prevent
+// signature replay attacks across multiple worlds.
 type Namespace string
 
 func (n Namespace) String() string {
 	return string(n)
+}
+
+// Validate validates that the namespace is alphanumeric and not the default namespace in production mode.
+func (n Namespace) Validate(mode RunMode) error {
+	if !regexAlphanumeric.MatchString(n.String()) {
+		return eris.New("Invalid namespace. A namespace must be alphanumeric.")
+	}
+	if mode == RunModeProd {
+		if n.String() == DefaultNamespace {
+			return eris.New("Default namespace is not allowed in production mode.")
+		}
+	}
+	return nil
 }

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"sync/atomic"
 	"syscall"
 	"time"
@@ -87,19 +86,12 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 	serverOptions, cardinalOptions := separateOptions(opts)
 
 	// Load config. Fallback value is used if it's not set.
-	cfg := getWorldConfig()
-	if err := cfg.Validate(); err != nil {
-		return nil, eris.Wrapf(err, "invalid configuration")
-	}
-	if err := setLogLevel(cfg.CardinalLogLevel); err != nil {
-		return nil, eris.Wrap(err, "")
+	cfg, err := loadWorldConfig()
+	if err != nil {
+		return nil, eris.Wrap(err, "Failed to load config to start world")
 	}
 
-	if cfg.CardinalMode == RunModeDev {
-		// Enable pretty printing of logs in development mode.
-		log.Logger = log.Output(zerolog.ConsoleWriter{Out: os.Stderr})
-	}
-	log.Logger.Info().Msgf("Starting a new Cardinal world in %s mode", cfg.CardinalMode)
+	log.Info().Msgf("Creating a new Cardinal world in %s mode", cfg.CardinalMode)
 
 	redisMetaStore := redis.NewRedisStorage(redis.Options{
 		Addr:        cfg.RedisAddress,
@@ -109,7 +101,6 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 	}, cfg.CardinalNamespace)
 
 	redisStore := gamestate.NewRedisPrimitiveStorage(redisMetaStore.Client)
-
 	entityCommandBuffer, err := gamestate.NewEntityCommandBuffer(&redisStore)
 	if err != nil {
 		return nil, err
@@ -151,11 +142,12 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 		addChannelWaitingForNextTick: make(chan chan struct{}),
 	}
 
+	// Shard router must be set in production mode
 	if cfg.CardinalMode == RunModeProd {
 		world.router, err = router.New(cfg.CardinalNamespace, cfg.BaseShardSequencerAddress, cfg.BaseShardQueryAddress,
 			world)
 		if err != nil {
-			return nil, err
+			return nil, eris.Wrap(err, "Failed to initialize shard router")
 		}
 	}
 
@@ -167,12 +159,8 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 	world.registerInternalPlugin()
 
 	var metricTags []string
-	if cfg.CardinalMode != "" {
-		metricTags = append(metricTags, string("cardinal_mode:"+cfg.CardinalMode))
-	}
-	if cfg.CardinalNamespace != "" {
-		metricTags = append(metricTags, "cardinal_namespace:"+cfg.CardinalNamespace)
-	}
+	metricTags = append(metricTags, string("cardinal_mode:"+cfg.CardinalMode))
+	metricTags = append(metricTags, "cardinal_namespace:"+cfg.CardinalNamespace)
 
 	if cfg.StatsdAddress != "" || cfg.TraceAddress != "" {
 		if err = statsd.Init(cfg.StatsdAddress, cfg.TraceAddress, metricTags); err != nil {
@@ -469,25 +457,6 @@ func (w *World) Shutdown() error {
 	}
 	log.Info().Msg("Successfully closed storage connection.")
 
-	return nil
-}
-
-func setLogLevel(levelStr string) error {
-	if levelStr == "" {
-		return eris.New("log level must not be empty")
-	}
-	level, err := zerolog.ParseLevel(levelStr)
-	if err != nil {
-		var exampleLogLevels = strings.Join([]string{
-			zerolog.DebugLevel.String(),
-			zerolog.InfoLevel.String(),
-			zerolog.WarnLevel.String(),
-			zerolog.ErrorLevel.String(),
-			zerolog.Disabled.String(),
-		}, ", ")
-		return eris.Errorf("log level %q is invalid, try one of: %v.", levelStr, exampleLogLevels)
-	}
-	zerolog.SetGlobalLevel(level)
 	return nil
 }
 


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced configuration validation logic, including detailed checks for various parameters.
	- Introduced logging configuration based on loaded settings.
	- Added validation for namespace to ensure it's alphanumeric and not default in production.
- **Refactor**
	- Reorganized the `WorldConfig` structure for better clarity.
	- Simplified metric tag generation in the creation of a new world instance.
	- Updated configuration loading and logging setup in `NewWorld`.
- **Bug Fixes**
	- Improved error handling and messaging in the creation of a new world instance.
- **Chores**
	- Removed unused import statements and obsolete functions related to log level setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->