### PR TITLE
docs: add nakama and evm docker image version on world.toml explanation

### DIFF
--- a/docs/cardinal/game/configuration/evm.mdx
+++ b/docs/cardinal/game/configuration/evm.mdx
@@ -13,6 +13,8 @@ DA_NAMESPACE_ID = "defaultnamespace"
 FAUCET_ADDRESS = "faucet_address"
 FAUCET_AMOUNT = "0x56BC75E2D6310000"  # 100 ETH
 FAUCET_ENABLED = false
+EVM_IMAGE="ghcr.io/argus-labs/world-engine-evm:latest"
+EVM_IMAGE_PLATFORM="linux/amd64"
 ```
 
 ### CHAIN_ID
@@ -87,4 +89,25 @@ Enables or disables the faucet feature, which automatically distributes tokens t
 **Example**
 ```
 FAUCET_ENABLED = false
+```
+
+### EVM_IMAGE
+
+Specifies EVM docker image. This will only work on world cli v1.3.3 above.
+- For Cardinal v1.7.1 and later, the EVM image must be `v1.5.1` or later.
+- For Cardinal v1.6.x and earlier, the EVM image must be `v1.4.1` or earlier.
+
+**Example**
+```
+EVM_IMAGE = "ghcr.io/argus-labs/world-engine-evm:1.5.1"
+```
+
+### EVM_IMAGE_PLATFORM
+
+Specifies the platform architecture for the EVM Docker image. The default value will match the operating system platform. this will only work on world cli v1.3.3 above. 
+For more details, you can visit this <a href='https://docs.docker.com/build/building/multi-platform/' target='_blank'>link</a> 
+
+**Example**
+```
+EVM_IMAGE_PLATFORM = "linux/amd64"
 ```

--- a/docs/cardinal/game/configuration/nakama.mdx
+++ b/docs/cardinal/game/configuration/nakama.mdx
@@ -11,6 +11,8 @@ NAKAMA_TRACE_ENABLED = true
 NAKAMA_METRICS_ENABLED = true
 NAKAMA_TRACE_SAMPLE_RATE = 0.6
 NAKAMA_METRICS_INTERVAL = 30
+NAKAMA_IMAGE = "ghcr.io/argus-labs/world-engine-nakama:latest"
+NAKAMA_IMAGE_PLATFORM = "linux/amd64"
 ```
 
 ### ENABLE_ALLOWLIST
@@ -65,4 +67,25 @@ Prometheus scraping interval in seconds.
 **Example**
 ```
 NAKAMA_METRICS_INTERVAL = 30
+```
+
+### NAKAMA_IMAGE
+
+Specifies Nakama Docker image. this will only work on world cli v1.3.3 above.
+- For Cardinal v1.7.1 and later, the Nakama image must be `v1.4.0` or later.
+- For Cardinal v1.6.x and earlier, the Nakama image must be `v1.2.9` or earlier.
+
+**Example**
+```
+NAKAMA_IMAGE = "ghcr.io/argus-labs/world-engine-nakama:1.4.0"
+```
+
+### NAKAMA_IMAGE_PLATFORM
+
+Specifies the platform architecture for the Nakama Docker image. The default value will match the operating system platform. this will only work on world cli v1.3.3 above.
+For more details, you can visit this <a href='https://docs.docker.com/build/building/multi-platform/' target='_blank'>link</a> 
+
+**Example**
+```
+NAKAMA_IMAGE_PLATFORM = "linux/arm64"
 ```


### PR DESCRIPTION
Closes: WORLD-1274

## Overview

Add explanation in world.toml to use specific nakama and evm docker image using `NAKAMA_IMAGE`, `NAKAMA_IMAGE_PLATFORM`, `EVM_MAGE`, and `EVM_IMAGE_PLATFORM`

## Brief Changelog

add section on `/cardinal/game/configuration/nakama` and `/cardinal/game/configuration/evm`

## Testing and Verifying

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/45a74f1f-82b4-485b-9066-1ea747a99502.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/ad73697c-fca6-4f2a-a37b-2947a554d68a.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/4b6cb170-4136-4369-b1a7-9b549fe3ba12.png)

![image.png](https://graphite-user-uploaded-assets-prod.s3.amazonaws.com/YO1Dcg4NByYdZHvKXaTq/20ede6ae-1454-4238-89b3-11c4a18a386e.png)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced new configuration parameters for EVM: `EVM_IMAGE` and `EVM_IMAGE_PLATFORM`, enhancing user customization options.
	- Added new configuration options for Nakama: `NAKAMA_IMAGE` and `NAKAMA_IMAGE_PLATFORM`, allowing users to specify image versions and platforms. 

- **Documentation**
	- Updated documentation to include descriptions and examples for the new configuration parameters for both EVM and Nakama.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->