### PR TITLE
feat(cardinal): millisecond timestamp

### DIFF
--- a/cardinal/engine_test.go
+++ b/cardinal/engine_test.go
@@ -377,7 +377,6 @@ func TestTransactionsSentToRouterAfterTick(t *testing.T) {
 	fooMessage, ok := world.GetMessageByFullName("game." + msgName)
 	assert.True(t, ok)
 	_, txHash := world.AddEVMTransaction(fooMessage.ID(), msg, tx, evmTxHash)
-	ts := uint64(time.Now().Unix())
 
 	rtr.
 		EXPECT().
@@ -395,7 +394,7 @@ func TestTransactionsSentToRouterAfterTick(t *testing.T) {
 				},
 			},
 			world.CurrentTick(),
-			ts,
+			gomock.Any(),
 		).
 		Return(nil).
 		Times(1)
@@ -411,7 +410,7 @@ func TestTransactionsSentToRouterAfterTick(t *testing.T) {
 			gomock.Any(),
 			txpool.TxMap{},
 			world.CurrentTick(),
-			ts,
+			gomock.Any(),
 		).
 		Return(nil).
 		Times(1)

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -419,7 +419,7 @@ func (w *World) tickTheEngine(ctx context.Context, tickDone chan<- uint64) {
 	// this is the final point where errors bubble up and hit a panic. There are other places where this occurs
 	// but this is the highest terminal point.
 	// the panic may point you to here, (or the tick function) but the real stack trace is in the error message.
-	err := w.doTick(ctx, uint64(time.Now().Unix()))
+	err := w.doTick(ctx, uint64(time.Now().UnixMilli()))
 	if err != nil {
 		bytes, errMarshal := json.Marshal(eris.ToJSON(err, true))
 		if errMarshal != nil {

--- a/cardinal/world_context.go
+++ b/cardinal/world_context.go
@@ -19,7 +19,9 @@ var _ WorldContext = (*worldContext)(nil)
 
 //go:generate mockgen -source=context.go -package mocks -destination=mocks/context.go
 type WorldContext interface {
-	// Timestamp returns the UNIX timestamp of the tick.
+	// Timestamp returns the UNIX timestamp of the tick in milliseconds.
+	// We are using millisecond because subsecond ticks are possible and we want to ensure we have that level
+	// of precision.
 	Timestamp() uint64
 	// CurrentTick returns the current tick.
 	CurrentTick() uint64


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
