### PR TITLE
fix siwe.go

### DIFF
--- a/relay/nakama/siwe/siwe.go
+++ b/relay/nakama/siwe/siwe.go
@@ -250,7 +250,7 @@ func getNonceStorageObject(
 	} else if len(objs) == 0 {
 		// No existing storage object was found, so return a storage object with no nonces and no version
 		return &nonceStorageObj{
-			// When this is later saved back to the DB, it will only be successful it the stoage object
+			// When this is later saved back to the DB, it will only be successful it the storage object
 			// doesn't already exist in the DB.
 			Version: "*",
 		}, nil


### PR DESCRIPTION
- **Change:** Replaced "stoage" with "storage" in the comment: "When this is later saved back to the DB, it will only be successful it the stoage object."

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a typo in a comment within the `getNonceStorageObject` function to improve code readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->