### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/workflows/ci-docs.yaml
+++ b/.github/workflows/ci-docs.yaml
@@ -20,7 +20,7 @@ jobs:
         working-directory: ./docs
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install Mintlify CLI
         run: npm install --global mintlify
       - name: Mintlify Check Broken Link

--- a/.github/workflows/ci-evm.yaml
+++ b/.github/workflows/ci-evm.yaml
@@ -16,7 +16,7 @@
 #     runs-on: namespace-profile-linux-8vcpu-16gb-cached
 #     steps:
 #       - name: Checkout
-#         uses: actions/checkout@v4
+#         uses: actions/checkout@v5
 #       - name: Install Foundry
 #         uses: foundry-rs/foundry-toolchain@v1
 #       - name: Set up Docker Buildx

--- a/.github/workflows/ci-go.yaml
+++ b/.github/workflows/ci-go.yaml
@@ -25,7 +25,7 @@ jobs:
       GO_VERSION: 1.24
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
@@ -57,7 +57,7 @@ jobs:
     runs-on: namespace-profile-linux-4vcpu-8gb-cached
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
@@ -83,7 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:
@@ -103,7 +103,7 @@ jobs:
       - nscloud-exp-features:privileged;host-pid-namespace
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Golang
         uses: actions/setup-go@v5
         with:

--- a/.github/workflows/ci-md.yaml
+++ b/.github/workflows/ci-md.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Setup Node
         uses: actions/setup-node@v4
       - name: Install eslint & eslint-plugin-mdx

--- a/.github/workflows/release-evm.yaml
+++ b/.github/workflows/release-evm.yaml
@@ -28,7 +28,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install and configure Namespace CLI
         uses: namespacelabs/nscloud-setup@v0
       - name: Configure Namespace powered Buildx

--- a/.github/workflows/release-nakama.yaml
+++ b/.github/workflows/release-nakama.yaml
@@ -28,7 +28,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
       - name: Install and configure Namespace CLI
         uses: namespacelabs/nscloud-setup@v0
       - name: Configure Namespace powered Buildx


### PR DESCRIPTION
Bumps checkout to v5 for future-proofing against Node 24 runner updates. Requires runner v2.327.1+. Workflows compile the same.

More info: https://github.com/actions/checkout/releases/tag/v5.0.0