### PR TITLE
chore(lobby): update lobby plugin with discovery query

### DIFF
--- a/pkg/lobby/README.md
+++ b/pkg/lobby/README.md
@@ -69,6 +69,7 @@ Shard broadcasts state changes to all subscribed clients.
 | `LeaderChangedEvent` | `LobbyID`, `OldLeaderID`, `NewLeaderID` | Leadership transferred |
 | `SessionStartedEvent` | `LobbyID` | Session started |
 | `SessionEndedEvent` | `LobbyID` | Session ended |
+| `SessionAwaitingAllocationEvent` | `LobbyID` | Session is pending shard assignment; orchestrators listen for this |
 | `InviteCodeGeneratedEvent` | `LobbyID`, `InviteCode` | New code generated |
 | `LobbyDeletedEvent` | `LobbyID` | Lobby deleted (empty) |
 | `PlayerTimedOutEvent` | `LobbyID`, `PlayerID` | Player removed due to missed heartbeats |
@@ -82,6 +83,7 @@ One shard sends a command to another shard.
 |---------|-----------|--------|-------------|
 | `NotifySessionStartCommand` | Lobby → Game | `Lobby`, `LobbyWorld` | Notify game shard to start session |
 | `NotifySessionEndCommand` | Game → Lobby | `LobbyID` | Notify lobby shard to end session |
+| `AssignShardCommand` | Orchestrator → Lobby | `LobbyID`, `RequestID`, `GameWorld`, `Reason` | Complete a pending session-start by assigning a game shard (see Shard Assignment) |
 
 ### 4. CrossShardResult (Shard → Shard, response)
 Shard sends a response back to the originating shard.
@@ -127,8 +129,10 @@ PlayerState
 
 ```
 Session
-- State SessionState             // idle | in_session
-- PassthroughData map[string]any // Forwarded to game shard
+- State SessionState                   // idle | awaiting_allocation | in_session
+- PassthroughData map[string]any       // Forwarded to game shard
+- PendingRequestID string              // StartSessionCommand RequestID while awaiting_allocation
+- PendingStartedAt int64               // Unix seconds at which awaiting_allocation began
 ```
 
 ## Configuration
@@ -138,6 +142,8 @@ Session
 | `LobbyWorld` | This lobby shard's address (for game shard to send NotifySessionEndCommand back) | required |
 | `Provider` | Custom provider (optional, default provided) | `DefaultProvider` |
 | `HeartbeatTimeout` | Seconds before a player is removed for not sending heartbeats. Clients should send heartbeats more frequently (e.g., every timeout/3 seconds). | 30 |
+| `AssignmentAuthority` | Accident-prevention filter for `AssignShardCommand` — dropped when `cmd.Persona` differs. **Not authentication.** `cmd.Persona` is not signature-verified at this layer, so a forged client command still passes if it matches. Real auth (NATS ACLs, gateway auth) must live above the plugin. | empty |
+| `MaxAllocationTimeout` | Max seconds a lobby may sit in `awaiting_allocation` before the plugin fails the pending request. `<= 0` disables timeout enforcement. | 0 (disabled) |
 
 ## Cross-Shard Communication
 
