### PR TITLE
chore: use errors.New to replace fmt.Errorf with no parameters

### DIFF
--- a/evm/api/namespace/v1/query.pulsar.go
+++ b/evm/api/namespace/v1/query.pulsar.go
@@ -2,6 +2,7 @@
 package namespacev1
 
 import (
+	"errors"
 	fmt "fmt"
 	runtime "github.com/cosmos/cosmos-proto/runtime"
 	_ "github.com/cosmos/gogoproto/gogoproto"
@@ -125,7 +126,7 @@ func (x *fastReflection_Namespace) Has(fd protoreflect.FieldDescriptor) bool {
 		return x.ShardAddress != ""
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: namespace.v1.Namespace"))
+			panic(errors.New("proto3 declared messages do not support extensions: namespace.v1.Namespace"))
 		}
 		panic(fmt.Errorf("message namespace.v1.Namespace does not contain field %s", fd.FullName()))
 	}

--- a/evm/api/shard/module/v1/module.pulsar.go
+++ b/evm/api/shard/module/v1/module.pulsar.go
@@ -3,6 +3,7 @@ package modulev1
 
 import (
 	_ "cosmossdk.io/api/cosmos/app/v1alpha1"
+	"errors"
 	fmt "fmt"
 	runtime "github.com/cosmos/cosmos-proto/runtime"
 	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
@@ -114,7 +115,7 @@ func (x *fastReflection_Module) Has(fd protoreflect.FieldDescriptor) bool {
 		return x.Authority != ""
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: shard.module.v1.Module"))
+			panic(errors.New("proto3 declared messages do not support extensions: shard.module.v1.Module"))
 		}
 		panic(fmt.Errorf("message shard.module.v1.Module does not contain field %s", fd.FullName()))
 	}

--- a/evm/api/shard/v1/genesis.pulsar.go
+++ b/evm/api/shard/v1/genesis.pulsar.go
@@ -164,7 +164,7 @@ func (x *fastReflection_GenesisState) Has(fd protoreflect.FieldDescriptor) bool 
 		return len(x.NamespaceTransactions) != 0
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: shard.v1.GenesisState"))
+			panic(errors.New("proto3 declared messages do not support extensions: shard.v1.GenesisState"))
 		}
 		panic(fmt.Errorf("message shard.v1.GenesisState does not contain field %s", fd.FullName()))
 	}

