### PR TITLE
fix(nakama): log websocket connection retries as error

### DIFF
--- a/relay/nakama/events/events.go
+++ b/relay/nakama/events/events.go
@@ -55,7 +55,7 @@ func (eh *EventHub) connectWithRetry(logger runtime.Logger) error {
 			return ErrEventHubIsShuttingDown
 		} else if err != nil {
 			// sleep a little try again...
-			logger.Info("No host found: %v", err)
+			logger.Error("Failed to establish websocket connection: %v", err)
 			time.Sleep(2 * time.Second) //nolint:gomnd // its ok.
 			continue
 		}


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

> Description of the overall background and high-level changes that this PR introduces

<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->
