### PR TITLE
refactor(cardinal): move GetMessage to testutils.

### DIFF
--- a/cardinal/cardinal_test.go
+++ b/cardinal/cardinal_test.go
@@ -191,7 +191,7 @@ func TestTransactionAreAppliedToSomeEntities(t *testing.T) {
 	ids, err := cardinal.CreateMany(wCtx, 100, ScoreComponent{})
 	assert.NilError(t, err)
 	// Entities at index 5, 10 and 50 will be updated with some values
-	modifyScoreMsg, err := cardinal.GetMessage[*ModifyScoreMsg, *EmptyMsgResult](wCtx)
+	modifyScoreMsg, err := testutils.GetMessage[*ModifyScoreMsg, *EmptyMsgResult](tf.World)
 	assert.NilError(t, err)
 	tf.AddTransaction(
 		modifyScoreMsg.ID(), &ModifyScoreMsg{
@@ -314,7 +314,7 @@ func TestTransactionsAreExecutedAtNextTick(t *testing.T) {
 	err := cardinal.RegisterSystems(
 		world,
 		func(wCtx cardinal.WorldContext) error {
-			modScoreMsg, err := cardinal.GetMessage[*ModifyScoreMsg, *EmptyMsgResult](wCtx)
+			modScoreMsg, err := testutils.GetMessage[*ModifyScoreMsg, *EmptyMsgResult](world)
 			if err != nil {
 				return err
 			}
@@ -328,7 +328,7 @@ func TestTransactionsAreExecutedAtNextTick(t *testing.T) {
 	err = cardinal.RegisterSystems(
 		world,
 		func(wCtx cardinal.WorldContext) error {
-			modScoreMsg, err := cardinal.GetMessage[*ModifyScoreMsg, *EmptyMsgResult](wCtx)
+			modScoreMsg, err := testutils.GetMessage[*ModifyScoreMsg, *EmptyMsgResult](world)
 			if err != nil {
 				return err
 			}
@@ -437,7 +437,7 @@ func TestCanGetTransactionErrorsAndResults(t *testing.T) {
 			// 2) An EntityID that uniquely identifies this specific transaction
 			// 3) The signature
 			// This function would replace both "In" and "TxsAndSigsIn"
-			moveMsg, err := cardinal.GetMessage[MoveMsg, MoveMsgResult](wCtx)
+			moveMsg, err := testutils.GetMessage[MoveMsg, MoveMsgResult](world)
 			assert.NilError(t, err)
 			txData := moveMsg.In(wCtx)
 			assert.Equal(t, 1, len(txData), "expected 1 move transaction")
@@ -496,7 +496,7 @@ func TestSystemCanFindErrorsFromEarlierSystem(t *testing.T) {
 		world,
 		func(wCtx cardinal.WorldContext) error {
 			systemCalls++
-			numTx, err := cardinal.GetMessage[MsgIn, MsgOut](wCtx)
+			numTx, err := testutils.GetMessage[MsgIn, MsgOut](world)
 			if err != nil {
 				return err
 			}
@@ -515,7 +515,7 @@ func TestSystemCanFindErrorsFromEarlierSystem(t *testing.T) {
 		world,
 		func(wCtx cardinal.WorldContext) error {
 			systemCalls++
-			numTx, err := cardinal.GetMessage[MsgIn, MsgOut](wCtx)
+			numTx, err := testutils.GetMessage[MsgIn, MsgOut](world)
 			if err != nil {
 				return err
 			}
@@ -558,7 +558,7 @@ func TestSystemCanClobberTransactionResult(t *testing.T) {
 		world,
 		func(wCtx cardinal.WorldContext) error {
 			systemCalls++
-			numTx, err := cardinal.GetMessage[MsgIn, MsgOut](wCtx)
+			numTx, err := testutils.GetMessage[MsgIn, MsgOut](world)
 			assert.NilError(t, err)
 			txs := numTx.In(wCtx)
 			assert.Equal(t, 1, len(txs))
@@ -575,7 +575,7 @@ func TestSystemCanClobberTransactionResult(t *testing.T) {
 		world,
 		func(wCtx cardinal.WorldContext) error {
 			systemCalls++
-			numTx, err := cardinal.GetMessage[MsgIn, MsgOut](wCtx)
+			numTx, err := testutils.GetMessage[MsgIn, MsgOut](world)
 			if err != nil {
 				return err
 			}
@@ -618,7 +618,7 @@ func TestTransactionExample(t *testing.T) {
 	assert.NilError(t, cardinal.RegisterMessage[AddHealthToEntityTx, AddHealthToEntityResult](world, msgName))
 	err := cardinal.RegisterSystems(world, func(wCtx cardinal.WorldContext) error {
 		// test "In" method
-		addHealthToEntity, err := cardinal.GetMessage[AddHealthToEntityTx, AddHealthToEntityResult](wCtx)
+		addHealthToEntity, err := testutils.GetMessage[AddHealthToEntityTx, AddHealthToEntityResult](world)
 		if err != nil {
 			return err
 		}

--- a/cardinal/state_test.go
+++ b/cardinal/state_test.go
@@ -309,7 +309,7 @@ func TestCanFindTransactionsAfterReloadingEngine(t *testing.T) {
 		err := cardinal.RegisterSystems(
 			world,
 			func(wCtx cardinal.WorldContext) error {
-				someTx, err := cardinal.GetMessage[Msg, Result](wCtx)
+				someTx, err := testutils.GetMessage[Msg, Result](world)
 				return cardinal.EachMessage[Msg, Result](wCtx, func(tx cardinal.TxData[Msg]) (Result, error) {
 					someTx.SetResult(wCtx, tx.Hash, Result{})
 					return Result{}, err

--- a/cardinal/testutils/testutils.go
+++ b/cardinal/testutils/testutils.go
@@ -2,11 +2,15 @@ package testutils
 
 import (
 	"crypto/ecdsa"
+	"reflect"
 	"testing"
 	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/rotisserie/eris"
 
+	"pkg.world.dev/world-engine/cardinal"
+	"pkg.world.dev/world-engine/cardinal/types"
 	"pkg.world.dev/world-engine/sign"
 )
 
@@ -54,4 +58,19 @@ func UniqueSignatureWithName(name string) *sign.Transaction {
 
 func UniqueSignature() *sign.Transaction {
 	return UniqueSignatureWithName("some_persona_tag")
+}
+
+func GetMessage[In any, Out any](w *cardinal.World) (*cardinal.MessageType[In, Out], error) {
+	var msg cardinal.MessageType[In, Out]
+	msgType := reflect.TypeOf(msg)
+	tempRes, ok := w.GetMessageByType(msgType)
+	if !ok {
+		return nil, eris.Errorf("Could not find %q, Message may not be registered.", msg.Name())
+	}
+	var _ types.Message = &msg
+	res, ok := tempRes.(*cardinal.MessageType[In, Out])
+	if !ok {
+		return &msg, eris.New("wrong type")
+	}
+	return res, nil
 }

--- a/cardinal/util.go
+++ b/cardinal/util.go
@@ -1,14 +1,10 @@
 package cardinal
 
 import (
-	"reflect"
-
 	"github.com/rotisserie/eris"
 
-	"pkg.world.dev/world-engine/cardinal/gamestate"
 	"pkg.world.dev/world-engine/cardinal/receipt"
 	"pkg.world.dev/world-engine/cardinal/server"
-	"pkg.world.dev/world-engine/cardinal/types"
 )
 
 var NonFatalError = []error{
@@ -53,31 +49,12 @@ func isFatalError(err error) bool {
 	return true
 }
 
-func GetMessage[In any, Out any](wCtx WorldContext) (*MessageType[In, Out], error) {
-	var msg MessageType[In, Out]
-	msgType := reflect.TypeOf(msg)
-	tempRes, ok := wCtx.getMessageByType(msgType)
-	if !ok {
-		return nil, eris.Errorf("Could not find %q, Message may not be registered.", msg.Name())
-	}
-	var _ types.Message = &msg
-	res, ok := tempRes.(*MessageType[In, Out])
-	if !ok {
-		return &msg, eris.New("wrong type")
-	}
-	return res, nil
-}
-
 func GetTransactionReceiptsForTick(wCtx WorldContext, tick uint64) ([]receipt.Receipt, error) {
 	ctx, ok := wCtx.(*worldContext)
 	if !ok {
 		return nil, eris.New("error in test type assertion.")
 	}
 	return ctx.world.GetTransactionReceiptsForTick(tick)
-}
-
-func GetStoreManagerFromContext(wCtx WorldContext) gamestate.Manager {
-	return wCtx.storeManager()
 }
 
 // InternalHandleQuery is only used for tests it should not be used outside of that context.


### PR DESCRIPTION
Closes: WORLD-1124

Moved GetMessage to testutils. In order to use "private" functionality changed the signature of this to use world instead of Wctx. 

