### PR TITLE
revert return of /debug/state endpoint from array to map

### DIFF
--- a/cardinal/server/debug_test.go
+++ b/cardinal/server/debug_test.go
@@ -25,25 +25,25 @@ func (s *ServerTestSuite) TestDebugStateQuery() {
 	s.Require().NoError(err)
 	s.Require().Equal(res.StatusCode, 200)
 
-	var results []types.EntityStateElement
+	var results []types.DebugStateElement
 	s.Require().NoError(json.NewDecoder(res.Body).Decode(&results))
 
 	numOfZeroLocation := 0
 	numOfNonZeroLocation := 0
-	for i, result := range results {
-		comp := result.Data[0]
+	for _, result := range results {
+		comp := result.Components["location"]
 		if comp == nil {
 			continue
 		}
 		var loc LocationComponent
 		s.Require().NoError(json.Unmarshal(comp, &loc))
-		if i != 6 {
-			if loc.Y == 0 {
-				numOfZeroLocation++
-			} else {
-				numOfNonZeroLocation++
-			}
+
+		if loc.Y == 0 {
+			numOfZeroLocation++
+		} else {
+			numOfNonZeroLocation++
 		}
+
 	}
 	s.Require().Equal(numOfZeroLocation, wantNumOfZeroLocation)
 	s.Require().Equal(numOfNonZeroLocation, 1)
@@ -56,7 +56,7 @@ func (s *ServerTestSuite) TestDebugStateQuery_NoState() {
 	res := s.fixture.Post("debug/state", handler.DebugStateRequest{})
 	s.Require().Equal(res.StatusCode, 200)
 
-	var results []types.EntityStateElement
+	var results []types.DebugStateElement
 	s.Require().NoError(json.NewDecoder(res.Body).Decode(&results))
 
 	s.Require().Equal(len(results), 0)

--- a/cardinal/server/handler/debug.go
+++ b/cardinal/server/handler/debug.go
@@ -9,7 +9,7 @@ import (
 
 type DebugStateRequest struct{}
 
-type DebugStateResponse = []types.EntityStateElement
+type DebugStateResponse = []types.DebugStateElement
 
 // GetState godoc
 //

--- a/cardinal/server/types/provider.go
+++ b/cardinal/server/types/provider.go
@@ -19,6 +19,6 @@ type ProviderWorld interface {
 	ReceiptHistorySize() uint64
 	GetTransactionReceiptsForTick(tick uint64) ([]receipt.Receipt, error)
 	EvaluateCQL(cql string) ([]types.EntityStateElement, error)
-	GetDebugState() ([]types.EntityStateElement, error)
+	GetDebugState() ([]types.DebugStateElement, error)
 	BuildQueryFields() []types.FieldDetail
 }

--- a/cardinal/types/entity.go
+++ b/cardinal/types/entity.go
@@ -8,3 +8,8 @@ type EntityStateElement struct {
 	ID   EntityID          `json:"id"`
 	Data []json.RawMessage `json:"data" swaggertype:"object"`
 }
+
+type DebugStateElement struct {
+	ID         EntityID                   `json:"id"`
+	Components map[string]json.RawMessage `json:"components" swaggertype:"object"`
+}

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -560,8 +560,8 @@ func (w *World) UseNonce(signerAddress string, nonce uint64) error {
 	return w.redisStorage.UseNonce(signerAddress, nonce)
 }
 
-func (w *World) GetDebugState() ([]types.EntityStateElement, error) {
-	result := make([]types.EntityStateElement, 0)
+func (w *World) GetDebugState() ([]types.DebugStateElement, error) {
+	result := make([]types.DebugStateElement, 0)
 	s := w.Search(filter.All())
 	var eachClosureErr error
 	wCtx := NewReadOnlyWorldContext(w)
@@ -572,9 +572,9 @@ func (w *World) GetDebugState() ([]types.EntityStateElement, error) {
 			if eachClosureErr != nil {
 				return false
 			}
-			resultElement := types.EntityStateElement{
-				ID:   id,
-				Data: make([]json.RawMessage, 0),
+			resultElement := types.DebugStateElement{
+				ID:         id,
+				Components: make(map[string]json.RawMessage),
 			}
 			for _, c := range components {
 				var data json.RawMessage
@@ -582,7 +582,7 @@ func (w *World) GetDebugState() ([]types.EntityStateElement, error) {
 				if eachClosureErr != nil {
 					return false
 				}
-				resultElement.Data = append(resultElement.Data, data)
+				resultElement.Components[c.Name()] = data
 			}
 			result = append(result, resultElement)
 			return true


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
