### PR TITLE
fix(docker): update `nakama-pluginbuilder` to 3.30.0 and add missing `go.sum` for local runs

### DIFF
--- a/e2e/testgames/go.mod
+++ b/e2e/testgames/go.mod
@@ -91,6 +91,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.32.0 // indirect
 	go.opentelemetry.io/otel/trace v1.32.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.4.0 // indirect
+	go.uber.org/mock v0.5.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	golang.org/x/crypto v0.30.0 // indirect
 	golang.org/x/exp v0.0.0-20241210194714-1829a127f884 // indirect

--- a/e2e/testgames/go.sum
+++ b/e2e/testgames/go.sum
@@ -256,6 +256,8 @@ go.opentelemetry.io/proto/otlp v1.4.0 h1:TA9WRvW6zMwP+Ssb6fLoUIuirti1gGbP28GcKG1
 go.opentelemetry.io/proto/otlp v1.4.0/go.mod h1:PPBWZIP98o2ElSqI35IHfu7hIhSwvc5N38Jw8pXuGFY=
 go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
 go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
+go.uber.org/mock v0.5.0 h1:KAMbZvZPyBPWgD14IrIQ38QCyjwpvVVV6K/bHl1IwQU=
+go.uber.org/mock v0.5.0/go.mod h1:ge71pBPLYDk7QIi1LupWxdAykm7KIEFchiOqd6z7qMM=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=

--- a/relay/nakama/Dockerfile
+++ b/relay/nakama/Dockerfile
@@ -1,4 +1,4 @@
-FROM heroiclabs/nakama-pluginbuilder:3.25.0 AS builder
+FROM heroiclabs/nakama-pluginbuilder:3.30.0 AS builder
 
 ENV GO111MODULE on
 ENV CGO_ENABLED 1
@@ -12,7 +12,7 @@ RUN go mod download
 
 RUN go build --trimpath --buildmode=plugin -o ./plugin.so
 
-FROM heroiclabs/nakama-pluginbuilder:3.25.0-arm AS builder-arm
+FROM heroiclabs/nakama-pluginbuilder:3.30.0-arm AS builder-arm
 
 ENV GO111MODULE on
 ENV CGO_ENABLED 1
@@ -26,7 +26,7 @@ RUN go mod download
 
 RUN go build --trimpath --buildmode=plugin -o ./plugin.so
 
-FROM heroiclabs/nakama:3.25.0 AS nakama
+FROM heroiclabs/nakama:3.30.0 AS nakama
 
 RUN apt-get -y update && \
     apt-get -y install --no-install-recommends curl && \
@@ -35,7 +35,7 @@ RUN apt-get -y update && \
 COPY --from=builder /nakama/plugin/plugin.so /nakama/data/modules/
 COPY relay/nakama/local.yml /nakama/data/
 
-FROM heroiclabs/nakama:3.25.0-arm AS nakama-arm
+FROM heroiclabs/nakama:3.30.0-arm AS nakama-arm
 
 COPY --from=builder-arm /nakama/plugin/plugin.so /nakama/data/modules/
 COPY relay/nakama/local.yml /nakama/data/


### PR DESCRIPTION
Closes: WORLD-XXX

## Overview

This PR updates the Docker base image `heroiclabs/nakama-pluginbuilder` to **3.30.0**.  
The previous image used Go 1.23, while our app now runs on Go 1.24.  
Additionally, it fixes a missing `go.sum` entry required for successful local builds.

## Brief Changelog

- Bumped nakama-pluginbuilder image to 3.30.0
- Added missing `go.sum` entry to allow local builds to succeed
- Ensured alignment between the app Go version and the plugin builder image

## Testing and Verifying

- Built Docker image locally and verified the build succeeds
- Ran the plugin locally to confirm it loads and runs as expected
- No changes to app functionality; existing tests already cover runtime behavior