### PR TITLE
chore(ci): upgrade golangci-lint-action to v8

### DIFF
--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -45,7 +45,7 @@ jobs:
         run: echo "path=$(go list -f '{{.Dir}}/...' -m | xargs)" >> $GITHUB_OUTPUT
         ## Equivalent to 'make lint' arguments
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v4
+        uses: golangci/golangci-lint-action@v8
         with:
           version: latest
           args: --timeout=10m -v ${{ steps.go-dir.outputs.path }}


### PR DESCRIPTION
Bumps golangci-lint-action to v8 for future-proofing against runner updates. Workflows compile the same. Reference: https://github.com/golangci/golangci-lint-action/releases/tag/v8.0.0
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Upgraded golangci-lint GitHub Action to v8 in the CI workflow to ensure compatibility with future GitHub runner updates.

<!-- End of auto-generated description by cubic. -->



<!-- greptile_comment -->

## Greptile Summary

Updates golangci-lint-action from v4 to v8 in the CI workflow to ensure compatibility with future GitHub runner updates.

- Updated `golangci/golangci-lint-action` to v8 in `.github/workflows/ci-go.yaml` while maintaining existing configuration
- Change is non-breaking according to referenced release notes
- Workflow maintains proper permissions and caching setup with Namespace volume cache



<sub>💡 (1/5) You can manually trigger the bot by mentioning @greptileai in a comment!</sub>

<!-- /greptile_comment -->