--- a/evm/api/shard/v1/query.pulsar.go
+++ b/evm/api/shard/v1/query.pulsar.go
@@ -127,7 +127,7 @@ func (x *fastReflection_QueryTransactionsRequest) Has(fd protoreflect.FieldDescr
 		return x.Page != nil
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
+			panic(errors.New("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
 		}
 		panic(fmt.Errorf("message shard.v1.QueryTransactionsRequest does not contain field %s", fd.FullName()))
 	}
@@ -147,7 +147,7 @@ func (x *fastReflection_QueryTransactionsRequest) Clear(fd protoreflect.FieldDes
 		x.Page = nil
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
+			panic(errors.New("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
 		}
 		panic(fmt.Errorf("message shard.v1.QueryTransactionsRequest does not contain field %s", fd.FullName()))
 	}
@@ -169,7 +169,7 @@ func (x *fastReflection_QueryTransactionsRequest) Get(descriptor protoreflect.Fi
 		return protoreflect.ValueOfMessage(value.ProtoReflect())
 	default:
 		if descriptor.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
+			panic(errors.New("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
 		}
 		panic(fmt.Errorf("message shard.v1.QueryTransactionsRequest does not contain field %s", descriptor.FullName()))
 	}
@@ -193,7 +193,7 @@ func (x *fastReflection_QueryTransactionsRequest) Set(fd protoreflect.FieldDescr
 		x.Page = value.Message().Interface().(*PageRequest)
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
+			panic(errors.New("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
 		}
 		panic(fmt.Errorf("message shard.v1.QueryTransactionsRequest does not contain field %s", fd.FullName()))
 	}
@@ -217,10 +217,10 @@ func (x *fastReflection_QueryTransactionsRequest) Mutable(fd protoreflect.FieldD
 		}
 		return protoreflect.ValueOfMessage(x.Page.ProtoReflect())
 	case "shard.v1.QueryTransactionsRequest.namespace":
-		panic(fmt.Errorf("field namespace of message shard.v1.QueryTransactionsRequest is not mutable"))
+		panic(errors.New("field namespace of message shard.v1.QueryTransactionsRequest is not mutable"))
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
+			panic(errors.New("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
 		}
 		panic(fmt.Errorf("message shard.v1.QueryTransactionsRequest does not contain field %s", fd.FullName()))
 	}
@@ -238,7 +238,7 @@ func (x *fastReflection_QueryTransactionsRequest) NewField(fd protoreflect.Field
 		return protoreflect.ValueOfMessage(m.ProtoReflect())
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
+			panic(errors.New("proto3 declared messages do not support extensions: shard.v1.QueryTransactionsRequest"))
 		}
 		panic(fmt.Errorf("message shard.v1.QueryTransactionsRequest does not contain field %s", fd.FullName()))
 	}

--- a/evm/api/shard/v1/tx.pulsar.go
+++ b/evm/api/shard/v1/tx.pulsar.go
@@ -206,7 +206,7 @@ func (x *fastReflection_SubmitShardTxRequest) Has(fd protoreflect.FieldDescripto
 		return len(x.Txs) != 0
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: shard.v1.SubmitShardTxRequest"))
+			panic(errors.New("proto3 declared messages do not support extensions: shard.v1.SubmitShardTxRequest"))
 		}
 		panic(fmt.Errorf("message shard.v1.SubmitShardTxRequest does not contain field %s", fd.FullName()))
 	}

--- a/evm/api/shard/v1/types.pulsar.go
+++ b/evm/api/shard/v1/types.pulsar.go
@@ -123,7 +123,7 @@ func (x *fastReflection_Transaction) Has(fd protoreflect.FieldDescriptor) bool {
 		return len(x.GameShardTransaction) != 0
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: shard.v1.Transaction"))
+			panic(errors.New("proto3 declared messages do not support extensions: shard.v1.Transaction"))
 		}
 		panic(fmt.Errorf("message shard.v1.Transaction does not contain field %s", fd.FullName()))
 	}
@@ -143,7 +143,7 @@ func (x *fastReflection_Transaction) Clear(fd protoreflect.FieldDescriptor) {
 		x.GameShardTransaction = nil
 	default:
 		if fd.IsExtension() {
-			panic(fmt.Errorf("proto3 declared messages do not support extensions: shard.v1.Transaction"))
+			panic(errors.New("proto3 declared messages do not support extensions: shard.v1.Transaction"))
 		}
 		panic(fmt.Errorf("message shard.v1.Transaction does not contain field %s", fd.FullName()))
 	}

--- a/evm/x/shard/types/query.pb.go
+++ b/evm/x/shard/types/query.pb.go
@@ -858,7 +858,7 @@ func (m *PageRequest) Unmarshal(dAtA []byte) error {
 		fieldNum := int32(wire >> 3)
 		wireType := int(wire & 0x7)
 		if wireType == 4 {
-			return fmt.Errorf("proto: PageRequest: wiretype end group for non-group")
+			return errors.New("proto: PageRequest: wiretype end group for non-group")
 		}
 		if fieldNum <= 0 {
 			return fmt.Errorf("proto: PageRequest: illegal tag %d (wire type %d)", fieldNum, wire)

--- a/evm/x/shard/types/types.pb.go
+++ b/evm/x/shard/types/types.pb.go
@@ -4,6 +4,7 @@
 package types
 
 import (
+	"errors"
 	fmt "fmt"
 	proto "github.com/cosmos/gogoproto/proto"
 	io "io"
@@ -607,7 +608,7 @@ func skipTypes(dAtA []byte) (n int, err error) {
 }
 
 var (
-	ErrInvalidLengthTypes        = fmt.Errorf("proto: negative length found during unmarshaling")
-	ErrIntOverflowTypes          = fmt.Errorf("proto: integer overflow")
-	ErrUnexpectedEndOfGroupTypes = fmt.Errorf("proto: unexpected end of group")
+	ErrInvalidLengthTypes        = errors.New("proto: negative length found during unmarshaling")
+	ErrIntOverflowTypes          = errors.New("proto: integer overflow")
+	ErrUnexpectedEndOfGroupTypes = errors.New("proto: unexpected end of group")
 )


### PR DESCRIPTION
use errors.New to replace fmt.Errorf with no parameters

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved error handling for unsupported extensions across multiple methods, enhancing clarity of error messages.
	- Ensured consistent behavior by returning new list values instead of nil for empty fields in various methods.

- **Refactor**
	- Standardized error creation method from `fmt.Errorf` to `errors.New` for better error reporting across the codebase.

- **Chores**
	- Updated method signatures to reflect changes in error handling and return values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->