### PR TITLE
feat: better error message for siwe auth errors

### DIFF
--- a/relay/nakama/auth/siwe.go
+++ b/relay/nakama/auth/siwe.go
@@ -73,7 +73,7 @@ func handleSIWE(
 	// The user has provided a signature and a message. Attempt to authenticate the user.
 	if err := siwe.ValidateSignature(ctx, nk, signerAddress, message, signature); err != nil {
 		_, err = utils.LogErrorWithMessageAndCode(
-			logger, siwe.ErrMissingMessage, codes.Unauthenticated, "authentication failed")
+			logger, err, codes.Unauthenticated, "authentication failed")
 		return nil, err
 	}
 	// The user has successfully been authenticated


### PR DESCRIPTION
Send the message of the error causing the SIWE error instead of "missing message".