### PR TITLE
feat(cardinal): increase redis timeout time by factor of 10

### DIFF
--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -36,7 +36,7 @@ import (
 
 const (
 	DefaultHistoricalTicksToStore = 10
-	RedisDialTimeOut              = 15
+	RedisDialTimeOut              = 150
 )
 
 var _ router.Provider = &World{}           //nolint:exhaustruct


### PR DESCRIPTION
Closes: gdev-1115

Straight forward. 

Basically we encountered this in datadog logs that seems like it coincides with all clients unable to receive or send messages to the server:

```
{
   "external":"read tcp [fd12:8218:c0eb::4f:72a3:e9ec]:43934-\u003e[fd12:8218:c0eb::84:1045:52ac]:6379: i/o timeout",
   "root":{
      "message":"",
      "stack":[
         "cardinal.(*World).tickTheEngine:/go/pkg/mod/pkg.world.dev/world-engine/cardinal@v1.3.4/world.go:418",
         "cardinal.(*World).doTick:/go/pkg/mod/pkg.world.dev/world-engine/cardinal@v1.3.4/world.go:223",
         "gamestate.(*EntityCommandBuffer).StartNextTick:/go/pkg/mod/pkg.world.dev/world-engine/cardinal@v1.3.4/gamestate/tick.go:67",
         "gamestate.(*EntityCommandBuffer).StartNextTick:/go/pkg/mod/pkg.world.dev/world-engine/cardinal@v1.3.4/gamestate/tick.go:67",
         "gamestate.(*RedisStorage).EndTransaction:/go/pkg/mod/pkg.world.dev/world-engine/cardinal@v1.3.4/gamestate/redis.go:123"
      ]
   },
   "wrap":[
      {
         "message":"",
         "stack":"gamestate.(*EntityCommandBuffer).StartNextTick:/go/pkg/mod/pkg.world.dev/world-engine/cardinal@v1.3.4/gamestate/tick.go:67"
      }
   ]
}
```

So it seems redis causes cardinal to panic because of a timeout error. 
If we increase this timeout time it should in theory mitigate a timeout issues that are genuinely just something taking a bit longer than usual.

