### PR TITLE
chore(cardinal): remove extra utils function

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -670,10 +670,7 @@ func TestTransactionExample(t *testing.T) {
 	payload := testutils.UniqueSignature()
 	addHealthToEntity, ok := world.GetMessageByFullName("game." + msgName)
 	assert.True(t, ok)
-	testutils.AddTransactionToWorldByAnyTransaction(
-		world, addHealthToEntity,
-		AddHealthToEntityTx{idToModify, amountToModify}, payload,
-	)
+	tf.AddTransaction(addHealthToEntity.ID(), AddHealthToEntityTx{idToModify, amountToModify}, payload)
 
 	// The health change should be applied during this tick
 	doTick()

--- a/cardinal/testutils/testutils.go
+++ b/cardinal/testutils/testutils.go
@@ -2,7 +2,6 @@ package testutils
 
 import (
 	"crypto/ecdsa"
-	"fmt"
 	"reflect"
 	"testing"
 	"time"
@@ -10,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/rotisserie/eris"
 
-	"pkg.world.dev/world-engine/cardinal"
 	"pkg.world.dev/world-engine/cardinal/message"
 	"pkg.world.dev/world-engine/cardinal/types"
 	"pkg.world.dev/world-engine/cardinal/types/engine"
@@ -61,33 +59,6 @@ func UniqueSignatureWithName(name string) *sign.Transaction {
 
 func UniqueSignature() *sign.Transaction {
 	return UniqueSignatureWithName("some_persona_tag")
-}
-
-func AddTransactionToWorldByAnyTransaction(
-	world *cardinal.World,
-	cardinalTx types.Message,
-	value any,
-	tx *sign.Transaction,
-) {
-	txs := world.GetRegisteredMessages()
-	txID := cardinalTx.ID()
-	found := false
-	for _, tx := range txs {
-		if tx.ID() == txID {
-			found = true
-			break
-		}
-	}
-	if !found {
-		panic(
-			fmt.Sprintf(
-				"cannot find transaction %q in registered transactions. Did you register it?",
-				cardinalTx.Name(),
-			),
-		)
-	}
-
-	_, _ = world.AddTransaction(txID, value, tx)
 }
 
 func GetMessage[In any, Out any](wCtx engine.Context) (*message.MessageType[In, Out], error) {


### PR DESCRIPTION
## Overview

removes a utils function that isn't needed. the testfixture has a method that handles the same thing. found it lingering around while working on nonce PR.


## Brief Changelog



## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
