### PR TITLE
feat(nakama): Use event hub to block until a persona tag has been reclaimed

### DIFF
--- a/relay/nakama/handlers.go
+++ b/relay/nakama/handlers.go
@@ -292,8 +292,8 @@ func blockUntilPersonaTagTxHasBeenProcessed(logger runtime.Logger, eventHub *eve
 		case receipts := <-ch:
 			for _, receipt := range receipts {
 				if receipt.TxHash == txHash {
-					// We just care that hte person tag re-claim tx was processed. Weather it was successful or not
-					// will become apparent when the initial tx is re-issued.
+					// We just care that the person tag re-claim tx was processed. Whether it was successful or not
+					// will become apparent when the initial tx is resent.
 					logger.Info("result of persona tag re-claim: %v", receipt.Result)
 					done = true
 					break

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -52,12 +52,12 @@ func InitModule(
 		return eris.Wrap(err, "failed to init globalNamespace")
 	}
 
-	globalEventHub, err := initEventHub(ctx, logger, nk, EventEndpoint, cardinalAddress)
+	eventHub, err := initEventHub(ctx, logger, nk, EventEndpoint, cardinalAddress)
 	if err != nil {
 		return eris.Wrap(err, "failed to init event hub")
 	}
 
-	notifier := events.NewNotifier(logger, nk, globalEventHub)
+	notifier := events.NewNotifier(logger, nk, eventHub)
 
 	txSigner, err := selectSigner(ctx, logger, nk)
 	if err != nil {
@@ -75,7 +75,7 @@ func InitModule(
 		return eris.Wrap(err, "failed to init persona tag assignment map")
 	}
 
-	verifier := persona.NewVerifier(logger, nk, globalEventHub)
+	verifier := persona.NewVerifier(logger, nk, eventHub)
 
 	if err := initPersonaTagEndpoints(
 		logger,
@@ -94,6 +94,7 @@ func InitModule(
 		logger,
 		initializer,
 		notifier,
+		eventHub,
 		txSigner,
 		cardinalAddress,
 		globalNamespace,
@@ -222,6 +223,7 @@ func initCardinalEndpoints(
 	logger runtime.Logger,
 	initializer runtime.Initializer,
 	notifier *events.Notifier,
+	eventHub *events.EventHub,
 	txSigner signer.Signer,
 	cardinalAddress string,
 	globalNamespace string,
@@ -261,6 +263,7 @@ func initCardinalEndpoints(
 		logger,
 		initializer,
 		notifier,
+		eventHub,
 		txEndpoints,
 		createTransaction,
 		cardinalAddress,
@@ -277,6 +280,7 @@ func initCardinalEndpoints(
 		logger,
 		initializer,
 		notifier,
+		eventHub,
 		queryEndpoints,
 		createUnsignedTransaction,
 		cardinalAddress,

--- a/relay/nakama/persona/persona.go
+++ b/relay/nakama/persona/persona.go
@@ -46,21 +46,21 @@ func ReclaimPersona(
 	txSigner signer.Signer,
 	cardinalAddress string,
 	namespace string,
-) error {
+) (txHash string, err error) {
 	tag, err := LoadPersonaTagStorageObj(ctx, nk)
 	if err != nil {
-		return eris.Wrap(err, "re-claim failed, storage object could not be found")
+		return "", eris.Wrap(err, "re-claim failed, storage object could not be found")
 	}
 	if tag.Status != StatusAccepted {
-		return eris.Wrap(err, "re-claim failed, status must already have been accepted")
+		return "", eris.Wrap(err, "re-claim failed, status must already have been accepted")
 	}
 	personaTag := tag.PersonaTag
 
-	_, _, err = createPersona(ctx, txSigner, personaTag, cardinalAddress, namespace)
+	txHash, _, err = createPersona(ctx, txSigner, personaTag, cardinalAddress, namespace)
 	if err != nil {
-		return eris.Wrap(err, "unable to make re-create persona request to cardinal")
+		return "", eris.Wrap(err, "unable to make re-create persona request to cardinal")
 	}
-	return nil
+	return txHash, nil
 }
 
 func ClaimPersona(

--- a/relay/nakama/rpc.go
+++ b/relay/nakama/rpc.go
@@ -96,6 +96,7 @@ func registerEndpoints(
 	logger runtime.Logger,
 	initializer runtime.Initializer,
 	notifier *events.Notifier,
+	eventHub *events.EventHub,
 	endpoints []string,
 	createPayload func(
 		string, string, runtime.NakamaModule,
@@ -116,6 +117,7 @@ func registerEndpoints(
 			currEndpoint,
 			createPayload,
 			notifier,
+			eventHub,
 			cardinalAddress,
 			namespace,
 			txSigner,


### PR DESCRIPTION
Closes: WORLD-1027

## Overview
Instead of using time.Sleep to wait for a persona tag to be re-claimed, use the event hub to watch for a specific persona tag claim transaction. 

## Testing and Verifying

Like the initial feature PR, this requires a manual test. Here are the instructions again for wiping redis and issuing a transaction for a persona tag that exists in Nakama but not Cardinal. On main, this will always take a second to re-register the persona tag. On this feature branch, it will happen very quickly, with little to no noticeable delay.

1. Start off in the `main` branch.
2. (probably optional) Delete all docker containers and volumes to start fresh.
3. From world-engine, run `docker compose up nakama --build`
4. Navigate to http://localhost:7351/#/apiexplorer
5. Send Request to the `AuthenticateDevice` endpoint with the following body:
    * ` {"account": {"id": "1234567890"},"create": true,"username": "some-cool-user"}`
6. Navigate to http://localhost:7351/#/accounts and copy the User ID of your newly authenticated user
7. Navigate back to http://localhost:7351/#/apiexplorer and paste the User ID into the `set user ID as request context` field.
8. Send Request to the `nakama/claim-persona` endpoint with the following body:
    * `{"personaTag": "sometag"}`
9. Send Request to the `nakama/show-persona` endpoint (no body required)
    * You should see a `status: accepted` field, indicating you've registered a persona tag successfully.
    * You're now ready to send actual game transactions to Cardinal.
10. Send Request to the `tx/game/join` endpoint with the following (empty) body:
    * `{}`
    * The response should contain a `TxHash` and `Tick` field, indicating a successfully submitted transaction.
11. From the docker UI, stop ALL running containers.
12. Delete the `redis` docker container.
13. Re-run `docker compose up nakama --build`
14. Re-do step 10. THIS SHOULD FAIL
    * The error message should contain `persona tag does not have a signer`
    * Cardinal's state was re-set, but Nakama still has a person tag associated with your User ID.
15. Stop all docker contaienrs.
16. Checkout this branch with: `git checkout jer/world-1022-reregister-persona-tags`
17. Re-run `docker compose up nakama --build`
18. Re-do step 10. THIS SHOULD SUCCEED
    * There will be a brief pause as Nakama waits for Cardinal to complete a tick.
    * The response body should contain `TxHash` and `Tick` fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the handling of persona tag reclamation by integrating transaction tracking to improve reliability and error reporting.

- **Refactor**
	- Simplified and standardized event handling components across various modules for better maintainability and performance.

- **Bug Fixes**
	- Improved error handling in persona management operations to include transaction hash details, aiding in troubleshooting and user support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->