### PR TITLE
refactor(cardinal): update docs of ecb pagkage o gamestate package

### DIFF
--- a/cardinal/gamestate/doc.go
+++ b/cardinal/gamestate/doc.go
@@ -1,5 +1,5 @@
 /*
-Package ecb allows for buffering of state changes to the ECS dbStorage layer, and either committing those changes
+Package gamestate allows for buffering of state changes to the ECS dbStorage layer, and either committing those changes
 in an atomic Redis transaction, or discarding the changes. In either case, the underlying Redis DB is never in an
 intermediate state.
 


### PR DESCRIPTION
Closes: WORLD-864
trivial change to docs. Just folliowing the ticket here: 
https://linear.app/arguslabs/issue/WORLD-864/package-gamestate-references-ecb-in-docgo-rename-back-to-ecb-or-update