@@ -195,11 +201,233 @@ Default: `Hash(LobbyID + Timestamp)` -> 6-char uppercase alphanumeric (excludes 
 ## Lifecycle
 
 ```
-CreateLobby -> idle -> (players join, ready up) -> StartSession -> in_session -> EndSession -> idle
-                                                                                      │
-                                                                                      v
-                                                                        (players can start again)
+CreateLobby -> idle -> (players join, ready up) -> StartSession -> awaiting_allocation
+                                                                         │
+                                                                         v
+                                                                  AssignShardCommand
+                                                                         │
+                                                                         v
+                                                                     in_session
+                                                                         │
+                                                                         v
+                                                                    EndSession
+                                                                         │
+                                                                         v
+                                                                       idle
+                                                          (players can start again)
 ```
+
+`StartSession` does not commit the session directly — the lobby enters
+`awaiting_allocation` and emits `SessionAwaitingAllocationEvent`. An
+external orchestrator (another system running in the same shard) picks a
+game shard and sends `AssignShardCommand` back to complete the start.
+
+## Shard Assignment
+
+When a `StartSessionCommand` is accepted, the plugin does not pick a
+game shard itself. Instead it transitions the lobby to
+`awaiting_allocation` and waits for an orchestrator to send
+`AssignShardCommand`. This lets consumers plug in any assignment strategy
+(static, round-robin, probe + claim, external matchmaker, etc.) without
+the lobby plugin knowing anything about the game.
+
+### ⚠ If you enable this plugin, you MUST register an orchestrator
+
+Every `StartSessionCommand` parks the lobby in
+`awaiting_allocation` and waits for `AssignShardCommand`. Without an
+orchestrator registered in the same shard, sessions never start and
+clients sit waiting until `MaxAllocationTimeout` expires (or forever,
+if unset). There is no implicit default behavior and no startup
+detection — the plugin cannot tell whether an orchestrator exists.
+
+**Always set `MaxAllocationTimeout` to a reasonable value** (e.g.,
+30–60 seconds). This is your only safety net: if the orchestrator is
+missing or broken, the timeout fails the pending session and returns
+the lobby to idle instead of hanging forever.
+
+### The orchestrator is just a normal system
+
+An orchestrator is not a special plugin or interface. It is a regular
+system registered in the same lobby shard.
+
+### Copy-paste template
+
+Drop this into your lobby shard. Change the five `REPLACE:` markers
+and you're running. The rest is boilerplate — the system shape stays
+the same regardless of how fancy your assignment logic becomes.
+
+> **Heads up:** this minimal template has no in-flight tracking. It
+> iterates every pending lobby each tick and sends
+> `AssignShardCommand` unconditionally. The plugin's one-shot
+> `RequestID` check rejects duplicates, but you'll see WARN logs for
+> every redundant send until the lobby leaves
+> `awaiting_allocation`. That's fine for the first smoke test or a
+> one-server deployment; for anything real, track in-flight
+> assignments — see the pool-based example below for the pattern
+> (a `PendingProbe`-style component destroyed after the first send).
+
+```go
+package main
+
+import (
+    "github.com/argus-labs/world-engine/pkg/cardinal"
+    "github.com/argus-labs/world-engine/pkg/lobby"
+)
+
+type AssignerState struct {
+    cardinal.BaseSystemState
+    Lobbies cardinal.Contains[struct {
+        Lobby cardinal.Ref[lobby.Component]
+    }]
+}
+
+func AssignerSystem(state *AssignerState) {
+    // REPLACE: your lobby shard's own address.
+    self := cardinal.OtherWorld{
+        Region:       "us-west", // REPLACE
+        Organization: "myorg",   // REPLACE
+        Project:      "mygame",  // REPLACE
+        ShardID:      "lobby",   // REPLACE
+    }
+
+    for _, refs := range state.Lobbies.Iter() {
+        lob := refs.Lobby.Get()
+        if lob.Session.State != lobby.SessionStateAwaitingAllocation {
+            continue
+        }
+        self.SendCommand(&state.BaseSystemState, lobby.AssignShardCommand{
+            LobbyID:   lob.ID,
+            RequestID: lob.Session.PendingRequestID,
+            GameWorld: cardinal.OtherWorld{
+                Region:       "us-west", // REPLACE
+                Organization: "myorg",   // REPLACE
+                Project:      "mygame",  // REPLACE
+                ShardID:      "game-shard-1", // REPLACE: pick your target shard
+            },
+        })
+    }
+}
+```
+
+Wire it up in `main.go` alongside the plugin:
+
+```go
+cardinal.RegisterPlugin(world, lobby.NewPlugin(lobby.Config{...}))
+cardinal.RegisterSystem(world, AssignerSystem)
+```
+
+That's it. Every `StartSessionCommand` now routes to the shard you
+named. To get smarter behavior (round-robin, probe-based idle
+selection, external matchmaker), replace the hardcoded `ShardID` with
+whatever selection logic you want — the command shape stays identical.
+
+### Minimum requirements for the orchestrator
+
+All three fields are required for the command to be accepted:
+
+| Field | Value | Why |
+|---|---|---|
+| `LobbyID` | `lob.ID` (from the `Lobby` entity) | Tells the plugin which pending lobby this assignment is for. |
+| `RequestID` | `lob.Session.PendingRequestID` (echoed verbatim) | Plugin rejects stale or mismatched assignments. Never generate your own — always read it from the lobby. |
+| `GameWorld` | `cardinal.OtherWorld` with at minimum a non-empty `ShardID` | The full address of the game shard for this session. Empty `ShardID` = failure (regardless of `Reason`); `Reason` is only used as the failure message. |
+
+### Example: pool-based orchestrator (probe + claim)
+
+A realistic deployment with multiple game shards needs dynamic
+assignment. The shape below probes a pool of game shards, claims the
+first idle one, and releases claims when the session ends. This is a
+pattern only — adapt it to your own shard naming, pool sizing, and
+failure handling.
+
+**Components** (two, both orchestrator-owned):
+
+```go
+type ShardClaim struct {
+    LobbyID   string  // which lobby owns the claim
+    ShardID   string  // which game shard is bound
+    ClaimedAt int64   // unix seconds
+}
+func (ShardClaim) Name() string { return "shard_claim" }
+
+type PendingProbe struct {
+    LobbyID   string  // lobby we've already fanned out probes for
+    StartedAt int64
+}
+func (PendingProbe) Name() string { return "pending_probe" }
+```
+
+**Custom commands** for the game-shard round trip:
+
+```go
+// Lobby → game shard: "are you idle?"
+type CheckAvailabilityCommand struct {
+    LobbyID       string
+    SendbackWorld cardinal.OtherWorld // where to reply
+}
+func (CheckAvailabilityCommand) Name() string { return "check_availability" }
+
+// Game shard → lobby: "here's my state"
+type AvailabilityResponseCommand struct {
+    LobbyID   string
+    ShardID   string
+    Idle      bool
+    SessionID string  // empty if Idle
+    StartedAt int64
+}
+func (AvailabilityResponseCommand) Name() string { return "availability_response" }
+```
+
+**Three systems working together:**
+
+1. `ProbeOnSessionAwaitingAllocationSystem` — scans lobbies; for each
+   in `awaiting_allocation` with no `PendingProbe` yet, creates a
+   `PendingProbe` entity and fans out `CheckAvailabilityCommand` to
+   every shard in the pool (e.g., `game-shard-1` .. `game-shard-N`).
+
+2. `HandleAvailabilityResponseSystem` — consumes
+   `AvailabilityResponseCommand`. For each `Idle=true` response whose
+   lobby is still pending and whose shard isn't already claimed: create
+   a `ShardClaim` entity, destroy the `PendingProbe`, send
+   `lobby.AssignShardCommand{LobbyID, RequestID, GameWorld}` to the lobby
+   shard itself.
+
+3. `ReleaseOnSessionEndSystem` — scans the lobby table each tick;
+   drops `ShardClaim` entities whose lobby is no longer `in_session`
+   (session ended, cancelled, or lobby destroyed) and drops
+   `PendingProbe` entities whose lobby left `awaiting_allocation`.
+
+**Game-shard side:** a single responder system handles
+`CheckAvailabilityCommand` and replies with
+`AvailabilityResponseCommand` to `SendbackWorld`, reading idle state
+from whatever singleton the game uses to track its active session.
+
+**Why it's this many pieces:** Cardinal's only inter-shard primitive is
+async `SendCommand`. Asking a shard "are you idle?" therefore requires
+a command out, a command back, and state to correlate them across
+ticks. Simpler orchestrators (static, round-robin) skip the probe
+entirely — see the minimal example above.
+
+### Orchestrator contract
+
+Send `AssignShardCommand` to the lobby shard's own address with:
+- `LobbyID` — the lobby awaiting allocation
+- `RequestID` — echoed from `lob.Session.PendingRequestID` (the plugin
+  rejects mismatches to guard against stale / duplicate commands)
+- `GameWorld` — the chosen game shard's full address, or empty
+  `ShardID` (+ `Reason`) to fail the start
+
+The plugin's handler validates the `RequestID`, checks
+`cmd.Persona` against `AssignmentAuthority` if configured, and rejects
+anything that doesn't match. On success it writes `GameWorld` onto
+`lobby.GameWorld`, transitions to `in_session`, dispatches
+`NotifySessionStartCommand`, and emits the final `StartSessionResult`.
+
+### Timing contract
+
+Because assignment is asynchronous, `StartSessionResult` is emitted
+several ticks after the `StartSessionCommand` arrives (orchestrator
+round-trip + decision). Clients should not set short timeouts on
+`StartSessionResult` — treat session start as a matchmaking-style wait.
 
 ## Key Behaviors
 

--- a/pkg/lobby/component/lobby.go
+++ b/pkg/lobby/component/lobby.go
@@ -6,8 +6,9 @@ import "github.com/argus-labs/world-engine/pkg/cardinal"
 type SessionState string
 
 const (
-	SessionStateIdle      SessionState = "idle"       // Lobby is waiting, not in a session
-	SessionStateInSession SessionState = "in_session" // Lobby is currently in a game session
+	SessionStateIdle               SessionState = "idle"                // Lobby is waiting, not in a session
+	SessionStateAwaitingAllocation SessionState = "awaiting_allocation" // Lobby is awaiting external shard assignment
+	SessionStateInSession          SessionState = "in_session"          // Lobby is currently in a game session
 )
 
 // PlayerComponent represents a player entity in a lobby.
@@ -36,6 +37,14 @@ type Team struct {
 type Session struct {
 	State           SessionState   `json:"state"`
 	PassthroughData map[string]any `json:"passthrough_data,omitempty"`
+	// PendingRequestID holds the StartSessionCommand RequestID while the
+	// lobby waits in SessionStateAwaitingAllocation for an external shard
+	// assignment. Empty in other states.
+	PendingRequestID string `json:"pending_request_id,omitempty"`
+	// PendingStartedAt records the unix timestamp (seconds) at which the
+	// lobby entered SessionStateAwaitingAllocation. Used by timeout
+	// enforcement. Zero in other states.
+	PendingStartedAt int64 `json:"pending_started_at,omitempty"`
 }
 
 // LobbyComponent represents a lobby where players gather.
@@ -403,6 +412,22 @@ type ConfigComponent struct {
 	// Clients should send heartbeats more frequently than this (e.g., every timeout/3 seconds).
 	// Default: 30 seconds.
 	HeartbeatTimeout int64 `json:"heartbeat_timeout"`
+
+	// AssignmentAuthority is an accident-prevention filter, NOT an
+	// authentication boundary. The plugin compares it against cmd.Persona
+	// and drops mismatches. This prevents an unrelated system that
+	// happens to send AssignShardCommand from accidentally completing the
+	// wrong lobby's session start. It does NOT defend against a client
+	// that forges Persona, because cmd.Persona is not signature-verified
+	// at this layer. Real authentication must live above the plugin
+	// (NATS ACLs, gateway auth, signed commands). Empty = no filter.
+	AssignmentAuthority string `json:"assignment_authority,omitempty"`
+
+	// MaxAllocationTimeout bounds how long (in seconds) a lobby may remain
+	// in SessionStateAwaitingAllocation before the lobby shard fails the
+	// start itself and returns to Idle. Values <= 0 disable timeout
+	// enforcement entirely.
+	MaxAllocationTimeout int64 `json:"max_allocation_timeout,omitempty"`
 }
 
 // Name returns the component name for ECS registration.

--- a/pkg/lobby/component/lobby_internal_test.go
+++ b/pkg/lobby/component/lobby_internal_test.go
@@ -397,3 +397,51 @@ func TestLobbyIndexComponent_UpdateInviteCode(t *testing.T) {
 	assert.True(t, exists)
 	assert.Equal(t, "lobby1", lobbyID)
 }
+
+func TestSessionStateConstants(t *testing.T) {
+	t.Parallel()
+
+	// Stable wire values for the session state machine. External consumers
+	// (dashboards, audit logs) may persist these strings, so renames must
+	// be intentional.
+	assert.Equal(t, SessionStateIdle, SessionState("idle"))
+	assert.Equal(t, SessionStateAwaitingAllocation, SessionState("awaiting_allocation"))
+	assert.Equal(t, SessionStateInSession, SessionState("in_session"))
+}
+
+func TestSessionPendingFields(t *testing.T) {
+	t.Parallel()
+
+	// Session carries the correlation fields the AssignShardCommand
+	// handler validates against. Renaming or removing these would silently
+	// break orchestrators that echo PendingRequestID.
+	s := Session{
+		State:            SessionStateAwaitingAllocation,
+		PendingRequestID: "req-42",
+		PendingStartedAt: 100,
+	}
+	assert.Equal(t, SessionStateAwaitingAllocation, s.State)
+	assert.Equal(t, "req-42", s.PendingRequestID)
+	assert.Equal(t, int64(100), s.PendingStartedAt)
+}
+
+func TestConfigComponent_AssignmentFields(t *testing.T) {
+	t.Parallel()
+
+	// Assignment-related config fields. AssignmentAuthority is an
+	// accident-prevention filter (not authentication — cmd.Persona is
+	// not verified at this layer). MaxAllocationTimeout bounds the
+	// pending-allocation lifetime.
+	cfg := ConfigComponent{
+		AssignmentAuthority:  "region.world.org.project.lobby",
+		MaxAllocationTimeout: 300,
+	}
+	assert.Equal(t, "region.world.org.project.lobby", cfg.AssignmentAuthority)
+	assert.Equal(t, int64(300), cfg.MaxAllocationTimeout)
+
+	// MaxAllocationTimeout <= 0 is the documented "disabled" sentinel.
+	disabled := ConfigComponent{MaxAllocationTimeout: 0}
+	assert.LessOrEqual(t, disabled.MaxAllocationTimeout, int64(0))
+	negDisabled := ConfigComponent{MaxAllocationTimeout: -1}
+	assert.LessOrEqual(t, negDisabled.MaxAllocationTimeout, int64(0))
+}

--- a/pkg/lobby/lobby_test.go
+++ b/pkg/lobby/lobby_test.go
@@ -9,9 +9,47 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// testOrchestratorState is the system state for a minimal orchestrator
+// that immediately assigns every awaiting-allocation lobby to a fixed
+// game shard. This ensures DST/E2E fuzzing exercises the full session
+// lifecycle (awaiting_allocation → in_session → idle) instead of
+// parking at awaiting_allocation forever.
+type testOrchestratorState struct {
+	cardinal.BaseSystemState
+	Lobbies cardinal.Contains[struct {
+		Lobby cardinal.Ref[lobby.Component]
+	}]
+}
+
+func testOrchestratorSystem(state *testOrchestratorState) {
+	self := cardinal.OtherWorld{
+		Region:       "local",
+		Organization: "organization",
+		Project:      "project",
+		ShardID:      "lobby",
+	}
+	for _, refs := range state.Lobbies.Iter() {
+		lob := refs.Lobby.Get()
+		if lob.Session.State != lobby.SessionStateAwaitingAllocation {
+			continue
+		}
+		self.SendCommand(&state.BaseSystemState, lobby.AssignShardCommand{
+			LobbyID:   lob.ID,
+			RequestID: lob.Session.PendingRequestID,
+			GameWorld: cardinal.OtherWorld{
+				Region:       "local",
+				Organization: "organization",
+				Project:      "project",
+				ShardID:      "game-test-1",
+			},
+		})
+	}
+}
+
 func TestDST(t *testing.T) {
 	cardinal.RunDST(t, func(w *cardinal.World) {
 		cardinal.RegisterPlugin(w, lobby.NewPlugin(lobby.Config{}))
+		cardinal.RegisterSystem(w, testOrchestratorSystem)
 	}, nil)
 }
 
@@ -32,6 +70,7 @@ func TestE2E(t *testing.T) {
 		require.NoError(t, err)
 
 		cardinal.RegisterPlugin(world, lobby.NewPlugin(lobby.Config{}))
+		cardinal.RegisterSystem(world, testOrchestratorSystem)
 
 		return world
 	})

--- a/pkg/lobby/plugin.go
+++ b/pkg/lobby/plugin.go
@@ -102,6 +102,10 @@ type (
 	// Provider.
 	Provider        = system.LobbyProvider
 	DefaultProvider = system.DefaultProvider
+
+	// Hooks.
+	Hooks     = system.LobbyHooks
+	NoopHooks = system.NoopHooks
 )
 
 // Session states.
@@ -119,6 +123,10 @@ type Config struct {
 	// Provider is the customizable provider for the lobby system.
 	// If nil, DefaultProvider is used.
 	Provider Provider
+
+	// Hooks lets consumers react to lobby lifecycle events.
+	// If nil, NoopHooks is used.
+	Hooks Hooks
 
 	// HeartbeatTimeout is how long (in seconds) before a player is removed for not sending heartbeats.
 	// Clients should send heartbeats more frequently than this (e.g., every timeout/3 seconds).
@@ -147,6 +155,9 @@ func (p *Plugin) Register(world *cardinal.World) {
 
 	// Store provider
 	system.SetProvider(p.config.Provider)
+
+	// Store hooks (nil falls back to NoopHooks inside SetHooks).
+	system.SetHooks(p.config.Hooks)
 
 	// Register init system (runs once during world initialization)
 	cardinal.RegisterSystem(world, system.InitSystem, cardinal.WithHook(cardinal.Init))

--- a/pkg/lobby/plugin.go
+++ b/pkg/lobby/plugin.go
@@ -56,6 +56,7 @@ type (
 	KickPlayerCommand               = system.KickPlayerCommand
 	TransferLeaderCommand           = system.TransferLeaderCommand
 	StartSessionCommand             = system.StartSessionCommand
+	AssignShardCommand              = system.AssignShardCommand
 	GenerateInviteCodeCommand       = system.GenerateInviteCodeCommand
 	HeartbeatCommand                = system.HeartbeatCommand
 	UpdateSessionPassthroughCommand = system.UpdateSessionPassthroughCommand
@@ -72,6 +73,7 @@ type (
 	PlayerChangedTeamEvent         = system.PlayerChangedTeamEvent
 	LeaderChangedEvent             = system.LeaderChangedEvent
 	SessionStartedEvent            = system.SessionStartedEvent
+	SessionAwaitingAllocationEvent = system.SessionAwaitingAllocationEvent
 	SessionEndedEvent              = system.SessionEndedEvent
 	InviteCodeGeneratedEvent       = system.InviteCodeGeneratedEvent
 	DeletedEvent                   = system.LobbyDeletedEvent
@@ -102,16 +104,13 @@ type (
 	// Provider.
 	Provider        = system.LobbyProvider
 	DefaultProvider = system.DefaultProvider
-
-	// Hooks.
-	Hooks     = system.LobbyHooks
-	NoopHooks = system.NoopHooks
 )
 
 // Session states.
 const (
-	SessionStateIdle      = component.SessionStateIdle
-	SessionStateInSession = component.SessionStateInSession
+	SessionStateIdle               = component.SessionStateIdle
+	SessionStateAwaitingAllocation = component.SessionStateAwaitingAllocation
+	SessionStateInSession          = component.SessionStateInSession
 )
 
 // Config holds configuration for the lobby package.
@@ -124,9 +123,17 @@ type Config struct {
 	// If nil, DefaultProvider is used.
 	Provider Provider
 
-	// Hooks lets consumers react to lobby lifecycle events.
-	// If nil, NoopHooks is used.
-	Hooks Hooks
+	// AssignmentAuthority is an accident-prevention filter — not
+	// authentication. Dropped commands whose cmd.Persona differs from
+	// this value. cmd.Persona is not signature-verified at this layer, so
+	// this does NOT protect against a malicious client; real auth belongs
+	// above the plugin (NATS ACLs, gateway auth). Empty = no filter.
+	AssignmentAuthority string
+
+	// MaxAllocationTimeout bounds how long (in seconds) a lobby may sit in
+	// SessionStateAwaitingAllocation before the lobby fails the start
+	// itself. Values <= 0 disable timeout enforcement.
+	MaxAllocationTimeout int64
 
 	// HeartbeatTimeout is how long (in seconds) before a player is removed for not sending heartbeats.
 	// Clients should send heartbeats more frequently than this (e.g., every timeout/3 seconds).
@@ -149,15 +156,14 @@ func NewPlugin(config Config) *Plugin {
 // Register implements cardinal.Plugin.
 func (p *Plugin) Register(world *cardinal.World) {
 	system.SetConfig(component.ConfigComponent{
-		LobbyWorld:       p.config.LobbyWorld,
-		HeartbeatTimeout: p.config.HeartbeatTimeout,
+		LobbyWorld:           p.config.LobbyWorld,
+		HeartbeatTimeout:     p.config.HeartbeatTimeout,
+		AssignmentAuthority:  p.config.AssignmentAuthority,
+		MaxAllocationTimeout: p.config.MaxAllocationTimeout,
 	})
 
 	// Store provider
 	system.SetProvider(p.config.Provider)
-
-	// Store hooks (nil falls back to NoopHooks inside SetHooks).
-	system.SetHooks(p.config.Hooks)
 
 	// Register init system (runs once during world initialization)
 	cardinal.RegisterSystem(world, system.InitSystem, cardinal.WithHook(cardinal.Init))

--- a/pkg/lobby/system/lobby.go
+++ b/pkg/lobby/system/lobby.go
@@ -93,7 +93,11 @@ type TransferLeaderCommand struct {
 // Name returns the command name.
 func (TransferLeaderCommand) Name() string { return "lobby_transfer_leader" }
 
-// StartSessionCommand starts the session (leader only).
+// StartSessionCommand starts the session (leader only). The
+// corresponding StartSessionResult is emitted asynchronously, typically
+// several ticks after this command is accepted, once an orchestrator
+// responds with AssignShardCommand. Clients must not set short
+// timeouts on StartSessionResult.
 type StartSessionCommand struct {
 	RequestID string `json:"request_id"` // For matching request/response
 }
@@ -233,6 +237,16 @@ type SessionStartedEvent struct {
 // Name returns the event name.
 func (SessionStartedEvent) Name() string { return "lobby_session_started" }
 
+// SessionAwaitingAllocationEvent is emitted when a session is awaiting shard
+// assignment. External orchestrators listen for this event and respond
+// with an AssignShardCommand to complete the session start.
+type SessionAwaitingAllocationEvent struct {
+	LobbyID string `json:"lobby_id"`
+}
+
+// Name returns the event name.
+func (SessionAwaitingAllocationEvent) Name() string { return "lobby_session_awaiting_allocation" }
+
 // SessionEndedEvent is emitted when a session ends.
 type SessionEndedEvent struct {
 	LobbyID string `json:"lobby_id"`
@@ -366,6 +380,8 @@ type TransferLeaderResult struct {
 func (r TransferLeaderResult) Name() string { return r.RequestID + "_transfer_leader_result" }
 
 // StartSessionResult is sent back to the client after StartSessionCommand.
+// Emitted asynchronously — may arrive several ticks after the command,
+// once the orchestrator assigns a game shard via AssignShardCommand.
 type StartSessionResult struct {
 	RequestID string `json:"request_id"`
 	IsSuccess bool   `json:"is_success"`
@@ -458,6 +474,31 @@ type NotifySessionEndCommand struct {
 // Name returns the command name.
 func (NotifySessionEndCommand) Name() string { return "lobby_notify_session_end" }
 
+// AssignShardCommand is sent by an external orchestrator to complete a
+// session start that is waiting in SessionStateAwaitingAllocation. The
+// lobby writes GameWorld directly onto the lobby component, transitions
+// to SessionStateInSession, and dispatches NotifySessionStartCommand.
+// The orchestrator is responsible for providing a complete GameWorld
+// address (Region, Organization, Project, ShardID).
+//
+// If GameWorld.ShardID is empty, the assignment is treated as a failure:
+// the lobby returns to SessionStateIdle and a failure StartSessionResult
+// is emitted with Reason as the failure message.
+//
+// RequestID must equal the lobby's current Session.PendingRequestID (which
+// the orchestrator reads from the LobbyComponent). Mismatched RequestIDs
+// are rejected; this rejects late duplicate or stale commands that arrive
+// after the original pending cycle has already been completed or cancelled.
+type AssignShardCommand struct {
+	LobbyID   string              `json:"lobby_id"`
+	RequestID string              `json:"request_id"`
+	GameWorld cardinal.OtherWorld `json:"game_world"`
+	Reason    string              `json:"reason,omitempty"`
+}
+
+// Name returns the command name.
+func (AssignShardCommand) Name() string { return "lobby_assign_shard" }
+
 // StartSessionPayload is an alias for NotifySessionStartCommand for documentation clarity.
 type StartSessionPayload = NotifySessionStartCommand
 
@@ -470,39 +511,6 @@ type LobbyProvider interface {
 	// GenerateInviteCode generates a custom invite code for the lobby.
 	GenerateInviteCode(lobby *component.LobbyComponent) string
 }
-
-// LobbyHooks lets consumers react to lobby lifecycle events.
-// Pass via Config.Hooks; nil falls back to NoopHooks.
-type LobbyHooks interface {
-	// PreSessionStart fires after session-start validation passes but before
-	// any state mutation, event emission, or cross-shard dispatch. May mutate
-	// lobby. Returning an error aborts session start; no state changes and no
-	// events are emitted.
-	//
-	// Runs on the lobby tick goroutine. Keep it fast; blocking I/O stalls the
-	// entire world.
-	//
-	// Use cases:
-	//   - Dynamic game-shard selection (set lobby.GameWorld.ShardID)
-	//   - Abort session start based on external state
-	//   - Session-start audit logging
-	PreSessionStart(lobby *component.LobbyComponent) error
-
-	// PostSessionEnd fires after session-end state transition.
-	// Fire-and-forget.
-	//
-	// Use cases:
-	//   - Release external locks or claims tied to the session
-	//   - Session-end metrics / audit logging
-	PostSessionEnd(lobby *component.LobbyComponent)
-}
-
-// NoopHooks is the default LobbyHooks implementation.
-// Embed it in a custom hooks type and override only the methods you need.
-type NoopHooks struct{}
-
-func (NoopHooks) PreSessionStart(*component.LobbyComponent) error { return nil }
-func (NoopHooks) PostSessionEnd(*component.LobbyComponent)        {}
 
 // DefaultProvider provides default implementations.
 type DefaultProvider struct{}
@@ -536,19 +544,6 @@ var storedProvider LobbyProvider = DefaultProvider{}
 func SetProvider(provider LobbyProvider) {
 	if provider != nil {
 		storedProvider = provider
-	}
-}
-
-// storedHooks holds the lobby hooks set by the Register function.
-//
-//nolint:gochecknoglobals // set once at initialization, read-only thereafter
-var storedHooks LobbyHooks = NoopHooks{}
-
-// SetHooks stores the hooks for the system to use.
-// Passing nil leaves the current hooks in place (default NoopHooks).
-func SetHooks(hooks LobbyHooks) {
-	if hooks != nil {
-		storedHooks = hooks
 	}
 }
 
@@ -612,6 +607,7 @@ type LobbySystemState struct {
 	TransferLeaderCmds           cardinal.WithCommand[TransferLeaderCommand]
 	StartSessionCmds             cardinal.WithCommand[StartSessionCommand]
 	NotifySessionEndCmds         cardinal.WithCommand[NotifySessionEndCommand]
+	AssignShardCmds              cardinal.WithCommand[AssignShardCommand]
 	GenerateInviteCodeCmds       cardinal.WithCommand[GenerateInviteCodeCommand]
 	UpdateSessionPassthroughCmds cardinal.WithCommand[UpdateSessionPassthroughCommand]
 	UpdatePlayerPassthroughCmds  cardinal.WithCommand[UpdatePlayerPassthroughCommand]
@@ -644,6 +640,7 @@ type LobbySystemState struct {
 	PlayerChangedTeamEvents         cardinal.WithEvent[PlayerChangedTeamEvent]
 	LeaderChangedEvents             cardinal.WithEvent[LeaderChangedEvent]
 	SessionStartedEvents            cardinal.WithEvent[SessionStartedEvent]
+	SessionAwaitingAllocationEvents cardinal.WithEvent[SessionAwaitingAllocationEvent]
 	SessionEndedEvents              cardinal.WithEvent[SessionEndedEvent]
 	InviteCodeGeneratedEvents       cardinal.WithEvent[InviteCodeGeneratedEvent]
 	LobbyDeletedEvents              cardinal.WithEvent[LobbyDeletedEvent]
@@ -740,7 +737,9 @@ func LobbySystem(state *LobbySystemState) {
 	processSetReadyCommands(state, &lobbyIndex)
 	processKickPlayerCommands(state, &lobbyIndex)
 	processTransferLeaderCommands(state, &lobbyIndex)
-	processStartSessionCommands(state, &lobbyIndex, &config)
+	processStartSessionCommands(state, &lobbyIndex)
+	processAssignShardCommands(state, &lobbyIndex, &config)
+	processAllocationTimeouts(state, &config)
 	processNotifySessionEndCommands(state, &lobbyIndex)
 	processGenerateInviteCodeCommands(state, &lobbyIndex)
 	processUpdateSessionPassthroughCommands(state, &lobbyIndex)
@@ -841,6 +840,10 @@ func createPlayerEntity(
 type lobbyToDestroy struct {
 	entityID cardinal.EntityID
 	lobbyID  string
+	// lobby is the last-read snapshot of the lobby component, used by the
+	// caller to emit a failure StartSessionResult if the lobby was in
+	// SessionStateAwaitingAllocation at destruction time.
+	lobby component.LobbyComponent
 }
 
 // processTimedOutLobby handles removing timed out players from a single lobby.
@@ -883,7 +886,11 @@ func processTimedOutLobby(
 		lobbyIndex.RemoveLobby(lobbyID, lobby.InviteCode)
 		state.Logger().Info().Str("lobby_id", lobbyID).Msg("Lobby marked for deletion (empty after timeout)")
 		state.LobbyDeletedEvents.Emit(LobbyDeletedEvent{LobbyID: lobbyID})
-		return playerEntities, &lobbyToDestroy{entityID: cardinal.EntityID(lobbyEntityID), lobbyID: lobbyID}
+		return playerEntities, &lobbyToDestroy{
+			entityID: cardinal.EntityID(lobbyEntityID),
+			lobbyID:  lobbyID,
+			lobby:    lobby,
+		}
 	}
 
 	// Handle leader timeout
@@ -1376,6 +1383,7 @@ func processLeaveLobbyCommands(state *LobbySystemState, lobbyIndex *component.Lo
 
 		// If lobby is empty, delete it - use index for O(1) check
 		if lobbyIndex.GetLobbyPlayerCount(lobbyID) == 0 {
+			failPendingAssignment(&state.StartSessionResults, &lobby, "lobby deleted before shard assignment")
 			lobbyIndex.RemoveLobby(lobbyID, lobby.InviteCode)
 			state.Lobbies.Destroy(result.entityID)
 
@@ -1649,7 +1657,6 @@ func processTransferLeaderCommands(state *LobbySystemState, lobbyIndex *componen
 func processStartSessionCommands(
 	state *LobbySystemState,
 	lobbyIndex *component.LobbyIndexComponent,
-	config *component.ConfigComponent,
 ) {
 	for cmd := range state.StartSessionCmds.Iter() {
 		playerID := cmd.Persona
@@ -1678,12 +1685,20 @@ func processStartSessionCommands(
 			continue
 		}
 
-		// Already in session
+		// Already in session or awaiting assignment
 		if lobby.Session.State == component.SessionStateInSession {
 			state.StartSessionResults.Emit(StartSessionResult{
 				RequestID: payload.RequestID,
 				IsSuccess: false,
 				Message:   "session already in progress",
+			})
+			continue
+		}
+		if lobby.Session.State == component.SessionStateAwaitingAllocation {
+			state.StartSessionResults.Emit(StartSessionResult{
+				RequestID: payload.RequestID,
+				IsSuccess: false,
+				Message:   "session already pending shard assignment",
 			})
 			continue
 		}
@@ -1699,72 +1714,118 @@ func processStartSessionCommands(
 			continue
 		}
 
-		// Let consumers react to session start. Hooks may mutate the lobby
-		// (e.g., set lobby.GameWorld.ShardID dynamically) or abort by
-		// returning an error. Must run before any state mutation or event
-		// emission so aborted starts leave no observable trace.
-		if err := storedHooks.PreSessionStart(&lobby); err != nil {
-			state.Logger().Warn().
-				Str("lobby_id", lobbyID).
-				Err(err).
-				Msg("PreSessionStart hook aborted session start")
-			state.StartSessionResults.Emit(StartSessionResult{
-				RequestID: payload.RequestID,
-				IsSuccess: false,
-				Message:   "session start aborted: " + err.Error(),
-			})
-			continue
-		}
-
-		// Commit session state (includes any hook mutations).
-		lobby.Session.State = component.SessionStateInSession
+		// Hand off to an external orchestrator via SessionAwaitingAllocationEvent. The
+		// lobby waits in SessionStateAwaitingAllocation until an AssignShardCommand
+		// arrives. Games that want immediate dispatch from a pre-configured
+		// GameWorld can wire a one-system orchestrator that observes
+		// SessionStateAwaitingAllocation lobbies and immediately sends AssignShardCommand
+		// with lobby.GameWorld.
+		lobby.Session.State = component.SessionStateAwaitingAllocation
+		lobby.Session.PendingRequestID = payload.RequestID
+		lobby.Session.PendingStartedAt = state.Timestamp().Unix()
 		result.lobbyRef.Set(lobby)
 
 		state.Logger().Info().
 			Str("lobby_id", lobbyID).
-			Msg("Session started")
+			Msg("Session pending shard assignment")
 
-		// Emit broadcast event
-		state.SessionStartedEvents.Emit(SessionStartedEvent{
+		state.SessionAwaitingAllocationEvents.Emit(SessionAwaitingAllocationEvent{
 			LobbyID: lobbyID,
-		})
-
-		dispatchSessionStart(state, config, &lobby, lobbyID)
-
-		state.StartSessionResults.Emit(StartSessionResult{
-			RequestID: payload.RequestID,
-			IsSuccess: true,
-			Message:   "session started",
 		})
 	}
 }
 
-// dispatchSessionStart sends NotifySessionStartCommand to the gameplay shard
-// configured on the lobby. No-op if no gameplay shard is configured.
+// processAllocationTimeouts fails any lobby that has been waiting in
+// SessionStateAwaitingAllocation for more than config.MaxAllocationTimeout
+// seconds. Disabled when MaxAllocationTimeout <= 0. Runs once per tick.
+func processAllocationTimeouts(
+	state *LobbySystemState,
+	config *component.ConfigComponent,
+) {
+	if config.MaxAllocationTimeout <= 0 {
+		return
+	}
+	now := state.Timestamp().Unix()
+
+	for _, refs := range state.Lobbies.Iter() {
+		lob := refs.Lobby.Get()
+		if lob.Session.State != component.SessionStateAwaitingAllocation {
+			continue
+		}
+		if now-lob.Session.PendingStartedAt < config.MaxAllocationTimeout {
+			continue
+		}
+
+		state.Logger().Warn().
+			Str("lobby_id", lob.ID).
+			Int64("waited_seconds", now-lob.Session.PendingStartedAt).
+			Int64("max_seconds", config.MaxAllocationTimeout).
+			Msg("allocation timeout: failing pending session-start")
+
+		abortAwaitingAllocation(&state.StartSessionResults, refs.Lobby, &lob, "shard assignment timed out")
+	}
+}
+
+// failPendingAssignment emits a failure StartSessionResult for a lobby that
+// is being destroyed or reset while in SessionStateAwaitingAllocation. Without this,
+// the client that issued the original StartSessionCommand would never
+// receive a response and would hang on its RequestID.
+func failPendingAssignment(
+	results *cardinal.WithEvent[StartSessionResult],
+	lobby *component.LobbyComponent,
+	reason string,
+) {
+	if lobby.Session.State != component.SessionStateAwaitingAllocation {
+		return
+	}
+	if lobby.Session.PendingRequestID == "" {
+		return
+	}
+	results.Emit(StartSessionResult{
+		RequestID: lobby.Session.PendingRequestID,
+		IsSuccess: false,
+		Message:   reason,
+	})
+}
+
+// abortAwaitingAllocation fails a lobby currently in
+// SessionStateAwaitingAllocation: emits a failure StartSessionResult,
+// clears all pending fields, transitions to SessionStateIdle, and
+// persists the mutation via ref. Safe to call on lobbies not in
+// SessionStateAwaitingAllocation — returns without effect. Centralizes
+// the exit protocol so no caller can forget a field.
+func abortAwaitingAllocation(
+	results *cardinal.WithEvent[StartSessionResult],
+	ref cardinal.Ref[component.LobbyComponent],
+	lobby *component.LobbyComponent,
+	reason string,
+) {
+	if lobby.Session.State != component.SessionStateAwaitingAllocation {
+		return
+	}
+	if lobby.Session.PendingRequestID != "" {
+		results.Emit(StartSessionResult{
+			RequestID: lobby.Session.PendingRequestID,
+			IsSuccess: false,
+			Message:   reason,
+		})
+	}
+	lobby.Session.State = component.SessionStateIdle
+	lobby.Session.PendingRequestID = ""
+	lobby.Session.PendingStartedAt = 0
+	ref.Set(*lobby)
+}
+
+// dispatchSessionStart sends NotifySessionStartCommand to the game shard
+// configured on the lobby. No-op if no game shard is configured.
 func dispatchSessionStart(
 	state *LobbySystemState,
 	config *component.ConfigComponent,
 	lobby *component.LobbyComponent,
 	lobbyID string,
 ) {
-	if lobby.GameWorld.ShardID == "" {
-		state.Logger().Debug().
-			Str("lobby_id", lobbyID).
-			Msg("no game shard configured; skipping NotifySessionStartCommand dispatch")
-		return
-	}
-	gameWorld := cardinal.OtherWorld{
-		Region:       lobby.GameWorld.Region,
-		Organization: lobby.GameWorld.Organization,
-		Project:      lobby.GameWorld.Project,
-		ShardID:      lobby.GameWorld.ShardID,
-	}
-	lobbyWorld := cardinal.OtherWorld{
-		Region:       config.LobbyWorld.Region,
-		Organization: config.LobbyWorld.Organization,
-		Project:      config.LobbyWorld.Project,
-		ShardID:      config.LobbyWorld.ShardID,
-	}
+	gameWorld := lobby.GameWorld
+	lobbyWorld := config.LobbyWorld
 	gameWorld.SendCommand(&state.BaseSystemState, NotifySessionStartCommand{
 		Lobby:      *lobby,
 		LobbyWorld: lobbyWorld,
@@ -1773,6 +1834,94 @@ func dispatchSessionStart(
 		Str("lobby_id", lobbyID).
 		Str("game_shard", lobby.GameWorld.ShardID).
 		Msg("[CROSS-SHARD] Sent NotifySessionStartCommand to game shard")
+}
+
+// processAssignShardCommands completes the session start for lobbies that
+// are waiting in SessionStateAwaitingAllocation. An empty GameWorld.ShardID is treated
+// as an assignment failure: the lobby returns to Idle and a failure
+// StartSessionResult is emitted carrying the original RequestID.
+func processAssignShardCommands(
+	state *LobbySystemState,
+	lobbyIndex *component.LobbyIndexComponent,
+	config *component.ConfigComponent,
+) {
+	for cmd := range state.AssignShardCmds.Iter() {
+		payload := cmd.Payload
+
+		lobbyEntityID, exists := lobbyIndex.GetEntityID(payload.LobbyID)
+		if !exists {
+			state.Logger().Warn().
+				Str("lobby_id", payload.LobbyID).
+				Msg("AssignShardCommand for unknown lobby; dropping")
+			continue
+		}
+		lobbyEntity, err := state.Lobbies.GetByID(cardinal.EntityID(lobbyEntityID))
+		if err != nil {
+			continue
+		}
+		lobby := lobbyEntity.Lobby.Get()
+
+		if lobby.Session.State != component.SessionStateAwaitingAllocation {
+			state.Logger().Warn().
+				Str("lobby_id", payload.LobbyID).
+				Str("state", string(lobby.Session.State)).
+				Msg("AssignShardCommand received for lobby not in pending state; dropping")
+			continue
+		}
+
+		if authority := config.AssignmentAuthority; authority != "" && cmd.Persona != authority {
+			state.Logger().Warn().
+				Str("lobby_id", payload.LobbyID).
+				Str("sender", cmd.Persona).
+				Str("expected", authority).
+				Msg("AssignShardCommand rejected: sender is not the configured AssignmentAuthority")
+			continue
+		}
+
+		if payload.RequestID != lobby.Session.PendingRequestID {
+			state.Logger().Warn().
+				Str("lobby_id", payload.LobbyID).
+				Str("command_request_id", payload.RequestID).
+				Str("pending_request_id", lobby.Session.PendingRequestID).
+				Msg("AssignShardCommand rejected: RequestID does not match current pending cycle")
+			continue
+		}
+
+		// Failure path: empty ShardID means the orchestrator could not assign.
+		if payload.GameWorld.ShardID == "" {
+			reason := payload.Reason
+			if reason == "" {
+				reason = "no game shard available"
+			}
+			abortAwaitingAllocation(&state.StartSessionResults, lobbyEntity.Lobby, &lobby, reason)
+			continue
+		}
+
+		requestID := lobby.Session.PendingRequestID
+		lobby.Session.PendingRequestID = ""
+		lobby.Session.PendingStartedAt = 0
+
+		lobby.GameWorld = payload.GameWorld
+		lobby.Session.State = component.SessionStateInSession
+		lobbyEntity.Lobby.Set(lobby)
+
+		state.Logger().Info().
+			Str("lobby_id", payload.LobbyID).
+			Str("game_shard", lobby.GameWorld.ShardID).
+			Msg("Session started (async assignment)")
+
+		state.SessionStartedEvents.Emit(SessionStartedEvent{
+			LobbyID: payload.LobbyID,
+		})
+
+		dispatchSessionStart(state, config, &lobby, payload.LobbyID)
+
+		state.StartSessionResults.Emit(StartSessionResult{
+			RequestID: requestID,
+			IsSuccess: true,
+			Message:   "session started",
+		})
+	}
 }
 
 func processNotifySessionEndCommands(state *LobbySystemState, lobbyIndex *component.LobbyIndexComponent) {
@@ -1791,8 +1940,27 @@ func processNotifySessionEndCommands(state *LobbySystemState, lobbyIndex *compon
 
 		lobby := lobbyEntity.Lobby.Get()
 
+		// If the lobby was awaiting allocation when NotifySessionEnd arrives,
+		// the session somehow ended before this shard ever assigned one.
+		// Fail the pending request so the client unblocks, transition to
+		// Idle, and continue. Without this, the lobby would stay stuck.
+		if lobby.Session.State == component.SessionStateAwaitingAllocation {
+			state.Logger().Warn().
+				Str("lobby_id", payload.LobbyID).
+				Msg("NotifySessionEndCommand arrived while lobby was awaiting allocation; failing pending request")
+			abortAwaitingAllocation(
+				&state.StartSessionResults, lobbyEntity.Lobby, &lobby,
+				"session ended before shard assignment completed",
+			)
+			continue
+		}
+
 		// Only end if in session
 		if lobby.Session.State != component.SessionStateInSession {
+			state.Logger().Warn().
+				Str("lobby_id", payload.LobbyID).
+				Str("state", string(lobby.Session.State)).
+				Msg("NotifySessionEndCommand dropped: lobby not in session")
 			continue
 		}
 
@@ -1821,9 +1989,6 @@ func processNotifySessionEndCommands(state *LobbySystemState, lobbyIndex *compon
 
 		// Emit broadcast event
 		state.SessionEndedEvents.Emit(SessionEndedEvent(payload))
-
-		// Let consumers react to session end (e.g., release external locks).
-		storedHooks.PostSessionEnd(&lobby)
 	}
 }
 
@@ -2136,6 +2301,7 @@ type HeartbeatSystemState struct {
 	PlayerTimedOutEvents cardinal.WithEvent[PlayerTimedOutEvent]
 	LeaderChangedEvents  cardinal.WithEvent[LeaderChangedEvent]
 	LobbyDeletedEvents   cardinal.WithEvent[LobbyDeletedEvent]
+	StartSessionResults  cardinal.WithEvent[StartSessionResult]
 }
 
 // HeartbeatSystem processes heartbeat commands and removes stale players.
@@ -2206,6 +2372,7 @@ func HeartbeatSystem(state *HeartbeatSystemState) {
 
 	// Destroy empty lobbies
 	for _, toDestroy := range lobbiesToDestroy {
+		failPendingAssignment(&state.StartSessionResults, &toDestroy.lobby, "lobby deleted (timeout) before shard assignment")
 		state.Lobbies.Destroy(toDestroy.entityID)
 		state.Logger().Info().
 			Str("lobby_id", toDestroy.lobbyID).

--- a/pkg/lobby/system/lobby.go
+++ b/pkg/lobby/system/lobby.go
@@ -471,6 +471,39 @@ type LobbyProvider interface {
 	GenerateInviteCode(lobby *component.LobbyComponent) string
 }
 
+// LobbyHooks lets consumers react to lobby lifecycle events.
+// Pass via Config.Hooks; nil falls back to NoopHooks.
+type LobbyHooks interface {
+	// PreSessionStart fires after session-start validation passes but before
+	// any state mutation, event emission, or cross-shard dispatch. May mutate
+	// lobby. Returning an error aborts session start; no state changes and no
+	// events are emitted.
+	//
+	// Runs on the lobby tick goroutine. Keep it fast; blocking I/O stalls the
+	// entire world.
+	//
+	// Use cases:
+	//   - Dynamic game-shard selection (set lobby.GameWorld.ShardID)
+	//   - Abort session start based on external state
+	//   - Session-start audit logging
+	PreSessionStart(lobby *component.LobbyComponent) error
+
+	// PostSessionEnd fires after session-end state transition.
+	// Fire-and-forget.
+	//
+	// Use cases:
+	//   - Release external locks or claims tied to the session
+	//   - Session-end metrics / audit logging
+	PostSessionEnd(lobby *component.LobbyComponent)
+}
+
+// NoopHooks is the default LobbyHooks implementation.
+// Embed it in a custom hooks type and override only the methods you need.
+type NoopHooks struct{}
+
+func (NoopHooks) PreSessionStart(*component.LobbyComponent) error { return nil }
+func (NoopHooks) PostSessionEnd(*component.LobbyComponent)        {}
+
 // DefaultProvider provides default implementations.
 type DefaultProvider struct{}
 
@@ -503,6 +536,19 @@ var storedProvider LobbyProvider = DefaultProvider{}
 func SetProvider(provider LobbyProvider) {
 	if provider != nil {
 		storedProvider = provider
+	}
+}
+
+// storedHooks holds the lobby hooks set by the Register function.
+//
+//nolint:gochecknoglobals // set once at initialization, read-only thereafter
+var storedHooks LobbyHooks = NoopHooks{}
+
+// SetHooks stores the hooks for the system to use.
+// Passing nil leaves the current hooks in place (default NoopHooks).
+func SetHooks(hooks LobbyHooks) {
+	if hooks != nil {
+		storedHooks = hooks
 	}
 }
 
@@ -1653,7 +1699,24 @@ func processStartSessionCommands(
 			continue
 		}
 
-		// Update session state
+		// Let consumers react to session start. Hooks may mutate the lobby
+		// (e.g., set lobby.GameWorld.ShardID dynamically) or abort by
+		// returning an error. Must run before any state mutation or event
+		// emission so aborted starts leave no observable trace.
+		if err := storedHooks.PreSessionStart(&lobby); err != nil {
+			state.Logger().Warn().
+				Str("lobby_id", lobbyID).
+				Err(err).
+				Msg("PreSessionStart hook aborted session start")
+			state.StartSessionResults.Emit(StartSessionResult{
+				RequestID: payload.RequestID,
+				IsSuccess: false,
+				Message:   "session start aborted: " + err.Error(),
+			})
+			continue
+		}
+
+		// Commit session state (includes any hook mutations).
 		lobby.Session.State = component.SessionStateInSession
 		result.lobbyRef.Set(lobby)
 
@@ -1666,29 +1729,7 @@ func processStartSessionCommands(
 			LobbyID: lobbyID,
 		})
 
-		// Send to game shard if GameWorld is configured on the lobby
-		if lobby.GameWorld.ShardID != "" {
-			gameWorld := cardinal.OtherWorld{
-				Region:       lobby.GameWorld.Region,
-				Organization: lobby.GameWorld.Organization,
-				Project:      lobby.GameWorld.Project,
-				ShardID:      lobby.GameWorld.ShardID,
-			}
-			lobbyWorld := cardinal.OtherWorld{
-				Region:       config.LobbyWorld.Region,
-				Organization: config.LobbyWorld.Organization,
-				Project:      config.LobbyWorld.Project,
-				ShardID:      config.LobbyWorld.ShardID,
-			}
-			gameWorld.SendCommand(&state.BaseSystemState, NotifySessionStartCommand{
-				Lobby:      lobby,
-				LobbyWorld: lobbyWorld,
-			})
-			state.Logger().Info().
-				Str("lobby_id", lobbyID).
-				Str("game_shard", lobby.GameWorld.ShardID).
-				Msg("[CROSS-SHARD] Sent NotifySessionStartCommand to game shard")
-		}
+		dispatchSessionStart(state, config, &lobby, lobbyID)
 
 		state.StartSessionResults.Emit(StartSessionResult{
 			RequestID: payload.RequestID,
@@ -1696,6 +1737,42 @@ func processStartSessionCommands(
 			Message:   "session started",
 		})
 	}
+}
+
+// dispatchSessionStart sends NotifySessionStartCommand to the gameplay shard
+// configured on the lobby. No-op if no gameplay shard is configured.
+func dispatchSessionStart(
+	state *LobbySystemState,
+	config *component.ConfigComponent,
+	lobby *component.LobbyComponent,
+	lobbyID string,
+) {
+	if lobby.GameWorld.ShardID == "" {
+		state.Logger().Debug().
+			Str("lobby_id", lobbyID).
+			Msg("no game shard configured; skipping NotifySessionStartCommand dispatch")
+		return
+	}
+	gameWorld := cardinal.OtherWorld{
+		Region:       lobby.GameWorld.Region,
+		Organization: lobby.GameWorld.Organization,
+		Project:      lobby.GameWorld.Project,
+		ShardID:      lobby.GameWorld.ShardID,
+	}
+	lobbyWorld := cardinal.OtherWorld{
+		Region:       config.LobbyWorld.Region,
+		Organization: config.LobbyWorld.Organization,
+		Project:      config.LobbyWorld.Project,
+		ShardID:      config.LobbyWorld.ShardID,
+	}
+	gameWorld.SendCommand(&state.BaseSystemState, NotifySessionStartCommand{
+		Lobby:      *lobby,
+		LobbyWorld: lobbyWorld,
+	})
+	state.Logger().Info().
+		Str("lobby_id", lobbyID).
+		Str("game_shard", lobby.GameWorld.ShardID).
+		Msg("[CROSS-SHARD] Sent NotifySessionStartCommand to game shard")
 }
 
 func processNotifySessionEndCommands(state *LobbySystemState, lobbyIndex *component.LobbyIndexComponent) {
@@ -1744,6 +1821,9 @@ func processNotifySessionEndCommands(state *LobbySystemState, lobbyIndex *compon
 
 		// Emit broadcast event
 		state.SessionEndedEvents.Emit(SessionEndedEvent(payload))
+
+		// Let consumers react to session end (e.g., release external locks).
+		storedHooks.PostSessionEnd(&lobby)
 	}
 }
 

--- a/pkg/lobby/system/lobby_internal_test.go
+++ b/pkg/lobby/system/lobby_internal_test.go
@@ -105,6 +105,31 @@ func TestCrossShardCommandNames(t *testing.T) {
 	// Verify cross-shard command names are correct
 	assert.Equal(t, "lobby_notify_session_start", NotifySessionStartCommand{}.Name())
 	assert.Equal(t, "lobby_notify_session_end", NotifySessionEndCommand{}.Name())
+	assert.Equal(t, "lobby_assign_shard", AssignShardCommand{}.Name())
+}
+
+func TestAssignShardCommand_Shape(t *testing.T) {
+	t.Parallel()
+
+	// Fields the handler reads — keep signatures stable so orchestrators
+	// can't break silently if a field is renamed.
+	cmd := AssignShardCommand{
+		LobbyID:   "lobby-1",
+		RequestID: "req-42",
+		GameWorld: cardinal.OtherWorld{ShardID: "game-shard-3"},
+	}
+	assert.Equal(t, "lobby-1", cmd.LobbyID)
+	assert.Equal(t, "req-42", cmd.RequestID)
+	assert.Equal(t, "game-shard-3", cmd.GameWorld.ShardID)
+	assert.Empty(t, cmd.Reason)
+
+	// Failure-path shape: empty GameWorld.ShardID + Reason triggers
+	// the handler's failure branch without hitting cross-shard dispatch.
+	fail := AssignShardCommand{
+		Reason: "pool full",
+	}
+	assert.Empty(t, fail.GameWorld.ShardID)
+	assert.Equal(t, "pool full", fail.Reason)
 }
 
 func TestEventNames(t *testing.T) {
@@ -120,6 +145,7 @@ func TestEventNames(t *testing.T) {
 	assert.Equal(t, "lobby_leader_changed", LeaderChangedEvent{}.Name())
 	assert.Equal(t, "lobby_session_started", SessionStartedEvent{}.Name())
 	assert.Equal(t, "lobby_session_ended", SessionEndedEvent{}.Name())
+	assert.Equal(t, "lobby_session_awaiting_allocation", SessionAwaitingAllocationEvent{}.Name())
 	assert.Equal(t, "lobby_invite_generated", InviteCodeGeneratedEvent{}.Name())
 	assert.Equal(t, "lobby_deleted", LobbyDeletedEvent{}.Name())
 	assert.Equal(t, "lobby_session_passthrough_updated", SessionPassthroughUpdatedEvent{}.Name())


### PR DESCRIPTION
### TL;DR

Added a hooks system to the lobby plugin that allows consumers to react to session lifecycle events with `PreSessionStart` and `PostSessionEnd` callbacks.

### What changed?

- Introduced `LobbyHooks` interface with two methods:
  - `PreSessionStart`: Called before session start state mutation, can abort the session by returning an error
  - `PostSessionEnd`: Called after session end state transition for cleanup tasks
- Added `NoopHooks` as the default implementation that can be embedded for partial overrides
- Extended `Config` struct to accept a `Hooks` field that defaults to `NoopHooks` if nil
- Integrated hook calls into the session start and end processing flows
- Refactored session start dispatch logic into a separate `dispatchSessionStart` function

### How to test?

1. Create a custom hooks implementation that embeds `NoopHooks` and overrides desired methods
2. Pass the custom hooks via `Config.Hooks` when initializing the lobby plugin
3. Start and end sessions to verify the hooks are called at the appropriate times
4. Test error handling by returning an error from `PreSessionStart` to ensure session start is aborted

### Why make this change?

This enables extensibility for lobby session management by allowing consumers to:
- Dynamically select game shards during session start
- Implement custom validation logic that can abort session starts
- Release external resources or locks when sessions end
- Add audit logging and metrics collection around session lifecycle events