### PR TITLE
feat: add ShapeTypeStaticChainLoop and ShapeTypeEdge collider shapes

### DIFF
--- a/pkg/plugin/physics2d/component/collider.go
+++ b/pkg/plugin/physics2d/component/collider.go
@@ -20,9 +20,17 @@ const (
 	ShapeTypeBox
 	// ShapeTypeConvexPolygon uses Vertices as a convex polygon in the shape's local frame.
 	ShapeTypeConvexPolygon
-	// ShapeTypeStaticChain uses ChainPoints for open chain segments (static/terrain-style
-	// geometry only; not for moving dynamic shapes).
+	// ShapeTypeStaticChain uses ChainPoints for open chain segments (static or kinematic
+	// bodies only; not for dynamic bodies which require mass).
 	ShapeTypeStaticChain
+	// ShapeTypeStaticChainLoop uses ChainPoints for closed chain loops (static or kinematic
+	// bodies only; not for dynamic bodies). Unlike ShapeTypeStaticChain, the last vertex
+	// automatically connects back to the first, creating a sealed boundary.
+	ShapeTypeStaticChainLoop
+	// ShapeTypeEdge uses EdgeVertices (exactly 2 points) for a single line segment
+	// (static or kinematic bodies only). Lighter than a 2-point chain for isolated barriers
+	// or triggers.
+	ShapeTypeEdge
 )
 
 // ColliderShape is one child shape inside a compound Collider2D.
