### PR TITLE
feat(cardinal): add emit string event

### DIFF
--- a/cardinal/tick_results.go
+++ b/cardinal/tick_results.go
@@ -31,6 +31,11 @@ func (tr *TickResults) AddEvent(event any) error {
 	return nil
 }
 
+func (tr *TickResults) AddStringEvent(e string) error {
+	tr.Events = append(tr.Events, []byte(e))
+	return nil
+}
+
 func (tr *TickResults) SetReceipts(newReceipts []receipt.Receipt) {
 	tr.Receipts = newReceipts
 }

--- a/cardinal/types/engine/context.go
+++ b/cardinal/types/engine/context.go
@@ -20,8 +20,11 @@ type Context interface {
 	CurrentTick() uint64
 	// Logger returns the logger that can be used to log messages from within system or query.
 	Logger() *zerolog.Logger
-	// EmitEvent emits an event that will be broadcasted to all websocket subscribers.
+	// EmitEvent emits an event that will be broadcast to all websocket subscribers.
 	EmitEvent(map[string]any) error
+	// EmitStringEvent emits a string event that will be broadcast to all websocket subscribers.
+	// This method is provided for backwards compatability. EmitEvent should be used for most cases.
+	EmitStringEvent(string) error
 	// Namespace returns the namespace of the world.
 	Namespace() string
 

--- a/cardinal/world_context.go
+++ b/cardinal/world_context.go
@@ -99,6 +99,10 @@ func (ctx *worldContext) EmitEvent(event map[string]any) error {
 	return ctx.world.tickResults.AddEvent(event)
 }
 
+func (ctx *worldContext) EmitStringEvent(e string) error {
+	return ctx.world.tickResults.AddStringEvent(e)
+}
+
 func (ctx *worldContext) GetSignerForPersonaTag(personaTag string, tick uint64) (addr string, err error) {
 	return ctx.world.GetSignerForPersonaTag(personaTag, tick)
 }


### PR DESCRIPTION
## Overview

adding back the ability to emit an event via string. this is for backwards compat for marks current code. and possibly others.

## Brief Changelog

- adds EmitStringEvent to both world context as well as TickResults

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
