### PR TITLE
fix(cardinal): Ensure components to delete are cleared between ticks

### DIFF
--- a/cardinal/gamestate/redis.go
+++ b/cardinal/gamestate/redis.go
@@ -230,6 +230,9 @@ func (m *EntityCommandBuffer) addComponentChangesToPipe(ctx context.Context, pip
 			return eris.Wrap(err, "")
 		}
 	}
+	if err = m.compValuesToDelete.Clear(); err != nil {
+		return eris.Wrap(err, "failed to clear to-be-deleted component values store")
+	}
 	keys, err := m.compValues.Keys()
 	if err != nil {
 		return err

--- a/cardinal/gamestate/redis_test.go
+++ b/cardinal/gamestate/redis_test.go
@@ -70,7 +70,13 @@ func TestComponentValuesAreDeletedFromRedis(t *testing.T) {
 	// Now remove the alpha component from the entity.
 	assert.NilError(t, manager.RemoveComponentFromEntity(alphaComp, id))
 
+	// One component should be marked for deletion
+	assert.Equal(t, 1, manager.compValuesToDelete.Len())
+
 	assert.NilError(t, manager.FinalizeTick(ctx))
+
+	// The list of components to be deleted should be cleared after each tick
+	assert.Equal(t, 0, manager.compValuesToDelete.Len())
 
 	// Verify the component in question no longer exists in the DB
 	err = client.Get(ctx, key).Err()


### PR DESCRIPTION
Closes: WORLD-1010


## Overview

compValuesToDelete keeps track of what entity/components need to be deleted from redis. Previously, this store was never cleared out between ticks. Consequently, if component X is delete on tick 10, every tick after 10 would also get a redis command to delete that component X. 

This set of components to delete would grow without bounds and cause the finalize tick portion of the tick to increase over time.

## Brief Changelog

Ensure compValuesToDelete is cleaned up between ticks. 
Add a test to ensure the struct is empty between ticks.

## Testing and Verifying

Unit test added.
