### PR TITLE
fix: remove redis address validation to support unix domain socket

### DIFF
--- a/cardinal/config.go
+++ b/cardinal/config.go
@@ -109,11 +109,6 @@ func (w *WorldConfig) Validate() error { //nolint:gocognit
 		return eris.New("CARDINAL_LOG_LEVEL must be one of the following: " + strings.Join(validLogLevels, ", "))
 	}
 
-	// Validate Redis address
-	if _, _, err := net.SplitHostPort(w.RedisAddress); err != nil {
-		return eris.New("REDIS_ADDRESS must follow the format <host>:<port>")
-	}
-
 	// Validate base shard configs (only required when rollup mode is enabled)
 	if w.CardinalRollupEnabled {
 		if _, _, err := net.SplitHostPort(w.BaseShardSequencerAddress); err != nil {

--- a/cardinal/config_test.go
+++ b/cardinal/config_test.go
@@ -70,7 +70,7 @@ func TestWorldConfig_Validate_Namespace(t *testing.T) {
 		{
 			name: "If namespace contains anything other than alphanumeric and -, error",
 			cfg: defaultConfigWithOverrides(WorldConfig{
-				RedisAddress: "&1235%^^",
+				CardinalNamespace: "&1235%^^",
 			}),
 			wantErr: true,
 		},
@@ -100,38 +100,6 @@ func TestWorldConfig_Validate_LogLevel(t *testing.T) {
 		cfg := defaultConfigWithOverrides(WorldConfig{CardinalLogLevel: "foo"})
 		assert.IsError(t, cfg.Validate())
 	})
-}
-
-func TestWorldConfig_Validate_Redis(t *testing.T) {
-	testCases := []struct {
-		name    string
-		cfg     WorldConfig
-		wantErr bool
-	}{
-		{
-			name:    "If redis address is valid, no errors",
-			cfg:     defaultConfigWithOverrides(WorldConfig{RedisAddress: "localhost:6379"}),
-			wantErr: false,
-		},
-		{
-			name: "If redis address has invalid format, error",
-			cfg: defaultConfigWithOverrides(WorldConfig{
-				RedisAddress: "localhost",
-			}),
-			wantErr: true,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			err := tc.cfg.Validate()
-			if tc.wantErr {
-				assert.IsError(t, err)
-			} else {
-				assert.NilError(t, err)
-			}
-		})
-	}
 }
 
 func TestWorldConfig_Validate_RollupMode(t *testing.T) {


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
