### PR TITLE
test(cardinal): Ensure this flaky test fails faster instead of timing out after 10 minutes

### DIFF
--- a/cardinal/server/event_test.go
+++ b/cardinal/server/event_test.go
@@ -43,27 +43,32 @@ func TestEventsThroughSystems(t *testing.T) {
 	counter1.Store(0)
 	event := map[string]any{"message": "test"}
 	sys1 := func(wCtx engine.Context) error {
-		assert.NilError(t, wCtx.EmitEvent(event))
+		err := wCtx.EmitEvent(event)
+		assert.Check(t, err == nil, "emit event encountered error is system 1: %v", err)
 		counter1.Add(1)
 		return nil
 	}
 	sys2 := func(wCtx engine.Context) error {
-		assert.NilError(t, wCtx.EmitEvent(event))
+		err := wCtx.EmitEvent(event)
+		assert.Check(t, err == nil, "emit event encountered error is system 2: %v", err)
 		counter1.Add(1)
 		return nil
 	}
 	sys3 := func(wCtx engine.Context) error {
-		assert.NilError(t, wCtx.EmitEvent(event))
+		err := wCtx.EmitEvent(event)
+		assert.Check(t, err == nil, "emit event encountered error is system 3: %v", err)
 		counter1.Add(1)
 		return nil
 	}
 	sys4 := func(wCtx engine.Context) error {
-		assert.NilError(t, wCtx.EmitEvent(event))
+		err := wCtx.EmitEvent(event)
+		assert.Check(t, err == nil, "emit event encountered error is system 4: %v", err)
 		counter1.Add(1)
 		return nil
 	}
 	sys5 := func(wCtx engine.Context) error {
-		assert.NilError(t, wCtx.EmitEvent(event))
+		err := wCtx.EmitEvent(event)
+		assert.Check(t, err == nil, "emit event encountered error is system 4: %v", err)
 		counter1.Add(1)
 		return nil
 	}

--- a/cardinal/server/event_test.go
+++ b/cardinal/server/event_test.go
@@ -68,7 +68,7 @@ func TestEventsThroughSystems(t *testing.T) {
 	}
 	sys5 := func(wCtx engine.Context) error {
 		err := wCtx.EmitEvent(event)
-		assert.Check(t, err == nil, "emit event encountered error is system 4: %v", err)
+		assert.Check(t, err == nil, "emit event encountered error is system 5: %v", err)
 		counter1.Add(1)
 		return nil
 	}


### PR DESCRIPTION

## Overview

TestEventsThroughSystems is flaky and I'm unable to reproduce the failure locally. In CI, the failure is identified by a test timeout after 10 minutes. I believe the reason for the hang is because assert.NilError kills the containing goroutine, so an event in the system is never emitted, causing `mode, message, err := dialer.ReadMessage()` to block forever.

I can reproduce the timeout by manually changing the EmitEvent error to non-nil.

assert.Check is allowed to be called from a non-main goroutine, but assert.NilError does not have that same guarantee.

By changing these assertions to assert.Check, this test will fail right away instead of timing out.

Note, this is NOT a fix for the flaky test. Instead it will 1) Ensure the flake test fails faster and 2) hopefully give us an error message that will help us track down why the EmitEvent call failed.

