### PR TITLE
chore: add configurable tick rate from envar or toml config file

### DIFF
--- a/cardinal/config.go
+++ b/cardinal/config.go
@@ -47,6 +47,7 @@ var (
 		BaseShardSequencerAddress: DefaultBaseShardSequencerAddress,
 		BaseShardRouterKey:        "",
 		TelemetryTraceEnabled:     false,
+		CardinalTickRate:          0,
 	}
 )
 
@@ -77,6 +78,9 @@ type WorldConfig struct {
 
 	// TelemetryTraceEnabled When true, Cardinal will collect OpenTelemetry traces
 	TelemetryTraceEnabled bool `mapstructure:"TELEMETRY_TRACE_ENABLED"`
+
+	// CardinalTickRate The number of ticks per second
+	CardinalTickRate uint64 `mapstructure:"CARDINAL_TICK_RATE"`
 }
 
 func loadWorldConfig() (*WorldConfig, error) {

--- a/cardinal/config_test.go
+++ b/cardinal/config_test.go
@@ -36,6 +36,7 @@ func TestWorldConfig_LoadFromEnv(t *testing.T) {
 		RedisPassword:             "bar",
 		BaseShardSequencerAddress: "localhost:8080",
 		BaseShardRouterKey:        "abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ01",
+		CardinalTickRate:          10,
 	}
 
 	// Set env vars to target config values
@@ -47,7 +48,7 @@ func TestWorldConfig_LoadFromEnv(t *testing.T) {
 	t.Setenv("REDIS_PASSWORD", wantCfg.RedisPassword)
 	t.Setenv("BASE_SHARD_SEQUENCER_ADDRESS", wantCfg.BaseShardSequencerAddress)
 	t.Setenv("BASE_SHARD_ROUTER_KEY", wantCfg.BaseShardRouterKey)
-
+	t.Setenv("CARDINAL_TICK_RATE", strconv.FormatUint(wantCfg.CardinalTickRate, 10))
 	gotCfg, err := loadWorldConfig()
 	assert.NilError(t, err)
 

--- a/cardinal/world.go
+++ b/cardinal/world.go
@@ -179,6 +179,12 @@ func NewWorld(opts ...WorldOption) (*World, error) {
 		}
 	}
 
+	// Set tick rate if provided
+	// it will be overridden by WithTickChannel option if provided
+	if cfg.CardinalTickRate > 0 {
+		world.tickChannel = time.Tick(time.Second / time.Duration(cfg.CardinalTickRate)) //nolint:staticcheck // its ok.
+	}
+
 	// Apply options
 	for _, opt := range cardinalOptions {
 		opt(world)


### PR DESCRIPTION
Closes: PLAT-90

## Overview

Based on the user stories, user can configure tick rate from world forge / world cli.
Need capabilities to configure tick rate for world engine from outside the code.
Added `CARDINAL_TICK_RATE` config that can be put on env variable or using toml config file

## Brief Changelog

- Added `CARDINAL_TICK_RATE` var on WorldConfig
- Set `world.tickChannel` if `CARDINAL_TICK_RATE > 0`

the value can be overridden by `WithTickChannel` option if provided. 

## Testing and Verifying

Manually tested using starter-game-template. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a configuration option to dynamically adjust the simulation tick rate, enabling users to fine-tune the game loop's performance.
	- Added support for specifying the tick rate via environment variables for enhanced configurability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->