### PR TITLE
docs: add world.toml explanation docs

### DIFF
--- a/docs/cardinal/game/configuration/evm.mdx
+++ b/docs/cardinal/game/configuration/evm.mdx
@@ -36,7 +36,8 @@ CHAIN_KEY_MNEMONIC = 'enact adjust liberty squirrel bulk ticket invest tissue an
 
 ### DA_AUTH_TOKEN
 
-An authentication token obtained from the Celestia client, which is used to interact with Celestia’s Data Availability layer.
+An authentication token obtained from the Celestia client, which is used to interact with Celestia’s Data Availability layer. 
+For more details, you can visit this <a href='https://docs.celestia.org/developers/node-tutorial#auth-token' target='_blank'>link</a> 
 
 **Example**
 ```

--- a/docs/cardinal/game/configuration/nakama.mdx
+++ b/docs/cardinal/game/configuration/nakama.mdx
@@ -5,7 +5,7 @@ description: 'This section configures Nakama, including allowlist, metrics, and 
 
 ```
 [nakama]
-ENABLE_ALLOWLIST = "false"
+ENABLE_ALLOWLIST = false
 OUTGOING_QUEUE_SIZE = 64
 NAKAMA_TRACE_ENABLED = true
 NAKAMA_METRICS_ENABLED = true
@@ -19,7 +19,7 @@ Enables Nakama’s allowlist feature, which allows for beta keys. This is useful
 
 **Example**
 ```
-ENABLE_ALLOWLIST = 'false'
+ENABLE_ALLOWLIST = false
 ```
 
 ### OUTGOING_QUEUE_SIZE


### PR DESCRIPTION
Closes: WORLD-1220

## Overview

Adding documentiation for world.toml

## Brief Changelog

- add new section in world.dev docs for configuration (world.toml)

## Testing and Verifying

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/308f1275-9c5c-42a4-9914-6d31aac537bc.png)

<div class='graphite__hidden'>
          <div>🎥 Video uploaded on Graphite:</div>
            <a href="https://app.graphite.dev/media/video/YO1Dcg4NByYdZHvKXaTq/55359eff-7ba7-4cde-b59e-9248ef62f479.mov">
              <img src="https://app.graphite.dev/api/v1/graphite/video/thumbnail/YO1Dcg4NByYdZHvKXaTq/55359eff-7ba7-4cde-b59e-9248ef62f479.mov">
            </a>
          </div>
<video src="https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/55359eff-7ba7-4cde-b59e-9248ef62f479.mov">Screen Recording 2024-10-23 at 20.03.02.mov</video>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the configuration documentation for Nakama, changing the `ENABLE_ALLOWLIST` parameter from a string to a boolean value for clarity and accuracy.
	- Enhanced the EVM configuration documentation with additional details and a hyperlink for the `DA_AUTH_TOKEN` parameter, improving clarity without altering existing configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->