### PR TITLE
perf(cardinal): Only rebuild the persona tag index when needed

### DIFF
--- a/cardinal/plugin_persona.go
+++ b/cardinal/plugin_persona.go
@@ -19,7 +19,17 @@ import (
 	"pkg.world.dev/world-engine/cardinal/types/engine"
 )
 
-var _ Plugin = (*personaPlugin)(nil)
+var (
+	_ Plugin = (*personaPlugin)(nil)
+
+	// globalPersonaTagToAddressIndex keeps track of the mapping of persona-tags->signer-address so it doesn't need to
+	// be recomputed each tick.
+	globalPersonaTagToAddressIndex personaIndex
+	// The tick that the globalPersonaTagToAddressIndex was built on. In normal usage, wCtx.CurrentTick should always
+	// be greater than this number, but during tests the currentTick will be reset. Tracking this number at the global
+	// is easier than updating each test to reset this global value.
+	tickOfPersonaTagToAddressIndex uint64
+)
 
 type personaIndex = map[string]personaIndexEntry
 
@@ -102,31 +112,20 @@ func (p *personaPlugin) RegisterMessages(world *World) error {
 // users who want to interact with the game via smart contract can link their EVM address to their persona tag, enabling
 // them to mutate their owned state from the context of the EVM.
 func AuthorizePersonaAddressSystem(wCtx engine.Context) error {
-	// The persona tag index will be lazily built for the first AuthorizePersonaAddress message. If no such messages
-	// are present, the index will not be built.
-	var personaTagToAddress personaIndex
-	var personaTagToAddressErr error
+	if err := buildGlobalPersonaIndex(wCtx); err != nil {
+		return err
+	}
 	return EachMessage[msg.AuthorizePersonaAddress, msg.AuthorizePersonaAddressResult](
 		wCtx,
 		func(txData message.TxData[msg.AuthorizePersonaAddress]) (
 			result msg.AuthorizePersonaAddressResult, err error,
 		) {
-			if personaTagToAddress == nil {
-				personaTagToAddress, personaTagToAddressErr = buildPersonaIndex(wCtx)
-			}
-			if personaTagToAddressErr != nil {
-				return result, personaTagToAddressErr
-			}
-			// If this is still nil, assign it to an empty map to prevent us from trying to rebuild it again.
-			if personaTagToAddress == nil {
-				personaTagToAddress = personaIndex{}
-			}
 			txMsg, tx := txData.Msg, txData.Tx
 			result.Success = false
 
 			// Check if the Persona Tag exists
 			lowerPersona := strings.ToLower(tx.PersonaTag)
-			data, ok := personaTagToAddress[lowerPersona]
+			data, ok := globalPersonaTagToAddressIndex[lowerPersona]
 			if !ok {
 				return result, eris.Errorf("persona %s does not exist", tx.PersonaTag)
 			}
@@ -166,24 +165,12 @@ func AuthorizePersonaAddressSystem(wCtx engine.Context) error {
 // CreatePersonaSystem is a system that will associate persona tags with signature addresses. Each persona tag
 // may have at most 1 signer, so additional attempts to register a signer with a persona tag will be ignored.
 func CreatePersonaSystem(wCtx engine.Context) error {
-	// The persona tag index will be lazily built for the first CreatePersona message. If no such messages
-	// are present, the index will not be built.
-	var personaTagToAddress personaIndex
-	var personaTagToAddressErr error
+	if err := buildGlobalPersonaIndex(wCtx); err != nil {
+		return err
+	}
 	return EachMessage[msg.CreatePersona, msg.CreatePersonaResult](
 		wCtx,
 		func(txData message.TxData[msg.CreatePersona]) (result msg.CreatePersonaResult, err error) {
-			if personaTagToAddress == nil {
-				personaTagToAddress, personaTagToAddressErr = buildPersonaIndex(wCtx)
-			}
-			if personaTagToAddressErr != nil {
-				return result, personaTagToAddressErr
-			}
-			// If this is still nil, assign it to an empty map to prevent us from trying to rebuild it again.
-			if personaTagToAddress == nil {
-				personaTagToAddress = personaIndex{}
-			}
-
 			txMsg := txData.Msg
 			result.Success = false
 
@@ -198,7 +185,7 @@ func CreatePersonaSystem(wCtx engine.Context) error {
 
 			// Temporarily convert tag to lowercase to check against mapping of lowercase tags
 			lowerPersona := strings.ToLower(txMsg.PersonaTag)
-			if _, ok := personaTagToAddress[lowerPersona]; ok {
+			if _, ok := globalPersonaTagToAddressIndex[lowerPersona]; ok {
 				// This PersonaTag has already been registered. Don't do anything
 				err = eris.Errorf("persona tag %s has already been registered", txMsg.PersonaTag)
 				return result, err
@@ -216,7 +203,7 @@ func CreatePersonaSystem(wCtx engine.Context) error {
 			); err != nil {
 				return result, eris.Wrap(err, "")
 			}
-			personaTagToAddress[lowerPersona] = personaIndexEntry{
+			globalPersonaTagToAddressIndex[lowerPersona] = personaIndexEntry{
 				SignerAddress: txMsg.SignerAddress,
 				EntityID:      id,
 			}
@@ -230,8 +217,13 @@ func CreatePersonaSystem(wCtx engine.Context) error {
 // Persona Index
 // -----------------------------------------------------------------------------
 
-func buildPersonaIndex(wCtx engine.Context) (personaIndex, error) {
-	personaTagToAddress := map[string]personaIndexEntry{}
+func buildGlobalPersonaIndex(wCtx engine.Context) error {
+	// Rebuild the index if we haven't built it yet OR if we're in test and the CurrentTick has been reset.
+	if globalPersonaTagToAddressIndex != nil && tickOfPersonaTagToAddressIndex < wCtx.CurrentTick() {
+		return nil
+	}
+	tickOfPersonaTagToAddressIndex = wCtx.CurrentTick()
+	globalPersonaTagToAddressIndex = map[string]personaIndexEntry{}
 	var errs []error
 	s := search.NewSearch().Entity(filter.Exact(filter.Component[component.SignerComponent]()))
 	err := s.Each(wCtx,
@@ -242,7 +234,7 @@ func buildPersonaIndex(wCtx engine.Context) (personaIndex, error) {
 				return true
 			}
 			lowerPersona := strings.ToLower(sc.PersonaTag)
-			personaTagToAddress[lowerPersona] = personaIndexEntry{
+			globalPersonaTagToAddressIndex[lowerPersona] = personaIndexEntry{
 				SignerAddress: sc.SignerAddress,
 				EntityID:      id,
 			}
@@ -250,10 +242,10 @@ func buildPersonaIndex(wCtx engine.Context) (personaIndex, error) {
 		},
 	)
 	if err != nil {
-		return nil, err
+		return err
 	}
 	if len(errs) != 0 {
-		return nil, errors.Join(errs...)
+		return errors.Join(errs...)
 	}
-	return personaTagToAddress, nil
+	return nil
 }

--- a/cardinal/plugin_persona.go
+++ b/cardinal/plugin_persona.go
@@ -22,12 +22,17 @@ import (
 var (
 	_ Plugin = (*personaPlugin)(nil)
 
+	// TODO: Replace these global variables when indexing/fast-searching is supported.
+	// See https://linear.app/arguslabs/issue/WORLD-1057/spec-out-component-indexing
+	// These global variables are used to quickly identify already-created persona tags. The map should exactly match
+	// the persona tag information stored in the ECS layer. When Cardinal restarts, this map needs to be rebuilt.
+	//
 	// globalPersonaTagToAddressIndex keeps track of the mapping of persona-tags->signer-address so it doesn't need to
 	// be recomputed each tick.
 	globalPersonaTagToAddressIndex personaIndex
-	// The tick that the globalPersonaTagToAddressIndex was built on. In normal usage, wCtx.CurrentTick should always
-	// be greater than this number, but during tests the currentTick will be reset. Tracking this number at the global
-	// is easier than updating each test to reset this global value.
+	// tickOfPersonaTagToAddressIndex is the tick that the globalPersonaTagToAddressIndex was built on. In normal usage,
+	// wCtx.CurrentTick should always be greater than this number, but during tests the currentTick will be reset.
+	// Tracking this number at the global is easier than updating each test to reset these global value.
 	tickOfPersonaTagToAddressIndex uint64
 )
 

--- a/cardinal/world_persona_test.go
+++ b/cardinal/world_persona_test.go
@@ -3,9 +3,10 @@ package cardinal_test
 import (
 	"fmt"
 	"testing"
+	"time"
 
 	"pkg.world.dev/world-engine/assert"
-	msg2 "pkg.world.dev/world-engine/cardinal/persona/msg"
+	"pkg.world.dev/world-engine/cardinal/persona/msg"
 	"pkg.world.dev/world-engine/cardinal/testutils"
 	"pkg.world.dev/world-engine/sign"
 )
@@ -13,15 +14,15 @@ import (
 func TestGetSignerComponentForPersona(t *testing.T) {
 	tf := testutils.NewTestFixture(t, nil)
 	world := tf.World
-	msg, exists := world.GetMessageByFullName("persona.create-persona")
+	msgType, exists := world.GetMessageByFullName("persona.create-persona")
 	assert.True(t, exists)
 	personaTag := "tyler"
 	signer := "foobar"
-	createPersonaMsg := msg2.CreatePersona{
+	createPersonaMsg := msg.CreatePersona{
 		PersonaTag:    personaTag,
 		SignerAddress: signer,
 	}
-	world.AddTransaction(msg.ID(), createPersonaMsg, &sign.Transaction{})
+	world.AddTransaction(msgType.ID(), createPersonaMsg, &sign.Transaction{})
 	tf.DoTick()
 
 	sc, err := world.GetSignerComponentForPersona(personaTag)
@@ -33,4 +34,46 @@ func TestGetSignerComponentForPersona(t *testing.T) {
 	sc, err = world.GetSignerComponentForPersona(notRealPersona)
 	assert.ErrorContains(t, err, fmt.Sprintf("persona tag %q not found", notRealPersona))
 	assert.Nil(t, sc)
+}
+
+func TestCreatePersonaSystem_WithNoPersonaTagCreateTxs_TickShouldBeFast(t *testing.T) {
+	tf := testutils.NewTestFixture(t, nil)
+
+	const trials = 100
+	startTime := time.Now()
+	// Collect a baseline average tick duration when there are no persona tags and nothing is going on
+	for i := 0; i < trials; i++ {
+		tf.DoTick()
+	}
+	baselineDuration := time.Since(startTime) / trials
+
+	msgType, exists := tf.World.GetMessageByFullName("persona.create-persona")
+	assert.True(t, exists)
+
+	// Create 100 persona tags and make sure they exist
+	for i := 0; i < 100; i++ {
+		createPersonaMsg := msg.CreatePersona{
+			PersonaTag:    fmt.Sprintf("personatag%d", i),
+			SignerAddress: fmt.Sprintf("some-signer-%d", i),
+		}
+		tf.World.AddTransaction(msgType.ID(), createPersonaMsg, &sign.Transaction{})
+		tf.DoTick()
+		// Make sure the persona tag was actually added
+		receipts, err := tf.World.GetTransactionReceiptsForTick(tf.World.CurrentTick() - 1)
+		assert.NilError(t, err)
+		assert.Equal(t, 1, len(receipts))
+		assert.Equal(t, 0, len(receipts[0].Errs))
+	}
+
+	startTime = time.Now()
+	// Collect another average for ticks that have no persona tag registrations. These ticks should be similar
+	// in duration to the baseline.
+	for i := 0; i < trials; i++ {
+		tf.DoTick()
+	}
+	saturatedDuration := time.Since(startTime) / trials
+	slowdownRatio := float64(saturatedDuration) / float64(baselineDuration)
+	// Fail this test if the second batch of ticks is more than 5 times slower than the original
+	// batch of ticks. The previously registered persona tags should have no performance impact on these systems.
+	assert.True(t, slowdownRatio < 5, "ticks are much slower when many persona tags have been registered")
 }

--- a/cardinal/world_persona_test.go
+++ b/cardinal/world_persona_test.go
@@ -1,13 +1,20 @@
 package cardinal_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 	"time"
 
 	"pkg.world.dev/world-engine/assert"
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/persona/component"
 	"pkg.world.dev/world-engine/cardinal/persona/msg"
+	"pkg.world.dev/world-engine/cardinal/search"
+	"pkg.world.dev/world-engine/cardinal/search/filter"
 	"pkg.world.dev/world-engine/cardinal/testutils"
+	"pkg.world.dev/world-engine/cardinal/types"
+	"pkg.world.dev/world-engine/cardinal/types/engine"
 	"pkg.world.dev/world-engine/sign"
 )
 
@@ -76,4 +83,83 @@ func TestCreatePersonaSystem_WithNoPersonaTagCreateTxs_TickShouldBeFast(t *testi
 	// Fail this test if the second batch of ticks is more than 5 times slower than the original
 	// batch of ticks. The previously registered persona tags should have no performance impact on these systems.
 	assert.True(t, slowdownRatio < 5, "ticks are much slower when many persona tags have been registered")
+}
+
+func TestCreatePersonaSystem_WhenCardinalIsRestarted_PersonaTagsAreStillRegistered(t *testing.T) {
+	tf := testutils.NewTestFixture(t, nil)
+
+	type countPersonaTagsResult struct {
+		personaTags map[string]bool
+		err         error
+	}
+
+	// This is a buffered channel so that the System that uses it doesn't block. It has to be drained
+	// after the DoTick call.
+	numOfPersonaTags := make(chan countPersonaTagsResult, 1)
+
+	// emitNumberOfPersonaTagsSystem is a system that finds all the registered persona tags and sends them
+	// across a channel.
+	emitNumberOfPersonaTagsSystem := func(wCtx engine.Context) error {
+		result := countPersonaTagsResult{personaTags: map[string]bool{}}
+		err := search.NewSearch().
+			Entity(filter.Exact(filter.Component[component.SignerComponent]())).
+			Each(wCtx, func(id types.EntityID) bool {
+				comp, err := cardinal.GetComponent[component.SignerComponent](wCtx, id)
+				result.err = errors.Join(result.err, err)
+				result.personaTags[comp.PersonaTag] = true
+				return true
+			})
+		result.err = errors.Join(result.err, err)
+		numOfPersonaTags <- result
+		return nil
+	}
+	assert.NilError(t, cardinal.RegisterSystems(tf.World, emitNumberOfPersonaTagsSystem))
+
+	msgType, exists := tf.World.GetMessageByFullName("persona.create-persona")
+	assert.True(t, exists)
+
+	// Register 10 persona tags. None of these should fail.
+	for i := 0; i < 10; i++ {
+		currPersonaTag := fmt.Sprintf("pt%d", i)
+		tf.World.AddTransaction(msgType.ID(), msg.CreatePersona{
+			PersonaTag:    currPersonaTag,
+			SignerAddress: fmt.Sprintf("sa%d", i),
+		}, &sign.Transaction{})
+		tf.DoTick()
+		result := <-numOfPersonaTags
+		assert.NilError(t, result.err)
+		assert.Equal(t, i+1, len(result.personaTags))
+		assert.True(t, result.personaTags[currPersonaTag])
+	}
+	// There should now be 10 persona tags registered.
+
+	// Simulate a cardinal restart by creating a new test fixture with the same redis DB.
+	tf = testutils.NewTestFixture(t, tf.Redis)
+	assert.NilError(t, cardinal.RegisterSystems(tf.World, emitNumberOfPersonaTagsSystem))
+
+	// Make sure there are still 10 persona tags registered.
+	tf.DoTick()
+	result := <-numOfPersonaTags
+	assert.NilError(t, result.err)
+	assert.Equal(t, 10, len(result.personaTags))
+	for i := 0; i < 10; i++ {
+		currPersonaTag := fmt.Sprintf("pt%d", i)
+		assert.True(t, result.personaTags[currPersonaTag])
+	}
+
+	// This persona tag has already been registered, so it should fail to register this time.
+	repeatPersonaTag := "pt5"
+	tf.World.AddTransaction(msgType.ID(), msg.CreatePersona{
+		PersonaTag:    repeatPersonaTag,
+		SignerAddress: "some-sa",
+	}, &sign.Transaction{})
+	tf.DoTick()
+
+	// Make sure the receipt from the previous tick talks about the failed persona tag registration.
+	receipts, err := tf.World.GetTransactionReceiptsForTick(tf.World.CurrentTick() - 1)
+	assert.NilError(t, err)
+	assert.Len(t, receipts, 1)
+	errs := receipts[0].Errs
+	assert.Len(t, errs, 1)
+	assert.ErrorContains(t, errs[0], "persona tag pt5 has already been registered")
 }


### PR DESCRIPTION

## Overview

Previously, these persona-tag related systems would build an index of every persona-tag -> signer address every single tick. If no persona-tag related messages were present, this index would go unused.

With this modification, these persona-tag -> signer address map will only be built if it's actually going to be used.

## Testing and Verifying

Unit test added. It ensures the persona-tag related systems don't slow down significantly when no persona-tag messages need to be processed.
