### PR TITLE
refactor(cardinal): switch query storage to use groups.

### DIFF
--- a/cardinal/cardinal.go
+++ b/cardinal/cardinal.go
@@ -146,7 +146,7 @@ func RegisterQuery[Request any, Reply any](
 		return err
 	}
 
-	res := w.RegisterQuery(name, q)
+	res := w.RegisterQuery(q)
 	return res
 }
 

--- a/cardinal/errors_test.go
+++ b/cardinal/errors_test.go
@@ -305,7 +305,7 @@ func TestQueriesDoNotPanicOnComponentHasNotBeenRegistered(t *testing.T) {
 			// Do an initial tick so that the single entity can be cardinal.Created.
 			tick()
 
-			query, err := world.GetQueryByName(queryName)
+			query, err := world.GetQuery(cardinal.DefaultQueryGroup, queryName)
 			assert.Check(t, err == nil)
 
 			readOnlyWorldCtx := cardinal.NewReadOnlyWorldContext(world)
@@ -343,7 +343,7 @@ func TestGetComponentInQueryDoesNotPanicOnRedisError(t *testing.T) {
 	// Tick so the entity can be cardinal.Created
 	tick()
 
-	query, err := world.GetQueryByName(queryName)
+	query, err := world.GetQuery(cardinal.DefaultQueryGroup, queryName)
 	assert.NilError(t, err)
 
 	// Uhoh, redis is now broken.

--- a/cardinal/persona/persona_test.go
+++ b/cardinal/persona/persona_test.go
@@ -233,7 +233,7 @@ func TestQuerySigner(t *testing.T) {
 	signerAddr := "123_456"
 	tf.CreatePersona(personaTag, signerAddr)
 
-	query, err := world.GetQueryByName("signer")
+	query, err := world.GetQuery("persona", "signer")
 	assert.NilError(t, err)
 
 	res, err := cardinal.InternalHandleQuery(
@@ -253,7 +253,7 @@ func TestQuerySignerAvailable(t *testing.T) {
 	world := tf.World
 	tf.DoTick()
 
-	query, err := world.GetQueryByName("signer")
+	query, err := world.GetQuery("persona", "signer")
 	assert.NilError(t, err)
 	res, err := cardinal.InternalHandleQuery(
 		cardinal.NewReadOnlyWorldContext(world), query, &cardinal.PersonaSignerQueryRequest{
@@ -271,7 +271,7 @@ func TestQuerySignerUnknown(t *testing.T) {
 	engine := tf.World
 	tf.DoTick()
 
-	query, err := engine.GetQueryByName("signer")
+	query, err := engine.GetQuery("persona", "signer")
 	assert.NilError(t, err)
 	res, err := cardinal.InternalHandleQuery(cardinal.NewReadOnlyWorldContext(engine), query,
 		&cardinal.PersonaSignerQueryRequest{

--- a/cardinal/query.go
+++ b/cardinal/query.go
@@ -13,6 +13,8 @@ import (
 
 var _ query = &queryType[struct{}, struct{}]{}
 
+var DefaultQueryGroup = "game"
+
 type query interface {
 	// Name returns the name of the query.
 	Name() string
@@ -76,7 +78,7 @@ func newQueryType[Request any, Reply any](
 	}
 	r := &queryType[Request, Reply]{
 		name:    name,
-		group:   "game",
+		group:   DefaultQueryGroup,
 		handler: handler,
 	}
 	for _, opt := range opts {

--- a/cardinal/query_manager.go
+++ b/cardinal/query_manager.go
@@ -71,13 +71,6 @@ func (m *queryManager) GetQuery(group string, name string) (query, error) {
 	return query, nil
 }
 
-func (m *queryManager) isQueryNameUnique(name string) error {
-	if _, ok := m.registeredQueriesByGroup[name]; ok {
-		return eris.Errorf("query %q is already registered", name)
-	}
-	return nil
-}
-
 func (m *queryManager) BuildQueryFields() []types.FieldDetail {
 	// Collecting the structure of all queries
 	queries := m.GetRegisteredQueries()

--- a/cardinal/query_test.go
+++ b/cardinal/query_test.go
@@ -98,7 +98,7 @@ func TestQueryExample(t *testing.T) {
 	}
 
 	// No entities should have health over a million.
-	q, err := world.GetQueryByName("query_health")
+	q, err := world.GetQuery(cardinal.DefaultQueryGroup, "query_health")
 	assert.NilError(t, err)
 
 	resp, err := cardinal.InternalHandleQuery(worldCtx, q, QueryHealthRequest{1_000_000})
@@ -159,7 +159,7 @@ func TestQueryEVM(t *testing.T) {
 	assert.NilError(t, err)
 
 	// create the abi encoded bytes that the EVM would send.
-	fooQuery, err := world.GetQueryByName("foo")
+	fooQuery, err := world.GetQuery(cardinal.DefaultQueryGroup, "foo")
 	assert.NilError(t, err)
 	bz, err := fooQuery.EncodeAsABI(FooRequest{ID: "foo"})
 	assert.NilError(t, err)

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -604,7 +604,7 @@ func (w *World) WaitForNextTick() (success bool) {
 }
 
 func (w *World) HandleEVMQuery(name string, abiRequest []byte) ([]byte, error) {
-	qry, err := w.GetQueryByName(name)
+	qry, err := w.GetQuery(DefaultQueryGroup, name)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Closes: WORLD-1125

Query storage used to be inconsistently implemented with an index based on group/name with storage based on name only. 

This PR completely converts query storage into a map[group][name] storage. 

The cost of this is that the API can no longer have a QueryByName, you need to have the group explicitly declared to fetch a query. 