### PR TITLE
docs(cardinal): use {custom-group} instead of 'game' in query/tx endpoints

### DIFF
--- a/cardinal/server/docs/docs.go
+++ b/cardinal/server/docs/docs.go
@@ -106,7 +106,44 @@ const docTemplate = `{
                 }
             }
         },
-        "/query/game/{queryName}": {
+        "/query/receipts/list": {
+            "post": {
+                "description": "Retrieves all transaction receipts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Retrieves all transaction receipts",
+                "parameters": [
+                    {
+                        "description": "Query body",
+                        "name": "ListTxReceiptsRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.ListTxReceiptsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of receipts",
+                        "schema": {
+                            "$ref": "#/definitions/handler.ListTxReceiptsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/query/{queryGroup}/{queryName}": {
             "post": {
                 "description": "Executes a query",
                 "consumes": [
@@ -117,6 +154,13 @@ const docTemplate = `{
                 ],
                 "summary": "Executes a query",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Query group",
+                        "name": "queryGroup",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "description": "Name of a registered query",
@@ -150,61 +194,17 @@ const docTemplate = `{
                 }
             }
         },
-        "/query/receipts/list": {
+        "/tx/persona/create-persona": {
             "post": {
-                "description": "Retrieves all transaction receipts",
+                "description": "Creates a persona",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieves all transaction receipts",
+                "summary": "Creates a persona",
                 "parameters": [
-                    {
-                        "description": "Query body",
-                        "name": "ListTxReceiptsRequest",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/cardinal.ListTxReceiptsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "List of receipts",
-                        "schema": {
-                            "$ref": "#/definitions/cardinal.ListTxReceiptsResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request body",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/tx/game/{txName}": {
-            "post": {
-                "description": "Submits a transaction",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Submits a transaction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Name of a registered message",
-                        "name": "txName",
-                        "in": "path",
-                        "required": true
-                    },
                     {
                         "description": "Transaction details \u0026 message to be submitted",
                         "name": "txBody",
@@ -231,17 +231,31 @@ const docTemplate = `{
                 }
             }
         },
-        "/tx/persona/create-persona": {
+        "/tx/{txGroup}/{txName}": {
             "post": {
-                "description": "Creates a persona",
+                "description": "Submits a transaction",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Creates a persona",
+                "summary": "Submits a transaction",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Message group",
+                        "name": "txGroup",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Name of a registered message",
+                        "name": "txName",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "description": "Transaction details \u0026 message to be submitted",
                         "name": "txBody",
@@ -296,49 +310,6 @@ const docTemplate = `{
         }
     },
     "definitions": {
-        "cardinal.ListTxReceiptsRequest": {
-            "type": "object",
-            "properties": {
-                "startTick": {
-                    "type": "integer"
-                }
-            }
-        },
-        "cardinal.ListTxReceiptsResponse": {
-            "type": "object",
-            "properties": {
-                "endTick": {
-                    "type": "integer"
-                },
-                "receipts": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cardinal.ReceiptEntry"
-                    }
-                },
-                "startTick": {
-                    "type": "integer"
-                }
-            }
-        },
-        "cardinal.ReceiptEntry": {
-            "type": "object",
-            "properties": {
-                "errors": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "result": {},
-                "tick": {
-                    "type": "integer"
-                },
-                "txHash": {
-                    "type": "string"
-                }
-            }
-        },
         "handler.CQLQueryRequest": {
             "type": "object",
             "properties": {
@@ -413,9 +384,52 @@ const docTemplate = `{
                 }
             }
         },
+        "handler.ListTxReceiptsRequest": {
+            "type": "object",
+            "properties": {
+                "startTick": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handler.ListTxReceiptsResponse": {
+            "type": "object",
+            "properties": {
+                "endTick": {
+                    "type": "integer"
+                },
+                "receipts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handler.ReceiptEntry"
+                    }
+                },
+                "startTick": {
+                    "type": "integer"
+                }
+            }
+        },
         "handler.PostTransactionResponse": {
             "type": "object",
             "properties": {
+                "tick": {
+                    "type": "integer"
+                },
+                "txHash": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.ReceiptEntry": {
+            "type": "object",
+            "properties": {
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "result": {},
                 "tick": {
                     "type": "integer"
                 },

--- a/cardinal/server/docs/swagger.json
+++ b/cardinal/server/docs/swagger.json
@@ -103,7 +103,44 @@
                 }
             }
         },
