### PR TITLE
Fix in the world_fixture.go

### DIFF
--- a/cardinal/world_fixture.go
+++ b/cardinal/world_fixture.go
@@ -207,7 +207,7 @@ func findOpenPorts(amount int) ([]string, error) {
 	for i := 0; i < amount; i++ {
 		var found bool
 
-		// Try to find a random port, retying if it turns out to be a duplicate in list of ports up to 10 times
+		// Try to find a random port, retrying if it turns out to be a duplicate in list of ports up to 10 times
 		for retries := 10; retries > 0; retries-- {
 			port, err := findOpenPort()
 			if err != nil {


### PR DESCRIPTION
# Fix typo in `world_fixture.go`

## Description
This PR fixes a typo in the `world_fixture.go` file where "retying" was incorrectly spelled. It has been corrected to "retrying."

## Changes
- **File:** `cardinal/world_fixture.go`
- **Line:** 207
- **Change:** Replaced "retying" with "retrying."


Thank you for reviewing this pull request! Let me know if any further changes are

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Fixed a typo in a comment within the `findOpenPorts` function, correcting "retying" to "retrying" for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->