@@ -33,6 +41,8 @@ const (
 //   - ShapeTypeBox → HalfExtents (half-width on X, half-height on Y, axis-aligned before LocalOffset/LocalRotation)
 //   - ShapeTypeConvexPolygon → Vertices (convex polygon, respect backend limits)
 //   - ShapeTypeStaticChain → ChainPoints (open polyline in local space)
+//   - ShapeTypeStaticChainLoop → ChainPoints (closed loop in local space)
+//   - ShapeTypeEdge → EdgeVertices (exactly 2 points in local space)
 type ColliderShape struct {
 	ShapeType     ShapeType `json:"shape_type"`
 	LocalOffset   Vec2      `json:"local_offset"`
@@ -40,10 +50,11 @@ type ColliderShape struct {
 	IsSensor      bool      `json:"is_sensor"`
 
 	// Geometry (use fields matching ShapeType).
-	Radius      float64 `json:"radius,omitempty"`
-	HalfExtents Vec2    `json:"half_extents,omitempty"`
-	Vertices    []Vec2  `json:"vertices,omitempty"`
-	ChainPoints []Vec2  `json:"chain_points,omitempty"`
+	Radius       float64 `json:"radius,omitempty"`
+	HalfExtents  Vec2    `json:"half_extents,omitempty"`
+	Vertices     []Vec2  `json:"vertices,omitempty"`
+	ChainPoints  []Vec2  `json:"chain_points,omitempty"`
+	EdgeVertices [2]Vec2 `json:"edge_vertices,omitempty"`
 
 	// Material and per-shape collision filtering (fixture-level in Box2D).
 	Friction     float64 `json:"friction"`
@@ -117,9 +128,15 @@ func (s ColliderShape) Validate() error {
 			return err
 		}
 	}
+	for i, v := range s.EdgeVertices {
+		if err := validateVec2(fmt.Sprintf("edge_vertices[%d]", i), v); err != nil {
+			return err
+		}
+	}
 
 	switch s.ShapeType {
-	case ShapeTypeCircle, ShapeTypeBox, ShapeTypeConvexPolygon, ShapeTypeStaticChain:
+	case ShapeTypeCircle, ShapeTypeBox, ShapeTypeConvexPolygon, ShapeTypeStaticChain,
+		ShapeTypeStaticChainLoop, ShapeTypeEdge:
 	default:
 		return fmt.Errorf("shape_type: unknown value %d", s.ShapeType)
 	}

--- a/pkg/plugin/physics2d/internal/create.go
+++ b/pkg/plugin/physics2d/internal/create.go
@@ -121,8 +121,12 @@ func attachFixture(
 	sh component.ColliderShape,
 	bodyType uint8,
 ) error {
-	if sh.ShapeType == component.ShapeTypeStaticChain && bodyType != box2d.B2BodyType.B2_staticBody {
-		return errors.New("static chain colliders require a static body")
+	//nolint:exhaustive // We only care about static chain, static chain loop, and edge shapes
+	switch sh.ShapeType {
+	case component.ShapeTypeStaticChain, component.ShapeTypeStaticChainLoop, component.ShapeTypeEdge:
+		if bodyType == box2d.B2BodyType.B2_dynamicBody {
+			return fmt.Errorf("%d shape type cannot be used on dynamic bodies (zero mass)", sh.ShapeType)
+		}
 	}
 
 	shape, err := buildShape(sh)
@@ -155,6 +159,10 @@ func buildShape(sh component.ColliderShape) (box2d.B2ShapeInterface, error) {
 		return buildPolygonShape(sh)
 	case component.ShapeTypeStaticChain:
 		return buildChainShape(sh)
+	case component.ShapeTypeStaticChainLoop:
+		return buildChainLoopShape(sh)
+	case component.ShapeTypeEdge:
+		return buildEdgeShape(sh)
 	default:
 		return nil, fmt.Errorf("unknown shape_type %d", sh.ShapeType)
 	}
@@ -192,6 +200,24 @@ func buildChainShape(sh component.ColliderShape) (box2d.B2ShapeInterface, error)
 	chain := box2d.MakeB2ChainShape()
 	chain.CreateChain(pts, len(sh.ChainPoints))
 	return &chain, nil
+}
+
+func buildChainLoopShape(sh component.ColliderShape) (box2d.B2ShapeInterface, error) {
+	pts := make([]box2d.B2Vec2, len(sh.ChainPoints))
+	for i := range sh.ChainPoints {
+		pts[i] = shapePointToBodySpace(sh.ChainPoints[i], sh.LocalOffset, sh.LocalRotation)
+	}
+	chain := box2d.MakeB2ChainShape()
+	chain.CreateLoop(pts, len(sh.ChainPoints))
+	return &chain, nil
+}
+
+func buildEdgeShape(sh component.ColliderShape) (box2d.B2ShapeInterface, error) {
+	v1 := shapePointToBodySpace(sh.EdgeVertices[0], sh.LocalOffset, sh.LocalRotation)
+	v2 := shapePointToBodySpace(sh.EdgeVertices[1], sh.LocalOffset, sh.LocalRotation)
+	edge := box2d.MakeB2EdgeShape()
+	edge.Set(v1, v2)
+	return &edge, nil
 }
 
 // shapePointToBodySpace maps a point from shape-local space into body-local space using

--- a/pkg/plugin/physics2d/internal/shadow.go
+++ b/pkg/plugin/physics2d/internal/shadow.go
@@ -49,6 +49,7 @@ func deepCopyColliderShape(s component.ColliderShape) component.ColliderShape {
 		HalfExtents:   s.HalfExtents,
 		Vertices:      cloneVec2Slice(s.Vertices),
 		ChainPoints:   cloneVec2Slice(s.ChainPoints),
+		EdgeVertices:  s.EdgeVertices,
 		Friction:      s.Friction,
 		Restitution:   s.Restitution,
 		Density:       s.Density,
@@ -140,7 +141,9 @@ func colliderShapeDeepEqual(a, b component.ColliderShape) bool {
 		a.GroupIndex != b.GroupIndex {
 		return false
 	}
-	return vec2SliceEqual(a.Vertices, b.Vertices) && vec2SliceEqual(a.ChainPoints, b.ChainPoints)
+	return vec2SliceEqual(a.Vertices, b.Vertices) &&
+		vec2SliceEqual(a.ChainPoints, b.ChainPoints) &&
+		a.EdgeVertices == b.EdgeVertices
 }
 
 // Collider2DStructuralEqual reports whether two colliders match for Box2D fixture shape
@@ -166,7 +169,8 @@ func colliderShapeStructuralEqual(a, b component.ColliderShape) bool {
 		a.Radius == b.Radius &&
 		vec2Equal(a.HalfExtents, b.HalfExtents) &&
 		vec2SliceEqual(a.Vertices, b.Vertices) &&
-		vec2SliceEqual(a.ChainPoints, b.ChainPoints)
+		vec2SliceEqual(a.ChainPoints, b.ChainPoints) &&
+		a.EdgeVertices == b.EdgeVertices
 }
 
 // ColliderShapeMutableFieldsEqual compares per-shape fields that Box2D can update without

--- a/pkg/plugin/physics2d/plugin.go
+++ b/pkg/plugin/physics2d/plugin.go
@@ -50,10 +50,12 @@ const (
 
 // Collider shape kinds (ColliderShape).
 const (
-	ShapeTypeCircle        = component.ShapeTypeCircle
-	ShapeTypeBox           = component.ShapeTypeBox
-	ShapeTypeConvexPolygon = component.ShapeTypeConvexPolygon
-	ShapeTypeStaticChain   = component.ShapeTypeStaticChain
+	ShapeTypeCircle          = component.ShapeTypeCircle
+	ShapeTypeBox             = component.ShapeTypeBox
+	ShapeTypeConvexPolygon   = component.ShapeTypeConvexPolygon
+	ShapeTypeStaticChain     = component.ShapeTypeStaticChain
+	ShapeTypeStaticChainLoop = component.ShapeTypeStaticChainLoop
+	ShapeTypeEdge            = component.ShapeTypeEdge
 )
 
 // Contact / trigger system events (implement ecs.SystemEvent; register with WithSystemEventEmitter).


### PR DESCRIPTION
### TL;DR

Added two new collider shape types: `ShapeTypeStaticChainLoop` for closed chain boundaries and `ShapeTypeEdge` for single line segments.

### What changed?

- Added `ShapeTypeStaticChainLoop` constant that creates closed chain loops where the last vertex automatically connects to the first
- Added `ShapeTypeEdge` constant for single line segments using exactly 2 points, providing a lighter alternative to 2-point chains
- Added `EdgeVertices [2]Vec2` field to `ColliderShape` struct for edge geometry data
- Updated validation logic to include the new shape types and validate `EdgeVertices`
- Implemented `buildChainLoopShape()` and `buildEdgeShape()` functions to create the corresponding Box2D shapes
- Enhanced body type validation to prevent dynamic bodies from using chain loop or edge shapes (they require zero mass)
- Updated deep copy and equality comparison functions to handle the new `EdgeVertices` field
- Exported the new shape type constants in the public plugin interface


### Why make this change?

This extends the physics2D plugin's shape capabilities to support more diverse collision geometry. Chain loops provide an efficient way to create sealed boundaries without manually connecting the last point to the first, while edge shapes offer a performance-optimized option for simple line segments compared to using chains with only two points.