### PR TITLE
chore: fix problematic method name and some typos in comment

### DIFF
--- a/cardinal/types/component.go
+++ b/cardinal/types/component.go
@@ -23,7 +23,7 @@ type Component interface {
 type ComponentMetadata interface { //revive:disable-line:exported
 	// SetID sets the ArchetypeID of this component. It must only be set once
 	SetID(ComponentID) error
-	// ArchetypeID returns the ArchetypeID of the component.
+	// ID returns the ArchetypeID of the component.
 	ID() ComponentID
 	// New returns the marshaled bytes of the default value for the component struct.
 	New() ([]byte, error)

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -356,7 +356,7 @@ func (w *World) StartGame() error {
 		return w.server.Serve(ctx)
 	})
 	if err := g.Wait(); err != nil {
-		return eris.Wrap(err, "error occured while running cardinal")
+		return eris.Wrap(err, "error occurred while running cardinal")
 	}
 
 	return nil

--- a/cardinal/world_context.go
+++ b/cardinal/world_context.go
@@ -36,7 +36,7 @@ type WorldContext interface {
 	EmitEvent(map[string]any) error
 
 	// EmitStringEvent emits a string event that will be broadcast to all websocket subscribers.
-	// This method is provided for backwards compatability. EmitEvent should be used for most cases.
+	// This method is provided for backwards compatibility. EmitEvent should be used for most cases.
 	EmitStringEvent(string) error
 
 	// Namespace returns the namespace of the world.

--- a/docs/cardinal/game/message.mdx
+++ b/docs/cardinal/game/message.mdx
@@ -21,7 +21,7 @@ You can easily create a new message and register it to the world by following th
 
 <Steps>
     <Step title="Define the message and reply struct">
-        A message request and and its reply are defined as a Go structs.
+        A message request and its reply are defined as a Go structs.
 
         ```go /msg/attack_player.go
         package msg

--- a/relay/nakama/siwe/siwe.go
+++ b/relay/nakama/siwe/siwe.go
@@ -250,7 +250,7 @@ func getNonceStorageObject(
 	} else if len(objs) == 0 {
 		// No existing storage object was found, so return a storage object with no nonces and no version
 		return &nonceStorageObj{
-			// When this is later saved back to the DB, it will only be successful it the stoage object
+			// When this is later saved back to the DB, it will only be successful it the storage object
 			// doesn't already exist in the DB.
 			Version: "*",
 		}, nil


### PR DESCRIPTION
Closes: WORLD-XXX

<!---
Add a prefix to indicate what kind of release this pull request corresponds to:
  feat, fix, docs, style, refactor, perf, test, build, ci, chore, revert
--->

## Overview

fix problematic method name and some typos in comment


<!---
Example: This pull request improves documentation of area A by adding ...
--->

## Brief Changelog

fix problematic method name and some typos in comment

<!---
Example:
- The metadata is stored in the blob store on job creation time as a persistent artifact
- Deployments RPC transmits only the blob storage reference
- Daemons retrieve the RPC data from the blob cache
--->

## Testing and Verifying

<!---
Pick one of the following options:

- This change is a trivial rework/code cleanup without any test coverage.

- This change is already covered by existing tests, such as <describe test>.

- This change added tests and can be verified as follows:
    - Added unit test that validates ...
    - Added integration tests for end-to-end deployment with ...
    - Extended integration test for ...
    - Manually verified the change by ...
--->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **Bug Fixes**
	- Corrected typo in the error message for the `StartGame` method to enhance clarity.
	- Fixed minor typos in comments across various components, improving documentation quality.

- **Documentation**
	- Updated documentation for defining and registering messages to correct typographical errors and enhance clarity.

- **Style**
	- Improved comments for better readability in the `WorldContext` interface and other files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->