### PR TITLE
test(cardinal): Include coverpkg env variable to ensure coverage from other packages …

### DIFF
--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -74,7 +74,7 @@ e2e-evm:
 .PHONY: unit-test
 
 unit-test:
-	cd $(filter-out $@,$(MAKECMDGOALS)) && GOWORK=off go test --cover -coverpkg=./... ./... -coverprofile=coverage-$(shell basename $(PWD)).out -covermode=count -v
+	cd $(filter-out $@,$(MAKECMDGOALS)) && GOWORK=off go test -coverpkg=./... ./... -coverprofile=coverage-$(shell basename $(PWD)).out -covermode=count -v
 
 unit-test-all:
 	$(MAKE) unit-test cardinal

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -74,7 +74,7 @@ e2e-evm:
 .PHONY: unit-test
 
 unit-test:
-	cd $(filter-out $@,$(MAKECMDGOALS)) && GOWORK=off go test ./... -coverprofile=coverage-$(shell basename $(PWD)).out -covermode=count -v
+	cd $(filter-out $@,$(MAKECMDGOALS)) && GOWORK=off go test --cover -coverpkg=./... ./... -coverprofile=coverage-$(shell basename $(PWD)).out -covermode=count -v
 
 unit-test-all:
 	$(MAKE) unit-test cardinal


### PR DESCRIPTION
…is still captured in the coverage report

Closes: WORLD-855

## Overview

Include the coverpkg flag when running unit tests so coverage is calculated across all packages instead of just the current package. [See the test package for more information on coverpkg](https://pkg.go.dev/cmd/go/internal/test)

## Testing and Verifying

From the main branch, in the world-engine directory, run 
`make unit-test-all`
Save the coverage report to some other location (so it can be compared to the coverage report generated by this branch)
`mv cardinal/coverage-world-engine.out cardinal/old-and-busted.out`

Checkout this branch and run
`make unit-test-all`
View the new coverage file:
`go tool cover -html cardinal/coverage-world-engine.out`
Compare it to the old-and-busted version:
`go tool cover -html cardinal/old-and-busted.out`

The coverage percentage will be lower in the old-and-busted version. e.g. world-engine/cardinal/message/manager.go goes from 0% to 93.5%.