### PR TITLE
ci: Fixed problem with evm release build

### DIFF
--- a/.github/workflows/release-evm.yaml
+++ b/.github/workflows/release-evm.yaml
@@ -55,7 +55,8 @@ jobs:
       - name: Build and push
         uses: docker/build-push-action@v5
         with:
-          context: ./evm
+          context: .
+          file: ./evm/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}


### PR DESCRIPTION
Fixed problem with the CI autorelease

pointed dockerfile at correct context and file from workflow yaml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the GitHub Actions workflow for Docker image build and push, streamlining the build context to the root directory and specifying the Dockerfile location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->