### PR TITLE
docs: Updated docs for Cardinal v1.7.1

### DIFF
--- a/docs/cardinal/game/world/api-reference.mdx
+++ b/docs/cardinal/game/world/api-reference.mdx
@@ -141,6 +141,34 @@ func WithTickDoneChannel(ch chan<- uint64) WorldOption
 |-----------|-----------------|------------------------------------------------------------|
 | ch        | `chan<- uint64` | The channel that will be notified at the end of each tick. |
 
+#### WithMessageExpiration
+
+The `WithMessageExpiration` option controls how long messages will live past their creation time on the sender before they are considered to be expired and will not be processed. Default is 10 seconds. For longer expiration times you may also need to set a larger hash cache size using the `WithHashCacheSize` option. This setting is ignored if the DisableSignatureVerification option is used. **NOTE**: this means that the real time clock for the sender and receiver must be synchronized
+
+```go
+func WithMessageExpiration(seconds uint) WorldOption
+```
+
+##### Parameters
+
+| Parameter | Type   | Description                                                    |
+|-----------|--------|----------------------------------------------------------------|
+| seconds   | `uint` | How long messages live past their creation time on the sender. |
+
+#### WithHashCacheSize
+
+The `WithHashCacheSize` option sets how big (in kilobytes) the cache of hashes used for replay protection is allowed to be. Values less than 512 will be treated as 512 (512K cache size). Default is 1024 (1MB cache size). This setting is ignored if the DisableSignatureVerification option is used
+
+```go
+func WithHashCacheSize(sizeKB uint) WorldOption
+```
+
+##### Parameters
+
+| Parameter | Type   | Description                                                    |
+|-----------|--------|----------------------------------------------------------------|
+| sizeKB    | `uint` | How big the cache for used hashes can be. Min value 512.       |
+
 ## RegisterSystems
 
 `RegisterSystems` registers one or more systems to the `World`. Systems are executed in the order of which they were added to the world.

--- a/docs/cardinal/openapi.json
+++ b/docs/cardinal/openapi.json
@@ -421,7 +421,7 @@
         "required": [
           "body",
           "namespace",
-          "nonce",
+          "timestamp",
           "personaTag",
           "signature"
         ],
@@ -435,9 +435,9 @@
             "type": "string",
             "example": "agar-shooter"
           },
-          "nonce": {
+          "timestamp": {
             "type": "integer",
-            "format": "int64"
+            "format": "unix millisecond timestamp"
           },
           "signature": {
             "type": "string"
@@ -539,7 +539,7 @@
         "required": [
           "body",
           "namespace",
-          "nonce",
+          "timestamp",
           "personaTag",
           "signature"
         ],
@@ -553,9 +553,9 @@
             "type": "string",
             "example": "agar-shooter"
           },
-          "nonce": {
+          "timestamp": {
             "type": "integer",
-            "format": "int64"
+            "format": "unix millisecond timestamp"
           },
           "signature": {
             "type": "string"


### PR DESCRIPTION
## Overview

This pull request improves documentation by adding info on new Options in Cardinal v1.7.1 and by changing references to `nonce` in the REST API documentation to the new `timestamp` field.

