### PR TITLE
fix: Fix grammar issues in multiple files

### DIFF
--- a/cardinal/persona_test.go
+++ b/cardinal/persona_test.go
@@ -41,7 +41,7 @@ func TestPersonaTagIsValid(t *testing.T) {
 }
 
 func TestCreatePersonaTransactionAutomaticallyCreated(t *testing.T) {
-	// Verify that the cardinal.CreatePersona is automatically cardinal.Created and registered with a engine.
+	// Verify that the cardinal.CreatePersona is automatically cardinal.Created and registered with an engine.
 	tf := NewTestFixture(t, nil)
 	world := tf.World
 	tf.StartWorld()
@@ -125,7 +125,7 @@ func TestDuplicatePersonaTagsInTickAreOnlyRegisteredOnce(t *testing.T) {
 }
 
 func TestCreatePersonaFailsIfTagIsInvalid(t *testing.T) {
-	// Verify that the cardinal.CreatePersona is automatically cardinal.Created and registered with a engine.
+	// Verify that the cardinal.CreatePersona is automatically cardinal.Created and registered with an engine.
 	tf := NewTestFixture(t, nil)
 	world := tf.World
 	tf.StartWorld()
@@ -140,7 +140,7 @@ func TestCreatePersonaFailsIfTagIsInvalid(t *testing.T) {
 }
 
 func TestSamePersonaWithDifferentCaseCannotBeClaimed(t *testing.T) {
-	// Verify that the cardinal.CreatePersona is automatically cardinal.Created and registered with a engine.
+	// Verify that the cardinal.CreatePersona is automatically cardinal.Created and registered with an engine.
 	tf := NewTestFixture(t, nil)
 	world := tf.World
 	tf.StartWorld()
@@ -154,7 +154,7 @@ func TestSamePersonaWithDifferentCaseCannotBeClaimed(t *testing.T) {
 }
 
 func TestCanAuthorizeAddress(t *testing.T) {
-	// Verify that the cardinal.CreatePersona is automatically cardinal.Created and registered with a engine.
+	// Verify that the cardinal.CreatePersona is automatically cardinal.Created and registered with an engine.
 	tf := NewTestFixture(t, nil)
 	world := tf.World
 	tf.StartWorld()
@@ -192,7 +192,7 @@ func TestCanAuthorizeAddress(t *testing.T) {
 }
 
 func TestAuthorizeAddressFailsOnInvalidAddress(t *testing.T) {
-	// Verify that the cardinal.CreatePersona is automatically cardinal.Created and registered with a engine.
+	// Verify that the cardinal.CreatePersona is automatically cardinal.Created and registered with an engine.
 	tf := NewTestFixture(t, nil)
 	world := tf.World
 	tf.StartWorld()

--- a/cardinal/receipt/receipt.go
+++ b/cardinal/receipt/receipt.go
@@ -49,7 +49,7 @@ func (r Receipt) MarshalJSON() ([]byte, error) {
 	})
 }
 
-// NewHistory creates a object that can track transaction receipts over a number of ticks.
+// NewHistory creates an object that can track transaction receipts over a number of ticks.
 func NewHistory(currentTick uint64, ticksToStore int) *History {
 	// Add an extra tick for the "current" tick.
 	ticksToStore++

--- a/cardinal/world_fixture.go
+++ b/cardinal/world_fixture.go
@@ -163,7 +163,7 @@ func (t *TestFixture) Post(path string, payload any) *http.Response {
 	return resp
 }
 
-// Get executes a http GET request to this TestFixture's cardinal server.
+// Get executes an http GET request to this TestFixture's cardinal server.
 func (t *TestFixture) Get(path string) *http.Response {
 	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, t.httpURL(strings.Trim(path, "/")),
 		nil)

--- a/cardinal/world_fixture.go
+++ b/cardinal/world_fixture.go
@@ -146,7 +146,7 @@ func (t *TestFixture) httpURL(path string) string {
 	return fmt.Sprintf("http://%s/%s", t.BaseURL, path)
 }
 
-// Post executes a http POST request to this TextFixture's cardinal server.
+// Post executes an http POST request to this TextFixture's cardinal server.
 func (t *TestFixture) Post(path string, payload any) *http.Response {
 	bz, err := json.Marshal(payload)
 	assert.NilError(t, err)

--- a/docs/cardinal/game/cql.mdx
+++ b/docs/cardinal/game/cql.mdx
@@ -59,7 +59,7 @@ Two functions are provided in the language that accept a variadic amount of comp
 
 **Examples:**
 
-- `CONTAINS(armComponent)` is a query for all entities that have a arm component. The entity can have more components than just the arm.
+- `CONTAINS(armComponent)` is a query for all entities that have an arm component. The entity can have more components than just the arm.
 - `CONTAINS(armComponent, legComponent)` is query for all entities that have both an arm component and a leg component. The entity can have more components than the arm and the leg.
 
 
@@ -92,4 +92,4 @@ You can use parenthesis to specify and change precedence in CQL.
 - The above is a query for either an entity with only a leg component or an entity that does not have a health component and also does not have an attack component.
 
 - Example: `(EXACT(legComponent) | !CONTAINS(healthComponent)) & !CONTAINS(attackComponent)`
-- The above is the same query but with precedence changed. Now it is querying an entity with either exactly one leg component or does not have a health component. Additionally that entity must not ever contain a attack component.
+- The above is the same query but with precedence changed. Now it is querying an entity with either exactly one leg component or does not have a health component. Additionally that entity must not ever contain an attack component.

--- a/evm/app/export.go
+++ b/evm/app/export.go
@@ -79,7 +79,7 @@ func (app *App) ExportAppStateAndValidators(
 func (app *App) prepForZeroHeightGenesis(ctx sdk.Context, jailAllowedAddrs []string) {
 	applyAllowedAddrs := false
 
-	// check if there is a allowed address list
+	// check if there is an allowed address list
 	if len(jailAllowedAddrs) > 0 {
 		applyAllowedAddrs = true
 	}

--- a/relay/nakama/utils/nakama.go
+++ b/relay/nakama/utils/nakama.go
@@ -22,7 +22,7 @@ func GetUserID(ctx context.Context) (string, error) {
 	return userID, nil
 }
 
-// MarshalResult marshals the given result and converts any marshalling error into a "Internal" RPC error.
+// MarshalResult marshals the given result and converts any marshalling error into an "Internal" RPC error.
 func MarshalResult(logger runtime.Logger, result any) (string, error) {
 	bz, err := json.Marshal(result)
 	if err != nil {


### PR DESCRIPTION
This pull request addresses grammatical issues in comments and documentation across several files in the project. The corrections ensure proper usage of "an" vs. "a" and enhance the readability and professionalism of the codebase.

### Changes Summary

1. **`persona_test.go`**
   - Corrected "a engine" to "an engine."

2. **`receipt.go`**
   - Corrected "a object" to "an object."

3. **`world_fixture.go`**
   - Corrected "a http" to "an http."

4. **`cql.mdx`**
   - Corrected "a arm component" to "an arm component."
   - Corrected "a attack component" to "an attack component."

5. **`export.go`**
   - Corrected "a allowed address list" to "an allowed address list."

6. **`nakama.go`**
   - Corrected "a Internal RPC error" to "an Internal RPC error."


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed minor grammatical errors in comments across multiple files
	- Corrected typographical mistakes in documentation for Cardinal Query Language (CQL)
	- Improved clarity of comments in various code files

- **Chores**
	- Updated quotation marks in a utility function comment
	- Minor text refinements in code comments

Note: These changes do not impact the functionality of the code and are purely cosmetic improvements to documentation and comments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->