### PR TITLE
fix(nakama): Jer/world 1011 string events should be wrapped in json

### DIFF
--- a/e2e/testgames/game/sys/join.go
+++ b/e2e/testgames/game/sys/join.go
@@ -37,6 +37,11 @@ func Join(ctx cardinal.WorldContext) error {
 			if err != nil {
 				return msg.JoinOutput{}, err
 			}
+			err = ctx.EmitStringEvent("this is a string event")
+			if err != nil {
+				return msg.JoinOutput{}, err
+			}
+
 			return msg.JoinOutput{Success: true}, nil
 		},
 	)

--- a/e2e/tests/nakama/nakama_test.go
+++ b/e2e/tests/nakama/nakama_test.go
@@ -11,10 +11,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/argus-labs/world-engine/e2e/tests/clients"
 	"github.com/ethereum/go-ethereum/crypto"
 
+	"github.com/argus-labs/world-engine/e2e/tests/clients"
+
 	"pkg.world.dev/world-engine/assert"
+)
+
+const (
+	stringEventPattern = "this is a string event"
+	mapEventPattern    = "player created"
 )
 
 func TestEvents(t *testing.T) {
@@ -49,7 +55,8 @@ func TestEvents(t *testing.T) {
 	// Fetch events and verify
 	var events []clients.Event
 	timeout := time.After(5 * time.Second)
-	for len(events) < amountOfPlayers {
+	// There are 2 event messages per player
+	for len(events) < amountOfPlayers*2 {
 		select {
 		case e := <-c.EventCh:
 			events = append(events, e)
@@ -58,10 +65,22 @@ func TestEvents(t *testing.T) {
 		}
 	}
 
-	assert.Equal(t, len(events), amountOfPlayers, "Expected number of player creation events does not match")
+	assert.Equal(t, len(events), amountOfPlayers*2,
+		"Expected number of player creation events does not match")
+	numOfStringEvents := 0
+	numOfMapEvents := 0
 	for _, event := range events {
-		assert.Contains(t, event.Message, "player created", "Event message does not contain expected text")
+		if strings.Contains(event.Message, stringEventPattern) {
+			numOfStringEvents++
+		} else if strings.Contains(event.Message, mapEventPattern) {
+			numOfMapEvents++
+		} else {
+			assert.Fail(t, fmt.Sprintf("message %q does not contain %q nor %q",
+				event.Message, stringEventPattern, mapEventPattern))
+		}
 	}
+	assert.Equal(t, amountOfPlayers, numOfStringEvents)
+	assert.Equal(t, amountOfPlayers, numOfMapEvents)
 }
 
 func TestReceipts(t *testing.T) {

--- a/e2e/tests/nakama/nakama_test.go
+++ b/e2e/tests/nakama/nakama_test.go
@@ -11,9 +11,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum/crypto"
-
 	"github.com/argus-labs/world-engine/e2e/tests/clients"
+	"github.com/ethereum/go-ethereum/crypto"
 
 	"pkg.world.dev/world-engine/assert"
 )
@@ -70,11 +69,12 @@ func TestEvents(t *testing.T) {
 	numOfStringEvents := 0
 	numOfMapEvents := 0
 	for _, event := range events {
-		if strings.Contains(event.Message, stringEventPattern) {
+		switch {
+		case strings.Contains(event.Message, stringEventPattern):
 			numOfStringEvents++
-		} else if strings.Contains(event.Message, mapEventPattern) {
+		case strings.Contains(event.Message, mapEventPattern):
 			numOfMapEvents++
-		} else {
+		default:
 			assert.Fail(t, fmt.Sprintf("message %q does not contain %q nor %q",
 				event.Message, stringEventPattern, mapEventPattern))
 		}

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -167,8 +167,13 @@ func initEventHub(
 		ch := eventHub.SubscribeToEvents("main")
 		for event := range ch {
 			content := make(map[string]any)
-			err = json.Unmarshal(event, &content)
-			err := eris.Wrap(nk.NotificationSendAll(ctx, "event", content, 1, false), "")
+			err := json.Unmarshal(event, &content)
+			if err != nil {
+				// The event content isn't in JSON format. Wrap whatever it is in a JSON blob.
+				content["message"] = string(event)
+			}
+
+			err = eris.Wrap(nk.NotificationSendAll(ctx, "event", content, 1, false), "")
 			if err != nil {
 				log.Error("error sending notifications: %s", eris.ToString(err, true))
 			}


### PR DESCRIPTION
Closes: WORLD-1011

## Overview

Previously, a non-json encoded string event would result in a json.Unmarshal error, which was then ignored.

Now when we encounter an error, the string is wrapped in a `{"message": "<the event>"}` json blob.

## Testing and Verifying

The e2e game has been adjusted to emit both a map event and a string event. The relevant test has been updated to check for both strings.