-        "/query/game/{queryName}": {
+        "/query/receipts/list": {
+            "post": {
+                "description": "Retrieves all transaction receipts",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Retrieves all transaction receipts",
+                "parameters": [
+                    {
+                        "description": "Query body",
+                        "name": "ListTxReceiptsRequest",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.ListTxReceiptsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "List of receipts",
+                        "schema": {
+                            "$ref": "#/definitions/handler.ListTxReceiptsResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request body",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/query/{queryGroup}/{queryName}": {
             "post": {
                 "description": "Executes a query",
                 "consumes": [
@@ -114,6 +151,13 @@
                 ],
                 "summary": "Executes a query",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Query group",
+                        "name": "queryGroup",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "type": "string",
                         "description": "Name of a registered query",
@@ -147,61 +191,17 @@
                 }
             }
         },
-        "/query/receipts/list": {
+        "/tx/persona/create-persona": {
             "post": {
-                "description": "Retrieves all transaction receipts",
+                "description": "Creates a persona",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Retrieves all transaction receipts",
+                "summary": "Creates a persona",
                 "parameters": [
-                    {
-                        "description": "Query body",
-                        "name": "ListTxReceiptsRequest",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/cardinal.ListTxReceiptsRequest"
-                        }
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "List of receipts",
-                        "schema": {
-                            "$ref": "#/definitions/cardinal.ListTxReceiptsResponse"
-                        }
-                    },
-                    "400": {
-                        "description": "Invalid request body",
-                        "schema": {
-                            "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "/tx/game/{txName}": {
-            "post": {
-                "description": "Submits a transaction",
-                "consumes": [
-                    "application/json"
-                ],
-                "produces": [
-                    "application/json"
-                ],
-                "summary": "Submits a transaction",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Name of a registered message",
-                        "name": "txName",
-                        "in": "path",
-                        "required": true
-                    },
                     {
                         "description": "Transaction details \u0026 message to be submitted",
                         "name": "txBody",
@@ -228,17 +228,31 @@
                 }
             }
         },
-        "/tx/persona/create-persona": {
+        "/tx/{txGroup}/{txName}": {
             "post": {
-                "description": "Creates a persona",
+                "description": "Submits a transaction",
                 "consumes": [
                     "application/json"
                 ],
                 "produces": [
                     "application/json"
                 ],
-                "summary": "Creates a persona",
+                "summary": "Submits a transaction",
                 "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Message group",
+                        "name": "txGroup",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Name of a registered message",
+                        "name": "txName",
+                        "in": "path",
+                        "required": true
+                    },
                     {
                         "description": "Transaction details \u0026 message to be submitted",
                         "name": "txBody",
@@ -293,49 +307,6 @@
         }
     },
     "definitions": {
-        "cardinal.ListTxReceiptsRequest": {
-            "type": "object",
-            "properties": {
-                "startTick": {
-                    "type": "integer"
-                }
-            }
-        },
-        "cardinal.ListTxReceiptsResponse": {
-            "type": "object",
-            "properties": {
-                "endTick": {
-                    "type": "integer"
-                },
-                "receipts": {
-                    "type": "array",
-                    "items": {
-                        "$ref": "#/definitions/cardinal.ReceiptEntry"
-                    }
-                },
-                "startTick": {
-                    "type": "integer"
-                }
-            }
-        },
-        "cardinal.ReceiptEntry": {
-            "type": "object",
-            "properties": {
-                "errors": {
-                    "type": "array",
-                    "items": {
-                        "type": "string"
-                    }
-                },
-                "result": {},
-                "tick": {
-                    "type": "integer"
-                },
-                "txHash": {
-                    "type": "string"
-                }
-            }
-        },
         "handler.CQLQueryRequest": {
             "type": "object",
             "properties": {
@@ -410,9 +381,52 @@
                 }
             }
         },
+        "handler.ListTxReceiptsRequest": {
+            "type": "object",
+            "properties": {
+                "startTick": {
+                    "type": "integer"
+                }
+            }
+        },
+        "handler.ListTxReceiptsResponse": {
+            "type": "object",
+            "properties": {
+                "endTick": {
+                    "type": "integer"
+                },
+                "receipts": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/handler.ReceiptEntry"
+                    }
+                },
+                "startTick": {
+                    "type": "integer"
+                }
+            }
+        },
         "handler.PostTransactionResponse": {
             "type": "object",
             "properties": {
+                "tick": {
+                    "type": "integer"
+                },
+                "txHash": {
+                    "type": "string"
+                }
+            }
+        },
+        "handler.ReceiptEntry": {
+            "type": "object",
+            "properties": {
+                "errors": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "result": {},
                 "tick": {
                     "type": "integer"
                 },

--- a/cardinal/server/docs/swagger.yaml
+++ b/cardinal/server/docs/swagger.yaml
@@ -1,33 +1,5 @@
 basePath: /
 definitions:
-  cardinal.ListTxReceiptsRequest:
-    properties:
-      startTick:
-        type: integer
-    type: object
-  cardinal.ListTxReceiptsResponse:
-    properties:
-      endTick:
-        type: integer
-      receipts:
-        items:
-          $ref: '#/definitions/cardinal.ReceiptEntry'
-        type: array
-      startTick:
-        type: integer
-    type: object
-  cardinal.ReceiptEntry:
-    properties:
-      errors:
-        items:
-          type: string
-        type: array
-      result: {}
-      tick:
-        type: integer
-      txHash:
-        type: string
-    type: object
   handler.CQLQueryRequest:
     properties:
       cql:
@@ -77,8 +49,36 @@ definitions:
           $ref: '#/definitions/handler.FieldDetail'
         type: array
     type: object
+  handler.ListTxReceiptsRequest:
+    properties:
+      startTick:
+        type: integer
+    type: object
+  handler.ListTxReceiptsResponse:
+    properties:
+      endTick:
+        type: integer
+      receipts:
+        items:
+          $ref: '#/definitions/handler.ReceiptEntry'
+        type: array
+      startTick:
+        type: integer
+    type: object
   handler.PostTransactionResponse:
     properties:
+      tick:
+        type: integer
+      txHash:
+        type: string
+    type: object
+  handler.ReceiptEntry:
+    properties:
+      errors:
+        items:
+          type: string
+        type: array
+      result: {}
       tick:
         type: integer
       txHash:
@@ -180,12 +180,17 @@ paths:
           schema:
             $ref: '#/definitions/handler.GetHealthResponse'
       summary: Retrieves the status of the server and game loop
-  /query/game/{queryName}:
+  /query/{queryGroup}/{queryName}:
     post:
       consumes:
       - application/json
       description: Executes a query
       parameters:
+      - description: Query group
+        in: path
+        name: queryGroup
+        required: true
+        type: string
       - description: Name of a registered query
         in: path
         name: queryName
@@ -220,25 +225,30 @@ paths:
         name: ListTxReceiptsRequest
         required: true
         schema:
-          $ref: '#/definitions/cardinal.ListTxReceiptsRequest'
+          $ref: '#/definitions/handler.ListTxReceiptsRequest'
       produces:
       - application/json
       responses:
         "200":
           description: List of receipts
           schema:
-            $ref: '#/definitions/cardinal.ListTxReceiptsResponse'
+            $ref: '#/definitions/handler.ListTxReceiptsResponse'
         "400":
           description: Invalid request body
           schema:
             type: string
       summary: Retrieves all transaction receipts
-  /tx/game/{txName}:
+  /tx/{txGroup}/{txName}:
     post:
       consumes:
       - application/json
       description: Submits a transaction
       parameters:
+      - description: Message group
+        in: path
+        name: txGroup
+        required: true
+        type: string
       - description: Name of a registered message
         in: path
         name: txName

--- a/cardinal/server/handler/query.go
+++ b/cardinal/server/handler/query.go
@@ -12,11 +12,12 @@ import (
 //	@Description  Executes a query
 //	@Accept       application/json
 //	@Produce      application/json
-//	@Param        queryName  path      string  true  "Name of a registered query"
-//	@Param        queryBody  body      object  true  "Query to be executed"
-//	@Success      200        {object}  object  "Results of the executed query"
-//	@Failure      400        {string}  string  "Invalid request parameters"
-//	@Router       /query/game/{queryName} [post]
+//	@Param        queryGroup  path      string  true  "Query group"
+//	@Param        queryName   path      string  true  "Name of a registered query"
+//	@Param        queryBody   body      object  true  "Query to be executed"
+//	@Success      200         {object}  object  "Results of the executed query"
+//	@Failure      400         {string}  string  "Invalid request parameters"
+//	@Router       /query/{queryGroup}/{queryName} [post]
 func PostQuery(queries map[string]map[string]engine.Query, wCtx engine.Context) func(*fiber.Ctx) error {
 	return func(ctx *fiber.Ctx) error {
 		query, ok := queries[ctx.Params("group")][ctx.Params("name")]

--- a/cardinal/server/handler/tx.go
+++ b/cardinal/server/handler/tx.go
@@ -34,11 +34,12 @@ type Transaction = sign.Transaction
 //	@Description  Submits a transaction
 //	@Accept       application/json
 //	@Produce      application/json
-//	@Param        txName  path      string                   true  "Name of a registered message"
-//	@Param        txBody  body      Transaction              true  "Transaction details & message to be submitted"
-//	@Success      200     {object}  PostTransactionResponse  "Transaction hash and tick"
-//	@Failure      400     {string}  string                   "Invalid request parameter"
-//	@Router       /tx/game/{txName} [post]
+//	@Param        txGroup  path      string                   true  "Message group"
+//	@Param        txName   path      string                   true  "Name of a registered message"
+//	@Param        txBody   body      Transaction              true  "Transaction details & message to be submitted"
+//	@Success      200      {object}  PostTransactionResponse  "Transaction hash and tick"
+//	@Failure      400      {string}  string                   "Invalid request parameter"
+//	@Router       /tx/{txGroup}/{txName} [post]
 func PostTransaction(
 	provider servertypes.Provider, msgs map[string]map[string]types.Message, disableSigVerification bool,
 ) func(*fiber.Ctx) error {


### PR DESCRIPTION
Closes: WORLD-1039

## Overview
Since the message/query group is variable (through `WithCustomMessageGroup`/`WithCustomQueryGroup`), the swagger docs should show this.


## Testing and Verifying
Manual verification