### PR TITLE
fix(cardinal): Jer/ensure e2e tests fail ci

### DIFF
--- a/cardinal/receipt/receipt.go
+++ b/cardinal/receipt/receipt.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rotisserie/eris"
 
+	"pkg.world.dev/world-engine/cardinal/codec"
 	"pkg.world.dev/world-engine/cardinal/types"
 )
 
@@ -27,9 +28,26 @@ type History struct {
 
 // Receipt contains a transaction hash, an arbitrary result, and a list of errors.
 type Receipt struct {
-	TxHash types.TxHash `json:"txHash"`
-	Result any          `json:"result"`
-	Errs   []error      `json:"errs"`
+	TxHash types.TxHash
+	Result any
+	Errs   []error
+}
+
+func (r Receipt) MarshalJSON() ([]byte, error) {
+	errStrings := make([]string, len(r.Errs))
+	for i, err := range r.Errs {
+		errStrings[i] = err.Error()
+	}
+
+	return codec.Encode(struct {
+		TxHash types.TxHash `json:"txHash"`
+		Result any          `json:"result"`
+		Errs   []string     `json:"errors"`
+	}{
+		TxHash: r.TxHash,
+		Result: r.Result,
+		Errs:   errStrings,
+	})
 }
 
 // NewHistory creates a object that can track transaction receipts over a number of ticks.

--- a/cardinal/receipt/receipt_test.go
+++ b/cardinal/receipt/receipt_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/rotisserie/eris"
 
 	"pkg.world.dev/world-engine/assert"
+	"pkg.world.dev/world-engine/cardinal/codec"
 	"pkg.world.dev/world-engine/cardinal/types"
 )
 
@@ -145,4 +146,27 @@ func TestOldTicksAreDiscarded(t *testing.T) {
 	rh.NextTick()
 	_, err := rh.GetReceiptsForTick(tickToGet)
 	assert.ErrorIs(t, ErrOldTickHasBeenDiscarded, eris.Cause(err))
+}
+
+func TestReceipt_ReceiptErrorsArePresentInJSON(t *testing.T) {
+	var (
+		receiptHash   = "some_tx_hash"
+		receiptResult = "some_receipt_result"
+		receiptError  = "some_receipt_error"
+	)
+	receipt := &Receipt{
+		TxHash: types.TxHash(receiptHash),
+		Result: map[string]string{
+			"field": receiptResult,
+		},
+		Errs: []error{
+			errors.New(receiptError),
+		},
+	}
+	bz, err := codec.Encode(receipt)
+	assert.NilError(t, err)
+	body := string(bz)
+	assert.Contains(t, body, receiptHash)
+	assert.Contains(t, body, receiptResult)
+	assert.Contains(t, body, receiptError)
 }

--- a/e2e/tests/nakama/nakama_test.go
+++ b/e2e/tests/nakama/nakama_test.go
@@ -171,7 +171,7 @@ func TestTransactionAndCQLAndRead(t *testing.T) {
 	// the game tick has executed. We spin on this check until we find the desired results or until we time out.
 	yAndNameNotFound := true
 	for yAndNameNotFound {
-		resp, err = c.RPC("/cql", struct {
+		resp, err = c.RPC("cql", struct {
 			CQL string `json:"CQL"`
 		}{"CONTAINS(player)"})
 		assert.NilError(t, err)

--- a/e2e/tests/nakama/nakama_test.go
+++ b/e2e/tests/nakama/nakama_test.go
@@ -171,7 +171,7 @@ func TestTransactionAndCQLAndRead(t *testing.T) {
 	// the game tick has executed. We spin on this check until we find the desired results or until we time out.
 	yAndNameNotFound := true
 	for yAndNameNotFound {
-		resp, err = c.RPC("query/game/cql", struct {
+		resp, err = c.RPC("/cql", struct {
 			CQL string `json:"CQL"`
 		}{"CONTAINS(player)"})
 		assert.NilError(t, err)

--- a/makefiles/test.mk
+++ b/makefiles/test.mk
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 DIRS_E2E = e2e/tests/nakama e2e/testgames/game relay/nakama
 DIRS_E2E_BENCHMARK = e2e/tests/bench e2e/testgames/gamebenchmark relay/nakama
 DIRS_E2E_EVM = e2e/tests/evm e2e/testgames/game relay/nakama
@@ -11,7 +12,14 @@ e2e-nakama:
 		cd $(ROOT_DIR); \
 	)
 
-	@docker compose up --build game nakama test_nakama --abort-on-container-exit --exit-code-from test_nakama 2>&1 | grep --color=force "test_nakama   | "
+	@(set -o pipefail; \
+		docker compose up --build \
+			game \
+			nakama \
+			test_nakama \
+			--abort-on-container-exit \
+			--exit-code-from test_nakama 2>&1 | \
+		grep --color=force "test_nakama   | ")
 	@docker compose down --volumes -v
 
 e2e-benchmark:

--- a/relay/nakama/main.go
+++ b/relay/nakama/main.go
@@ -275,6 +275,9 @@ func initCardinalEndpoints(
 		return err
 	}
 	// Register all the query endpoints. These do not require signatures.
+	// cql and debug/state are similar to normal cardinal queries, but they are not created by the same mechanism,
+	// so they don't show up in the queryEndpoints slice.
+	queryEndpoints = append(queryEndpoints, "cql", "debug/state")
 	err = registerEndpoints(
 		// Register all the transaction endpoints. These require signatures.
 		logger,


### PR DESCRIPTION


## Overview

Ensure failing e2e tests will properly fail CI. Fix broken e2e tests.

## Brief Changelog

- Add the `set -o pipefail` prefix to a make command to ensure the pipe does not swallow test errors
- Fix a broken cql test (the cql endpoint was moved from query/game/cql to just cql)
- Fix a broken receipts test (receipt errors were not converted to strings before being sent across the wire)

## Testing and Verifying

`make e2e-nakama` to run the end to end tests locally.
