### PR TITLE
docs(cardinal): add default message/query group route in swagger

### DIFF
--- a/cardinal/server/docs/docs.go
+++ b/cardinal/server/docs/docs.go
@@ -106,6 +106,50 @@ const docTemplate = `{
                 }
             }
         },
+        "/query/game/{queryName}": {
+            "post": {
+                "description": "Executes a query",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Executes a query",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name of a registered query",
+                        "name": "queryName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Query to be executed",
+                        "name": "queryBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Results of the executed query",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/query/receipts/list": {
             "post": {
                 "description": "Retrieves all transaction receipts",
@@ -187,6 +231,50 @@ const docTemplate = `{
                     },
                     "400": {
                         "description": "Invalid request parameters",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/tx/game/{txName}": {
+            "post": {
+                "description": "Submits a transaction",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Submits a transaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name of a registered message",
+                        "name": "txName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Transaction details \u0026 message to be submitted",
+                        "name": "txBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.Transaction"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Transaction hash and tick",
+                        "schema": {
+                            "$ref": "#/definitions/handler.PostTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
                         "schema": {
                             "type": "string"
                         }

--- a/cardinal/server/docs/swagger.json
+++ b/cardinal/server/docs/swagger.json
@@ -103,6 +103,50 @@
                 }
             }
         },
+        "/query/game/{queryName}": {
+            "post": {
+                "description": "Executes a query",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Executes a query",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name of a registered query",
+                        "name": "queryName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Query to be executed",
+                        "name": "queryBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "object"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Results of the executed query",
+                        "schema": {
+                            "type": "object"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameters",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
         "/query/receipts/list": {
             "post": {
                 "description": "Retrieves all transaction receipts",
@@ -184,6 +228,50 @@
                     },
                     "400": {
                         "description": "Invalid request parameters",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "/tx/game/{txName}": {
+            "post": {
+                "description": "Submits a transaction",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "summary": "Submits a transaction",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Name of a registered message",
+                        "name": "txName",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "description": "Transaction details \u0026 message to be submitted",
+                        "name": "txBody",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/handler.Transaction"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Transaction hash and tick",
+                        "schema": {
+                            "$ref": "#/definitions/handler.PostTransactionResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Invalid request parameter",
                         "schema": {
                             "type": "string"
                         }

--- a/cardinal/server/docs/swagger.yaml
+++ b/cardinal/server/docs/swagger.yaml
@@ -214,6 +214,35 @@ paths:
           schema:
             type: string
       summary: Executes a query
+  /query/game/{queryName}:
+    post:
+      consumes:
+      - application/json
+      description: Executes a query
+      parameters:
+      - description: Name of a registered query
+        in: path
+        name: queryName
+        required: true
+        type: string
+      - description: Query to be executed
+        in: body
+        name: queryBody
+        required: true
+        schema:
+          type: object
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Results of the executed query
+          schema:
+            type: object
+        "400":
+          description: Invalid request parameters
+          schema:
+            type: string
+      summary: Executes a query
   /query/receipts/list:
     post:
       consumes:
@@ -249,6 +278,35 @@ paths:
         name: txGroup
         required: true
         type: string
+      - description: Name of a registered message
+        in: path
+        name: txName
+        required: true
+        type: string
+      - description: Transaction details & message to be submitted
+        in: body
+        name: txBody
+        required: true
+        schema:
+          $ref: '#/definitions/handler.Transaction'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: Transaction hash and tick
+          schema:
+            $ref: '#/definitions/handler.PostTransactionResponse'
+        "400":
+          description: Invalid request parameter
+          schema:
+            type: string
+      summary: Submits a transaction
+  /tx/game/{txName}:
+    post:
+      consumes:
+      - application/json
+      description: Submits a transaction
+      parameters:
       - description: Name of a registered message
         in: path
         name: txName

--- a/cardinal/server/handler/query.go
+++ b/cardinal/server/handler/query.go
@@ -34,3 +34,19 @@ func PostQuery(queries map[string]map[string]engine.Query, wCtx engine.Context) 
 		return ctx.Send(resBz)
 	}
 }
+
+// NOTE: duplication for cleaner swagger docs
+// PostQuery godoc
+//
+//	@Summary      Executes a query
+//	@Description  Executes a query
+//	@Accept       application/json
+//	@Produce      application/json
+//	@Param        queryName   path      string  true  "Name of a registered query"
+//	@Param        queryBody   body      object  true  "Query to be executed"
+//	@Success      200         {object}  object  "Results of the executed query"
+//	@Failure      400         {string}  string  "Invalid request parameters"
+//	@Router       /query/game/{queryName} [post]
+func PostGameQuery(queries map[string]map[string]engine.Query, wCtx engine.Context) func(*fiber.Ctx) error {
+	return PostQuery(queries, wCtx)
+}

--- a/cardinal/server/handler/tx.go
+++ b/cardinal/server/handler/tx.go
@@ -91,7 +91,25 @@ func PostTransaction(
 	}
 }
 
-// NOTE: duplication for cleaner swagger JSON file
+// NOTE: duplication for cleaner swagger docs
+// PostTransaction godoc
+//
+//	@Summary      Submits a transaction
+//	@Description  Submits a transaction
+//	@Accept       application/json
+//	@Produce      application/json
+//	@Param        txName  path      string                   true  "Name of a registered message"
+//	@Param        txBody  body      Transaction              true  "Transaction details & message to be submitted"
+//	@Success      200     {object}  PostTransactionResponse  "Transaction hash and tick"
+//	@Failure      400     {string}  string                   "Invalid request parameter"
+//	@Router       /tx/game/{txName} [post]
+func PostGameTransaction(
+	provider servertypes.Provider, msgs map[string]map[string]types.Message, disableSigVerification bool,
+) func(*fiber.Ctx) error {
+	return PostTransaction(provider, msgs, disableSigVerification)
+}
+
+// NOTE: duplication for cleaner swagger docs
 // PostTransaction godoc
 //
 //	@Summary      Creates a persona


### PR DESCRIPTION
Closes: WORLD-XXX


## Overview
Add back `/tx/game/{txName}` & `/query/game/{queryName}` endpoints.

## Testing and Verifying
Manually verified
