### PR TITLE
ci: lock eslint linter package version

### DIFF
--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -34,5 +34,5 @@ jobs:
           version: 0.39.0
       - name: MDX Lint
         run: |
-          npx eslint ./docs --ext js,md,mdx \
+          npx eslint . --ext js,mdx \
           --resolve-plugins-relative-to=$(npm config get prefix)/lib/node_modules

--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -34,4 +34,5 @@ jobs:
           version: 0.39.0
       - name: MDX Lint
         run: |
-          npx eslint ./docs --ext js,md,mdx --resolve-plugins-relative-to=$(npm config get prefix)/lib/node_modules
+          npx eslint ./docs --ext js,md,mdx \
+          --resolve-plugins-relative-to=$(npm config get prefix)/lib/node_modules

--- a/.github/workflows/lint-md.yml
+++ b/.github/workflows/lint-md.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
       - name: Install eslint & eslint-plugin-mdx
-        run: npm install eslint eslint-plugin-mdx --global
+        run: npm install eslint@8.57.0 eslint-plugin-mdx@3.1.5 --global
       ## detect errors from markdownlint-cli and create annotations for them
       - uses: xt0rted/markdownlint-problem-matcher@v3
       - name: Markdown Lint
@@ -34,5 +34,4 @@ jobs:
           version: 0.39.0
       - name: MDX Lint
         run: |
-          npx eslint . --ext js,mdx \
-          --resolve-plugins-relative-to=$(npm config get prefix)/lib/node_modules
+          npx eslint ./docs --ext js,md,mdx --resolve-plugins-relative-to=$(npm config get prefix)/lib/node_modules


### PR DESCRIPTION
Closes: WORLD-XXX

## Overview

Lock eslint & eslint-plugin-mdx linter package version, latest v8 --> v9 (5 April) introduce breaking changes with the CLI & config file.

## Brief Changelog

- lock version package eslint @8.57.0
- lock version package eslint-plugin-mdx @3.1.5

## Testing and Verifying

- Linter CI passed