### PR TITLE
fix: revert return of /debug/state endpoint from array to map

### DIFF
--- a/cardinal/server/debug_test.go
+++ b/cardinal/server/debug_test.go
@@ -25,24 +25,23 @@ func (s *ServerTestSuite) TestDebugStateQuery() {
 	s.Require().NoError(err)
 	s.Require().Equal(res.StatusCode, 200)
 
-	var results []types.EntityStateElement
+	var results []types.DebugStateElement
 	s.Require().NoError(json.NewDecoder(res.Body).Decode(&results))
 
 	numOfZeroLocation := 0
 	numOfNonZeroLocation := 0
-	for i, result := range results {
-		comp := result.Data[0]
+	for _, result := range results {
+		comp := result.Components["location"]
 		if comp == nil {
 			continue
 		}
 		var loc LocationComponent
 		s.Require().NoError(json.Unmarshal(comp, &loc))
-		if i != 6 {
-			if loc.Y == 0 {
-				numOfZeroLocation++
-			} else {
-				numOfNonZeroLocation++
-			}
+
+		if loc.Y == 0 {
+			numOfZeroLocation++
+		} else {
+			numOfNonZeroLocation++
 		}
 	}
 	s.Require().Equal(numOfZeroLocation, wantNumOfZeroLocation)
@@ -56,7 +55,7 @@ func (s *ServerTestSuite) TestDebugStateQuery_NoState() {
 	res := s.fixture.Post("debug/state", handler.DebugStateRequest{})
 	s.Require().Equal(res.StatusCode, 200)
 
-	var results []types.EntityStateElement
+	var results []types.DebugStateElement
 	s.Require().NoError(json.NewDecoder(res.Body).Decode(&results))
 
 	s.Require().Equal(len(results), 0)

--- a/cardinal/server/docs/docs.go
+++ b/cardinal/server/docs/docs.go
@@ -65,7 +65,7 @@ const docTemplate = `{
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/pkg_world_dev_world-engine_cardinal_types.EntityStateElement"
+                                "$ref": "#/definitions/pkg_world_dev_world-engine_cardinal_types.DebugStateElement"
                             }
                         }
                     }
@@ -494,6 +494,17 @@ const docTemplate = `{
             "type": "object",
             "properties": {
                 "data": {
+                    "type": "object"
+                },
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "pkg_world_dev_world-engine_cardinal_types.DebugStateElement": {
+            "type": "object",
+            "properties": {
+                "components": {
                     "type": "object"
                 },
                 "id": {

--- a/cardinal/server/docs/swagger.json
+++ b/cardinal/server/docs/swagger.json
@@ -62,7 +62,7 @@
                         "schema": {
                             "type": "array",
                             "items": {
-                                "$ref": "#/definitions/pkg_world_dev_world-engine_cardinal_types.EntityStateElement"
+                                "$ref": "#/definitions/pkg_world_dev_world-engine_cardinal_types.DebugStateElement"
                             }
                         }
                     }
@@ -491,6 +491,17 @@
             "type": "object",
             "properties": {
                 "data": {
+                    "type": "object"
+                },
+                "id": {
+                    "type": "integer"
+                }
+            }
+        },
+        "pkg_world_dev_world-engine_cardinal_types.DebugStateElement": {
+            "type": "object",
+            "properties": {
+                "components": {
                     "type": "object"
                 },
                 "id": {

--- a/cardinal/server/docs/swagger.yaml
+++ b/cardinal/server/docs/swagger.yaml
@@ -96,6 +96,13 @@ definitions:
       id:
         type: integer
     type: object
+  pkg_world_dev_world-engine_cardinal_types.DebugStateElement:
+    properties:
+      components:
+        type: object
+      id:
+        type: integer
+    type: object
   pkg_world_dev_world-engine_cardinal_types.FieldDetail:
     properties:
       fields:
@@ -148,7 +155,7 @@ paths:
           description: List of all entities
           schema:
             items:
-              $ref: '#/definitions/pkg_world_dev_world-engine_cardinal_types.EntityStateElement'
+              $ref: '#/definitions/pkg_world_dev_world-engine_cardinal_types.DebugStateElement'
             type: array
       summary: Retrieves a list of all entities in the game state
   /events:

--- a/cardinal/server/handler/debug.go
+++ b/cardinal/server/handler/debug.go
@@ -9,7 +9,7 @@ import (
 
 type DebugStateRequest struct{}
 
-type DebugStateResponse = []types.EntityStateElement
+type DebugStateResponse = []types.DebugStateElement
 
 // GetState godoc
 //

--- a/cardinal/server/types/provider.go
+++ b/cardinal/server/types/provider.go
@@ -19,6 +19,6 @@ type ProviderWorld interface {
 	ReceiptHistorySize() uint64
 	GetTransactionReceiptsForTick(tick uint64) ([]receipt.Receipt, error)
 	EvaluateCQL(cql string) ([]types.EntityStateElement, error)
-	GetDebugState() ([]types.EntityStateElement, error)
+	GetDebugState() ([]types.DebugStateElement, error)
 	BuildQueryFields() []types.FieldDetail
 }

--- a/cardinal/types/entity.go
+++ b/cardinal/types/entity.go
@@ -8,3 +8,8 @@ type EntityStateElement struct {
 	ID   EntityID          `json:"id"`
 	Data []json.RawMessage `json:"data" swaggertype:"object"`
 }
+
+type DebugStateElement struct {
+	ID         EntityID                   `json:"id"`
+	Components map[string]json.RawMessage `json:"components" swaggertype:"object"`
+}

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -560,8 +560,8 @@ func (w *World) UseNonce(signerAddress string, nonce uint64) error {
 	return w.redisStorage.UseNonce(signerAddress, nonce)
 }
 
-func (w *World) GetDebugState() ([]types.EntityStateElement, error) {
-	result := make([]types.EntityStateElement, 0)
+func (w *World) GetDebugState() ([]types.DebugStateElement, error) {
+	result := make([]types.DebugStateElement, 0)
 	s := w.Search(filter.All())
 	var eachClosureErr error
 	wCtx := NewReadOnlyWorldContext(w)
@@ -572,9 +572,9 @@ func (w *World) GetDebugState() ([]types.EntityStateElement, error) {
 			if eachClosureErr != nil {
 				return false
 			}
-			resultElement := types.EntityStateElement{
-				ID:   id,
-				Data: make([]json.RawMessage, 0),
+			resultElement := types.DebugStateElement{
+				ID:         id,
+				Components: make(map[string]json.RawMessage),
 			}
 			for _, c := range components {
 				var data json.RawMessage
@@ -582,7 +582,7 @@ func (w *World) GetDebugState() ([]types.EntityStateElement, error) {
 				if eachClosureErr != nil {
 					return false
 				}
-				resultElement.Data = append(resultElement.Data, data)
+				resultElement.Components[c.Name()] = data
 			}
 			result = append(result, resultElement)
 			return true


### PR DESCRIPTION
Closes: WORLD-1146

## Overview

Cardinal editor breaking because the response format of `/debug/state` endpoint is changed.
This PR is to revert the changes.
From : 
```
type EntityStateElement struct {
	ID   EntityID          `json:"id"`
	Data []json.RawMessage `json:"data" swaggertype:"object"`
}
```
To :
```
type DebugStateElement struct {
	ID         EntityID                   `json:"id"`
	Components map[string]json.RawMessage `json:"components" swaggertype:"object"`
}
```

## Brief Changelog
- Add new `DebugStateElement` types entity for response
- Change the response using `DebugStateElement` struct
- Adjust the unit test and swagger

## Testing and Verifying
- Adjusted Unit Test
- Tested manually using Cardinal Editor v0.4.0

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/3b48e03b-55df-412d-a990-59e7d0e4229e.png)

- Tested manually using Postman

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/9645d0b0-7723-4fa5-aac4-89aa695385fb.png)

Sample Result :
```
[
    {
        "id": 0,
        "components": {
            "Health": {
                "HP": 246
            },
            "Player": {
                "nickname": "default-0"
            }
        }
    },
    {
        "id": 1,
        "components": {
            "Health": {
                "HP": 246
            },
            "Player": {
                "nickname": "default-1"
            }
        }
    },
    {
        "id": 2,
        "components": {
            "Health": {
                "HP": 246
            },
            "Player": {
                "nickname": "default-2"
            }
        }
    },
    {
        "id": 3,
        "components": {
            "Health": {
                "HP": 246
            },
            "Player": {
                "nickname": "default-3"
            }
        }
    },
    {
        "id": 4,
        "components": {
            "Health": {
                "HP": 246
            },
            "Player": {
                "nickname": "default-4"
            }
        }
    },
    {
        "id": 5,
        "components": {
            "Health": {
                "HP": 246
            },
            "Player": {
                "nickname": "default-5"
            }
        }
    },
    {
        "id": 6,
        "components": {
            "Health": {
                "HP": 246
            },
            "Player": {
                "nickname": "default-6"
            }
        }
    },
    {
        "id": 7,
        "components": {
            "Health": {
                "HP": 246
            },
            "Player": {
                "nickname": "default-7"
            }
        }
    },
    {
        "id": 8,
        "components": {
            "Health": {
                "HP": 246
            },
            "Player": {
                "nickname": "default-8"
            }
        }
    },
    {
        "id": 9,
        "components": {
            "Health": {
                "HP": 246
            },
            "Player": {
                "nickname": "default-9"
            }
        }
    },
    {
        "id": 10,
        "components": {
            "SignerComponent": {
                "PersonaTag": "_test_persona",
                "SignerAddress": "0x46d9a3548Ff919dd06F35963538fAe1569A4cEcc",
                "AuthorizedAddresses": []
            }
        }
    }
]
```
