### PR TITLE
feat: add data plugin for JSON config loading with snapshot reconciliation

### DIFF
--- a/pkg/plugin/data/component/manifest.go
+++ b/pkg/plugin/data/component/manifest.go
@@ -1,0 +1,23 @@
+// Package component holds the Cardinal components the data plugin owns.
+//
+// The plugin keeps loaded configuration in an in-memory catalog (not in components), so this
+// package is small: just the ConfigManifest singleton that records, per file, the content hash of
+// the config the world is running. The reconcile system in pkg/plugin/data/system uses it to keep
+// the catalog matched to whatever a snapshot restore brings back.
+package component
+
+// ConfigManifest is the only snapshot-resident component the data plugin owns. It records, per
+// config file, the content hash of the bytes loaded into the plugin's in-memory catalog.
+//
+// On a snapshot restore the reconcile system reads this back and uses it to re-fetch the exact
+// config the world was running before the restart, so a crash never silently changes the rules of
+// an in-flight game. The hashes themselves come from the source — a forge column in production,
+// sha256 of the embedded bytes in local dev.
+type ConfigManifest struct {
+	// Files maps each kind's JSONFile() path to the content hash the source reported when those
+	// bytes were last loaded into the catalog.
+	Files map[string]string
+}
+
+// Name implements cardinal.Component.
+func (ConfigManifest) Name() string { return "data_config_manifest" }

--- a/pkg/plugin/data/data_test.go
+++ b/pkg/plugin/data/data_test.go
@@ -1,0 +1,542 @@
+package data_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+	"unsafe"
+
+	"github.com/argus-labs/world-engine/pkg/cardinal"
+	"github.com/argus-labs/world-engine/pkg/cardinal/snapshot"
+	"github.com/argus-labs/world-engine/pkg/plugin/data"
+	"github.com/argus-labs/world-engine/pkg/plugin/data/component"
+	"github.com/stretchr/testify/require"
+)
+
+// -------------------------------------------------------------------------------------------------
+// Test fixtures
+// -------------------------------------------------------------------------------------------------
+
+//go:embed testdata/abilities.json testdata/resolver_side.json
+var testFS embed.FS
+
+// AbilityRecord matches a single record in testdata/abilities.json.
+type AbilityRecord struct {
+	ID       string  `json:"id"`
+	Cooldown float64 `json:"cooldown"`
+}
+
+// Abilities is the primary test Definition.
+type Abilities struct {
+	Items []AbilityRecord `json:"items"`
+}
+
+func (Abilities) Name() string     { return "test_abilities" }
+func (Abilities) JSONFile() string { return "testdata/abilities.json" }
+
+// -------------------------------------------------------------------------------------------------
+// Helpers
+// -------------------------------------------------------------------------------------------------
+
+func newWorld(t *testing.T) *cardinal.World {
+	t.Helper()
+	t.Setenv("LOG_LEVEL", "disabled")
+	debug := true
+	w, err := cardinal.NewWorld(cardinal.WorldOptions{
+		Region:              "local",
+		Organization:        "data-test",
+		Project:             "data-test",
+		ShardID:             "0",
+		TickRate:            60,
+		SnapshotStorageType: snapshot.StorageTypeNop,
+		SnapshotRate:        1_000_000,
+		Debug:               &debug,
+	})
+	require.NoError(t, err)
+	return w
+}
+
+// initCardinalECS runs Init-hook systems on Cardinal's embedded ecs.World. The shard loop
+// (cardinal.World.run) does this between RegisterPlugin and the first Tick, but unit tests can't
+// call run(). Cardinal's ecs world is unexported, so we reach in via reflection.
+//
+// Same pattern as physics2d/test/utils_test.go's initCardinalECS.
+func initCardinalECS(t *testing.T, w *cardinal.World) {
+	t.Helper()
+	v := reflect.ValueOf(w).Elem()
+	f := v.FieldByName("world")
+	require.True(t, f.IsValid(), "cardinal.World: missing embedded ecs world field")
+	inner := reflect.NewAt(f.Type(), unsafe.Pointer(f.UnsafeAddr())).Elem()
+	m := inner.MethodByName("Init")
+	require.True(t, m.IsValid(), "ecs.World: missing Init method")
+	m.Call(nil)
+}
+
+func tickOnce(t *testing.T, w *cardinal.World) {
+	t.Helper()
+	w.Tick(context.Background(), time.Unix(0, 0))
+}
+
+func sha256hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// manifestSearch is the Exact search shape used by the test harness systems below. Declaring it
+// in a system state struct registers component.ConfigManifest with Cardinal so the test's
+// pre-seed/observer systems can read and write the same singleton as the plugin's reconcile.
+type manifestSearch = cardinal.Exact[struct {
+	Item cardinal.Ref[component.ConfigManifest]
+}]
+
+type manifestObserverState struct {
+	cardinal.BaseSystemState
+	Manifest manifestSearch
+}
+
+type manifestPreseedState struct {
+	cardinal.BaseSystemState
+	Manifest manifestSearch
+}
+
+// -------------------------------------------------------------------------------------------------
+// Fake sources
+// -------------------------------------------------------------------------------------------------
+
+// versionedFake is a versioned source: it holds multiple content versions per file, addressed by
+// hash. Mimics OperatorSource — pin-by-hash works, missing-hash errors.
+type versionedFake struct {
+	current map[string]string // file → hash of the version this source currently serves
+	byHash  map[string][]byte // hash → bytes
+}
+
+func (f *versionedFake) Fetch(_ context.Context, file, hash string) ([]byte, string, error) {
+	if hash == "" {
+		h, ok := f.current[file]
+		if !ok {
+			return nil, "", errors.New("versionedFake: file not currently served: " + file)
+		}
+		hash = h
+	}
+	bytes, ok := f.byHash[hash]
+	if !ok {
+		return nil, "", errors.New("versionedFake: no blob for hash " + hash)
+	}
+	return bytes, hash, nil
+}
+
+// singleVersionFake mimics EmbedSource: only one version exists; the requested hash is ignored
+// and current bytes are returned. The caller (the plugin's reconcile) detects this by comparing
+// the returned hash to what it asked for.
+type singleVersionFake struct {
+	files map[string][]byte
+}
+
+func (f *singleVersionFake) Fetch(_ context.Context, file, _ string) ([]byte, string, error) {
+	bytes, ok := f.files[file]
+	if !ok {
+		return nil, "", errors.New("singleVersionFake: file not present: " + file)
+	}
+	return bytes, sha256hex(bytes), nil
+}
+
+// errFake always errors. Used to test the Register-time fetch failure path.
+type errFake struct{}
+
+func (errFake) Fetch(_ context.Context, _, _ string) ([]byte, string, error) {
+	return nil, "", errors.New("synthetic fetch failure")
+}
+
+// -------------------------------------------------------------------------------------------------
+// Tests — basic load
+// -------------------------------------------------------------------------------------------------
+
+// TestPlugin_LoadsRegisteredKind verifies Get[T] returns the loaded value immediately after
+// cardinal.RegisterPlugin — the catalog loads eagerly in Plugin.Register, no Init/Tick needed.
+func TestPlugin_LoadsRegisteredKind(t *testing.T) {
+	w := newWorld(t)
+
+	plugin := data.NewPlugin(data.Config{EmbeddedFS: testFS})
+	data.Register[Abilities](plugin)
+	cardinal.RegisterPlugin(w, plugin)
+
+	got := data.Get[Abilities]()
+	require.Equal(t, []AbilityRecord{
+		{ID: "fireball", Cooldown: 2.5},
+		{ID: "frostbolt", Cooldown: 3.0},
+	}, got.Items)
+}
+
+// -------------------------------------------------------------------------------------------------
+// Tests — manifest component lifecycle
+// -------------------------------------------------------------------------------------------------
+
+// TestPlugin_ManifestComponentOnFreshWorld verifies the reconcile system creates a ConfigManifest
+// singleton on the first tick of a fresh world, populated from the plugin's per-file manifest.
+func TestPlugin_ManifestComponentOnFreshWorld(t *testing.T) {
+	w := newWorld(t)
+
+	plugin := data.NewPlugin(data.Config{EmbeddedFS: testFS})
+	data.Register[Abilities](plugin)
+	cardinal.RegisterPlugin(w, plugin)
+
+	abilitiesBytes, err := testFS.ReadFile("testdata/abilities.json")
+	require.NoError(t, err)
+	expectedHash := sha256hex(abilitiesBytes)
+
+	var observed component.ConfigManifest
+	var observeErr error
+	cardinal.RegisterSystem(w, func(state *manifestObserverState) {
+		_, ent, err := state.Manifest.Iter().Single()
+		observeErr = err
+		if err == nil {
+			observed = ent.Item.Get()
+		}
+	}, cardinal.WithHook(cardinal.PostUpdate))
+
+	initCardinalECS(t, w)
+	tickOnce(t, w)
+
+	require.NoError(t, observeErr, "expected ConfigManifest singleton to exist after first tick")
+	require.Equal(t, map[string]string{"testdata/abilities.json": expectedHash}, observed.Files)
+}
+
+// TestPlugin_ReconcileReFetchesChangedFileAtSnapshotHash simulates a snapshot restore whose
+// manifest references an OLD hash. The plugin loaded the source's CURRENT version at Register;
+// the reconcile pass on the first tick must detect the mismatch and re-fetch the old version
+// from the source. Asserts the catalog ends up holding the old bytes and the ConfigManifest
+// component is left equal to the post-reconcile manifest.
+func TestPlugin_ReconcileReFetchesChangedFileAtSnapshotHash(t *testing.T) {
+	w := newWorld(t)
+
+	v1Bytes := []byte(`{"items":[{"id":"oldfire","cooldown":1.0}]}`)
+	v2Bytes := []byte(`{"items":[{"id":"newfire","cooldown":2.0}]}`)
+	h1 := sha256hex(v1Bytes)
+	h2 := sha256hex(v2Bytes)
+
+	src := &versionedFake{
+		current: map[string]string{"testdata/abilities.json": h2},
+		byHash:  map[string][]byte{h1: v1Bytes, h2: v2Bytes},
+	}
+
+	plugin := data.NewPlugin(data.Config{Source: src})
+	data.Register[Abilities](plugin)
+	cardinal.RegisterPlugin(w, plugin)
+
+	// Sanity: plugin loaded the current (v2) at Register.
+	require.Equal(t, []AbilityRecord{{ID: "newfire", Cooldown: 2.0}}, data.Get[Abilities]().Items)
+
+	// Pre-seed at Init: a ConfigManifest referencing the OLD hash, as if restored from a snapshot.
+	cardinal.RegisterSystem(w, func(state *manifestPreseedState) {
+		_, ent := state.Manifest.Create()
+		ent.Item.Set(component.ConfigManifest{Files: map[string]string{"testdata/abilities.json": h1}})
+	}, cardinal.WithHook(cardinal.Init))
+
+	var observed component.ConfigManifest
+	cardinal.RegisterSystem(w, func(state *manifestObserverState) {
+		_, ent, err := state.Manifest.Iter().Single()
+		if err == nil {
+			observed = ent.Item.Get()
+		}
+	}, cardinal.WithHook(cardinal.PostUpdate))
+
+	initCardinalECS(t, w)
+	tickOnce(t, w)
+
+	// Catalog reconciled to v1 content.
+	require.Equal(t, []AbilityRecord{{ID: "oldfire", Cooldown: 1.0}}, data.Get[Abilities]().Items)
+	// Component reflects the reconciled manifest (now equal to plugin.manifest).
+	require.Equal(t, map[string]string{"testdata/abilities.json": h1}, observed.Files)
+}
+
+// TestPlugin_EmbedMismatchWarnsAndKeepsCurrent simulates a rebuilt-binary case: a single-version
+// source's bytes differ from what the snapshot's manifest claims. Reconcile must keep the current
+// catalog and rewrite the ConfigManifest component to the plugin's current manifest so the next
+// snapshot is self-consistent and the warning doesn't re-fire on subsequent ticks.
+func TestPlugin_EmbedMismatchWarnsAndKeepsCurrent(t *testing.T) {
+	w := newWorld(t)
+
+	currentBytes := []byte(`{"items":[{"id":"current","cooldown":1.0}]}`)
+	currentHash := sha256hex(currentBytes)
+	src := &singleVersionFake{files: map[string][]byte{"testdata/abilities.json": currentBytes}}
+
+	plugin := data.NewPlugin(data.Config{Source: src})
+	data.Register[Abilities](plugin)
+	cardinal.RegisterPlugin(w, plugin)
+
+	// Pre-seed a manifest with a stale hash the source cannot serve (it'll return currentBytes
+	// regardless of requested hash → gotHash != requested → warn path).
+	const staleHash = "0000000000000000000000000000000000000000000000000000000000000000"
+	cardinal.RegisterSystem(w, func(state *manifestPreseedState) {
+		_, ent := state.Manifest.Create()
+		ent.Item.Set(component.ConfigManifest{Files: map[string]string{"testdata/abilities.json": staleHash}})
+	}, cardinal.WithHook(cardinal.Init))
+
+	var observed component.ConfigManifest
+	cardinal.RegisterSystem(w, func(state *manifestObserverState) {
+		_, ent, err := state.Manifest.Iter().Single()
+		if err == nil {
+			observed = ent.Item.Get()
+		}
+	}, cardinal.WithHook(cardinal.PostUpdate))
+
+	initCardinalECS(t, w)
+	tickOnce(t, w)
+
+	// Catalog unchanged (current bytes).
+	require.Equal(t, []AbilityRecord{{ID: "current", Cooldown: 1.0}}, data.Get[Abilities]().Items)
+	// Component rewritten to current hash.
+	require.Equal(t, map[string]string{"testdata/abilities.json": currentHash}, observed.Files)
+
+	// Second tick: steady state, component still matches plugin manifest.
+	tickOnce(t, w)
+	require.Equal(t, map[string]string{"testdata/abilities.json": currentHash}, observed.Files)
+}
+
+// TestPlugin_ReconcileFailurePanicsOnVersionedSource verifies the fail-loud path: when a versioned
+// source returns an error for a hash the snapshot says was running, the reconcile system panics.
+func TestPlugin_ReconcileFailurePanicsOnVersionedSource(t *testing.T) {
+	w := newWorld(t)
+
+	currentBytes := []byte(`{"items":[{"id":"current","cooldown":1.0}]}`)
+	hCurrent := sha256hex(currentBytes)
+	src := &versionedFake{
+		current: map[string]string{"testdata/abilities.json": hCurrent},
+		byHash:  map[string][]byte{hCurrent: currentBytes},
+	}
+
+	plugin := data.NewPlugin(data.Config{Source: src})
+	data.Register[Abilities](plugin)
+	cardinal.RegisterPlugin(w, plugin)
+
+	const missingHash = "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+	cardinal.RegisterSystem(w, func(state *manifestPreseedState) {
+		_, ent := state.Manifest.Create()
+		ent.Item.Set(component.ConfigManifest{Files: map[string]string{"testdata/abilities.json": missingHash}})
+	}, cardinal.WithHook(cardinal.Init))
+
+	initCardinalECS(t, w)
+	require.Panics(t, func() { tickOnce(t, w) })
+}
+
+// -------------------------------------------------------------------------------------------------
+// Tests — error paths
+// -------------------------------------------------------------------------------------------------
+
+// TestPlugin_FetchErrorPanicsAtRegister verifies the Register-time fetch path: a Source error on
+// the initial load surfaces as a panic from cardinal.RegisterPlugin, not as a deferred failure on
+// the first tick.
+func TestPlugin_FetchErrorPanicsAtRegister(t *testing.T) {
+	w := newWorld(t)
+	plugin := data.NewPlugin(data.Config{Source: errFake{}})
+	data.Register[Abilities](plugin)
+	require.Panics(t, func() { cardinal.RegisterPlugin(w, plugin) })
+}
+
+// TestPlugin_DuplicateNamePanics verifies Register[T] rejects two kinds sharing a Name().
+func TestPlugin_DuplicateNamePanics(t *testing.T) {
+	plugin := data.NewPlugin(data.Config{EmbeddedFS: testFS})
+	data.Register[Abilities](plugin)
+	require.Panics(t, func() { data.Register[abilitiesAlias](plugin) })
+}
+
+// abilitiesAlias collides with Abilities on Name() but uses a different JSONFile.
+type abilitiesAlias struct {
+	Items []AbilityRecord `json:"items"`
+}
+
+func (abilitiesAlias) Name() string     { return "test_abilities" }
+func (abilitiesAlias) JSONFile() string { return "testdata/other.json" }
+
+// TestPlugin_DuplicateJSONFilePanics verifies Register[T] rejects two kinds sharing a JSONFile().
+func TestPlugin_DuplicateJSONFilePanics(t *testing.T) {
+	plugin := data.NewPlugin(data.Config{EmbeddedFS: testFS})
+	data.Register[Abilities](plugin)
+	require.Panics(t, func() { data.Register[abilitiesFileTwin](plugin) })
+}
+
+// abilitiesFileTwin collides with Abilities on JSONFile() but uses a different Name.
+type abilitiesFileTwin struct {
+	Items []AbilityRecord `json:"items"`
+}
+
+func (abilitiesFileTwin) Name() string     { return "test_abilities_twin" }
+func (abilitiesFileTwin) JSONFile() string { return "testdata/abilities.json" }
+
+// -------------------------------------------------------------------------------------------------
+// Tests — custom UnmarshalJSON / Resolver / Validator hooks
+// -------------------------------------------------------------------------------------------------
+
+// TestPlugin_CustomUnmarshalKind verifies a kind with its own UnmarshalJSON is honored (covers
+// the path rampage's MapLevels uses).
+func TestPlugin_CustomUnmarshalKind(t *testing.T) {
+	bareArray := []byte(`["fireball","frostbolt"]`)
+	src := &versionedFake{
+		current: map[string]string{"custom.json": sha256hex(bareArray)},
+		byHash:  map[string][]byte{sha256hex(bareArray): bareArray},
+	}
+
+	w := newWorld(t)
+	plugin := data.NewPlugin(data.Config{Source: src})
+	data.Register[customUnmarshalKind](plugin)
+	cardinal.RegisterPlugin(w, plugin)
+
+	require.Equal(t, []string{"fireball", "frostbolt"}, data.Get[customUnmarshalKind]().IDs)
+}
+
+// customUnmarshalKind has a custom UnmarshalJSON that accepts a bare JSON array of strings.
+// Mixed receivers are intentional: UnmarshalJSON must be pointer (it mutates), while
+// Name/JSONFile are value-receiver to satisfy the generic Definition constraint without
+// forcing callers to write data.Register[*customUnmarshalKind].
+//
+//nolint:recvcheck // intentional pointer/value mix; see comment above.
+type customUnmarshalKind struct {
+	IDs []string
+}
+
+func (customUnmarshalKind) Name() string     { return "custom_unmarshal_kind" }
+func (customUnmarshalKind) JSONFile() string { return "custom.json" }
+
+func (c *customUnmarshalKind) UnmarshalJSON(b []byte) error {
+	var arr []string
+	if err := json.Unmarshal(b, &arr); err != nil {
+		return err
+	}
+	c.IDs = arr
+	return nil
+}
+
+// TestPlugin_ResolverUsesLocalNotPrimary verifies the documented Resolver policy: Resolver hooks
+// always fetch through the local embedded filesystem, never the configured primary Source. The
+// primary fake here errors on any file other than the kind's JSONFile() — a request for the
+// side file would crash the test, proving the Resolver hook never went through primary.
+func TestPlugin_ResolverUsesLocalNotPrimary(t *testing.T) {
+	primaryJSON := []byte(`{"include":"testdata/resolver_side.json"}`)
+	primarySrc := &mainOnlyFake{
+		mainFile:  "resolver_main.json",
+		mainBytes: primaryJSON,
+	}
+
+	w := newWorld(t)
+	plugin := data.NewPlugin(data.Config{Source: primarySrc, EmbeddedFS: testFS})
+	data.Register[resolverKind](plugin)
+	cardinal.RegisterPlugin(w, plugin)
+
+	got := data.Get[resolverKind]()
+	require.Equal(t, "testdata/resolver_side.json", got.Include)
+	require.Equal(t, "{\"extra\":\"hello\"}\n", got.Side)
+}
+
+// mainOnlyFake serves a single primary file and errors on anything else. Used to prove Resolver
+// fetches don't go through the primary Source.
+type mainOnlyFake struct {
+	mainFile  string
+	mainBytes []byte
+}
+
+func (f *mainOnlyFake) Fetch(_ context.Context, file, _ string) ([]byte, string, error) {
+	if file != f.mainFile {
+		return nil, "", errors.New("mainOnlyFake: primary should never be asked for: " + file)
+	}
+	return f.mainBytes, sha256hex(f.mainBytes), nil
+}
+
+// resolverKind exercises the Resolver hook by fetching a referenced second file in Resolve.
+// Mixed receivers are intentional: Resolve must be pointer (it mutates), Name/JSONFile are
+// value-receiver for the generic constraint.
+//
+//nolint:recvcheck // intentional pointer/value mix; see comment above.
+type resolverKind struct {
+	Include string `json:"include"`
+	Side    string `json:"-"`
+}
+
+func (resolverKind) Name() string     { return "resolver_kind" }
+func (resolverKind) JSONFile() string { return "resolver_main.json" }
+
+func (r *resolverKind) Resolve(ctx context.Context, src data.Source) error {
+	raw, _, err := src.Fetch(ctx, r.Include, "")
+	if err != nil {
+		return err
+	}
+	r.Side = string(raw)
+	return nil
+}
+
+// TestPlugin_ValidatorRunsOnSuccessfulLoad verifies a Definition implementing Validator is loaded
+// normally when Validate returns nil.
+func TestPlugin_ValidatorRunsOnSuccessfulLoad(t *testing.T) {
+	w := newWorld(t)
+
+	plugin := data.NewPlugin(data.Config{EmbeddedFS: testFS})
+	data.Register[validatedAbilities](plugin)
+	cardinal.RegisterPlugin(w, plugin)
+
+	require.Len(t, data.Get[validatedAbilities]().Items, 2)
+}
+
+// validatedAbilities accepts any non-empty Items slice. Used to verify Validate is invoked.
+type validatedAbilities struct {
+	Items []AbilityRecord `json:"items"`
+}
+
+func (validatedAbilities) Name() string     { return "test_validated_abilities" }
+func (validatedAbilities) JSONFile() string { return "testdata/abilities.json" }
+
+func (v validatedAbilities) Validate() error {
+	if len(v.Items) == 0 {
+		return errors.New("validated_abilities: empty items")
+	}
+	return nil
+}
+
+// TestPlugin_ValidateErrorPanicsAtRegister verifies a Validator returning an error surfaces as a
+// panic from cardinal.RegisterPlugin — same fail-loud discipline as a fetch or unmarshal error.
+func TestPlugin_ValidateErrorPanicsAtRegister(t *testing.T) {
+	w := newWorld(t)
+	plugin := data.NewPlugin(data.Config{EmbeddedFS: testFS})
+	data.Register[rejectingAbilities](plugin)
+	require.Panics(t, func() { cardinal.RegisterPlugin(w, plugin) })
+}
+
+// rejectingAbilities always fails Validate.
+type rejectingAbilities struct {
+	Items []AbilityRecord `json:"items"`
+}
+
+func (rejectingAbilities) Name() string     { return "test_rejecting_abilities" }
+func (rejectingAbilities) JSONFile() string { return "testdata/abilities.json" }
+
+func (rejectingAbilities) Validate() error { return errors.New("rejecting_abilities: rejected") }
+
+// TestPlugin_PointerReceiverValidatorRuns verifies a Validator implemented on a POINTER receiver
+// is still detected and run. MakeAssemble asserts the Validator interface against &def (the
+// pointer), not def (the value): a pointer-receiver Validate is not in the value's method set, so
+// a value assertion would silently skip it and let invalid config load. rejectingAbilities above
+// uses a value receiver and so cannot catch that regression — this kind does.
+func TestPlugin_PointerReceiverValidatorRuns(t *testing.T) {
+	w := newWorld(t)
+	plugin := data.NewPlugin(data.Config{EmbeddedFS: testFS})
+	data.Register[pointerRejectingKind](plugin)
+	require.Panics(t, func() { cardinal.RegisterPlugin(w, plugin) })
+}
+
+// pointerRejectingKind implements Validator on a pointer receiver and always rejects.
+//
+//nolint:recvcheck // intentional pointer/value receiver mix; pointer-receiver Validate is the point.
+type pointerRejectingKind struct {
+	Items []AbilityRecord `json:"items"`
+}
+
+func (pointerRejectingKind) Name() string     { return "test_pointer_rejecting_kind" }
+func (pointerRejectingKind) JSONFile() string { return "testdata/abilities.json" }
+
+func (k *pointerRejectingKind) Validate() error {
+	return errors.New("pointer_rejecting_kind: rejected")
+}

--- a/pkg/plugin/data/plugin.go
+++ b/pkg/plugin/data/plugin.go
@@ -1,0 +1,170 @@
+// Package data is a Cardinal plugin that loads JSON configuration into a process-local catalog at
+// world init.
+//
+// Each kind is a user-defined type implementing Definition (Name() + JSONFile()). The plugin
+// fetches each file via a Source, unmarshals the bytes into the kind, and stores the result in an
+// in-memory catalog keyed by Name(). Game systems read the data via:
+//
+//	mobs := data.Get[component.Mobs](plugin)
+//
+// Loaded data does not live on Cardinal components — only the catalog does. The single
+// snapshot-resident artifact is a ConfigManifest component recording, per file, the content hash
+// of what's currently loaded. On a snapshot restore the reconcile system reads the snapshot's
+// manifest and re-fetches each changed file at the snapshot's hash (from a versioned operator
+// source) so an in-flight game resumes on the config it was running. Where the source can't pin
+// history (the embed: a rebuilt binary served new bytes for an old hash) the system logs a warning
+// and keeps the current config; where it should be able to but can't (operator says "I don't have
+// that version") the system panics — fail loud, ops problem.
+//
+// Usage:
+//
+//	dataPlugin := data.NewPlugin(data.Config{
+//	    EmbeddedFS: myEmbeddedFS,
+//	})
+//	data.Register[component.Abilities](dataPlugin)
+//	data.Register[component.Mobs](dataPlugin)
+//	cardinal.RegisterPlugin(world, dataPlugin)
+//
+//	// Anywhere downstream:
+//	abilities := data.Get[component.Abilities](dataPlugin)
+//
+// All Register[T] calls must happen before cardinal.RegisterPlugin so the plugin can load every
+// kind into the catalog before the tick loop begins. Get[T] is valid immediately after
+// cardinal.RegisterPlugin returns.
+//
+// The plugin picks the underlying Source based on the runtime environment (embedded files for
+// local dev; operator/forge integration is a future addition that flips automatically when
+// OPERATOR_ADDR is set). Shards do not select a source themselves — they hand the plugin their
+// embedded data and the plugin handles the rest.
+package data
+
+import (
+	"context"
+	"embed"
+
+	"github.com/argus-labs/world-engine/pkg/cardinal"
+	"github.com/argus-labs/world-engine/pkg/plugin/data/component"
+	"github.com/argus-labs/world-engine/pkg/plugin/data/system"
+)
+
+// Re-export user-facing types so callers only need to import the plugin root.
+type (
+	// Definition is the contract a config kind must satisfy to be loaded by the plugin.
+	Definition = system.Definition
+
+	// Resolver is an optional Definition interface for loading additional files from the same
+	// Source after the primary JSON has been unmarshaled.
+	Resolver = system.Resolver
+
+	// Validator is an optional Definition interface for enforcing post-load invariants. A
+	// non-nil error panics.
+	Validator = system.Validator
+
+	// Source supplies the raw bytes for a named file along with its content hash (embed, local
+	// disk, operator, etc).
+	Source = system.Source
+
+	// EmbedSource serves files baked into the binary via go:embed.
+	EmbedSource = system.EmbedSource
+
+	// ConfigManifest is the snapshot-resident component recording, per file, the content hash of
+	// the config the world is running. Internal to the plugin under normal use; re-exported for
+	// tests and any tooling that needs to inspect it.
+	ConfigManifest = component.ConfigManifest
+)
+
+// Config holds plugin options.
+type Config struct {
+	// EmbeddedFS is the build-time embedded filesystem used as the data source in local dev and as
+	// a fallback once operator integration ships. Required unless Source is set.
+	EmbeddedFS embed.FS
+
+	// Source overrides automatic source selection. Tests and custom integrations set this;
+	// production callers leave it nil and let the plugin pick based on the environment.
+	Source Source
+}
+
+// Plugin implements cardinal.Plugin. The actual catalog, manifest, and reconcile logic live on
+// the embedded *system.State; this struct is the thin facade users see (matches the lobby /
+// physics2d convention).
+type Plugin struct {
+	config Config
+	state  *system.State
+}
+
+var _ cardinal.Plugin = (*Plugin)(nil)
+
+// NewPlugin builds a data plugin instance. Call Register[T] for each kind before passing the
+// plugin to cardinal.RegisterPlugin.
+//
+// If config.Source is nil (the production path), the plugin picks a Source from the current
+// environment via system.PickSource using config.EmbeddedFS as the embedded fallback.
+func NewPlugin(config Config) *Plugin {
+	if config.Source == nil {
+		config.Source = system.PickSource(config.EmbeddedFS)
+	}
+	return &Plugin{config: config, state: system.NewState()}
+}
+
+// Source returns the configured Source so games can write custom loaders for kinds that need
+// per-kind conditional logic (e.g. environment-gated content) and still go through the same
+// dev/prod data path.
+func (p *Plugin) Source() Source {
+	return p.config.Source
+}
+
+// Register adds T to the plugin's load list. Each registered kind is fetched, unmarshaled, and
+// (if applicable) run through Resolve and Validate at cardinal.RegisterPlugin time.
+//
+// Panics if another kind has already claimed the same Name() or JSONFile() — a wiring bug that
+// would otherwise silently collide.
+func Register[T Definition](p *Plugin) {
+	var zero T
+	p.state.AddKind(zero.Name(), zero.JSONFile(), system.MakeAssemble[T]())
+}
+
+// registered is the process-global plugin instance set by Plugin.Register(world). It lets
+// data.Get[T]() resolve config without callers threading a *Plugin handle through every system.
+// A shard is a single process running one Cardinal world, so one global is the right shape;
+// tests that need multi-plugin isolation can use Plugin.GetT (instance-scoped, below).
+//
+//nolint:gochecknoglobals // Process-global plugin handle for data.Get[T]() consumer ergonomics.
+var registered *Plugin
+
+// Get returns the loaded value for kind T from the registered plugin. Call this from any game
+// system after cardinal.RegisterPlugin(world, dataPlugin) has run:
+//
+//	mobs := data.Get[component.Mobs]()
+//
+// Panics if no plugin has been registered yet, or if T was never registered with that plugin —
+// both are wiring bugs and should be caught loudly the first time any system reads.
+func Get[T Definition]() T {
+	if registered == nil {
+		panic("data: no plugin registered — call cardinal.RegisterPlugin(world, dataPlugin) first")
+	}
+	var zero T
+	v, ok := registered.state.MustGet(zero.Name()).(T)
+	if !ok {
+		// MakeAssemble[T] stores the concrete T in the catalog keyed by T's Name(), so this
+		// branch is unreachable in practice — but the checked assertion satisfies errcheck and
+		// fails loud if a future change ever breaks the invariant.
+		panic("data: catalog entry for " + zero.Name() + " is not of type T (catalog key collided across kinds)")
+	}
+	return v
+}
+
+// Register implements cardinal.Plugin. Called synchronously by cardinal.RegisterPlugin, before
+// StartGame. Loads every registered kind into the catalog, stashes the plugin as the
+// process-global for data.Get[T](), and registers the per-tick reconcile system that keeps the
+// catalog matched to whatever ConfigManifest the snapshot restored.
+func (p *Plugin) Register(world *cardinal.World) {
+	// Resolver hooks always go through the local embed regardless of how the primary source is
+	// configured (operator, fake, etc.). Resolver-fetched files are heavy designer-bundled assets
+	// — tilemaps, prefab manifests — that ship with the binary and aren't operator-editable.
+	resolverSource := system.EmbedSource{FS: p.config.EmbeddedFS}
+	p.state.LoadAll(context.Background(), p.config.Source, resolverSource)
+	registered = p
+	cardinal.RegisterSystem(world, func(rs *system.ReconcileState) {
+		p.state.Reconcile(rs, p.config.Source, resolverSource)
+	}, cardinal.WithHook(cardinal.PreUpdate))
+}

--- a/pkg/plugin/data/system/definition.go
+++ b/pkg/plugin/data/system/definition.go
@@ -1,0 +1,58 @@
+package system
+
+import "context"
+
+// Definition is the contract a config kind must satisfy to be loaded by the data plugin.
+//
+// A Definition is whatever Go type the plugin unmarshals JSON into and stores in its in-memory
+// catalog. The Name() value is the catalog key (game systems read via data.Get[T](plugin), which
+// looks the value up under T's Name()). JSONFile() is the source-relative path the plugin hands
+// to Source.Fetch at boot.
+//
+//	type AbilityData struct{ ID string; Cooldown float64 }
+//	type Abilities struct{ Items []AbilityData }
+//
+//	func (Abilities) Name() string     { return "abilities" }
+//	func (Abilities) JSONFile() string { return "abilities.json" }
+//
+// Implement Name() and JSONFile() on value receivers — the plugin instantiates a zero T to read
+// them before any pointer is taken.
+type Definition interface {
+	// Name uniquely identifies this kind within the plugin's catalog (and, by convention,
+	// matches Cardinal's component-name conventions: letters, digits, underscores).
+	Name() string
+
+	// JSONFile is the source-relative path Source.Fetch is called with at world init.
+	JSONFile() string
+}
+
+// Resolver is an optional interface a Definition may implement to perform a second-stage load
+// after the primary JSON has been unmarshaled — typically to fetch additional designer-bundled
+// files the JSON references (e.g. Tiled .tmj tilemaps that map_levels.json points at).
+//
+// The Source handed to Resolve is ALWAYS the local embedded filesystem, never the operator. The
+// reasoning: Resolver-fetched files are heavy build-time assets that don't fit a "designer edits
+// a row in a web UI" workflow — they change when someone commits a new .tmj, which is a deploy
+// event, not a database write. They are also NOT version-pinned in the snapshot manifest; an
+// in-flight game resuming after a redeploy will see the current embedded files.
+//
+// Resolve is called after Unmarshal and before the value is written to the catalog, so the
+// receiver already has every field the JSON populated. Mutate the receiver in place. Returning
+// an error panics — same failure mode as a fetch or unmarshal error.
+//
+// Implement on a pointer receiver so mutations stick.
+type Resolver interface {
+	Resolve(ctx context.Context, source Source) error
+}
+
+// Validator is an optional interface a Definition may implement to enforce post-load structural
+// invariants — duplicate IDs, required fields, canonical enum values, cross-field rules, etc.
+// The plugin calls Validate after Unmarshal (and after Resolve, if implemented), so the value
+// seen by Validate is exactly what would be written to the catalog.
+//
+// Returning an error panics. This is the right home for checks that the old per-kind loader
+// systems used to enforce: fail loud at boot rather than letting a malformed JSON file produce a
+// quietly-broken runtime.
+type Validator interface {
+	Validate() error
+}

--- a/pkg/plugin/data/system/source.go
+++ b/pkg/plugin/data/system/source.go
@@ -1,0 +1,53 @@
+package system
+
+import (
+	"context"
+	"crypto/sha256"
+	"embed"
+	"encoding/hex"
+)
+
+// Source supplies the raw bytes for a named file along with the content hash the source attaches
+// to those bytes. Implementations are how the plugin stays dev/prod portable: tests use
+// EmbedSource, local dev runs against the embed FS, and a future OperatorSource pulls from the
+// operator/forge control plane.
+//
+// The hash argument selects which version to return:
+//   - ""        — the version the source currently serves.
+//   - non-empty — a specific historical content hash (used on crash-restart to resume the
+//     snapshot's exact config). A versioned source that no longer holds the requested hash
+//     returns an error.
+//
+// A single-version source (EmbedSource) ignores the requested hash and returns its current
+// bytes; the caller compares the returned gotHash to the requested hash to detect that case.
+type Source interface {
+	Fetch(ctx context.Context, file, hash string) (bytes []byte, gotHash string, err error)
+}
+
+// EmbedSource serves files baked into the binary via go:embed. It is single-version by design —
+// there is only one snapshot of the embedded files for the lifetime of a binary.
+type EmbedSource struct {
+	FS embed.FS
+}
+
+// Fetch reads file from the embedded filesystem and returns the bytes plus their sha256 hex digest.
+// The hash argument is ignored — EmbedSource only has one version. Callers compare the returned
+// hash to what they asked for to know whether they got the version they wanted.
+func (e EmbedSource) Fetch(_ context.Context, file, _ string) ([]byte, string, error) {
+	raw, err := e.FS.ReadFile(file)
+	if err != nil {
+		return nil, "", err
+	}
+	sum := sha256.Sum256(raw)
+	return raw, hex.EncodeToString(sum[:]), nil
+}
+
+// PickSource returns the Source the plugin should use given the current environment.
+//
+// Today there is only one path: EmbedSource backed by the shard's build-time embedded
+// filesystem. When operator/forge integration ships, this function gains an OPERATOR_ADDR
+// branch that returns an OperatorSource — every shard's main.go stays unchanged because
+// source selection happens here, not in the caller.
+func PickSource(fs embed.FS) Source {
+	return EmbedSource{FS: fs}
+}

--- a/pkg/plugin/data/system/state.go
+++ b/pkg/plugin/data/system/state.go
@@ -1,0 +1,223 @@
+package system
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"maps"
+	"slices"
+
+	"github.com/argus-labs/world-engine/pkg/cardinal"
+	"github.com/argus-labs/world-engine/pkg/plugin/data/component"
+	"github.com/goccy/go-json"
+	"github.com/rotisserie/eris"
+)
+
+// State owns the data plugin's per-instance load state: registered kinds, the in-memory catalog,
+// and the per-file manifest hashes currently reflected in that catalog.
+//
+// The plugin facade (data.Plugin) holds a pointer to a State and forwards every operation here.
+// Splitting it out keeps plugin.go a thin facade (matching the lobby / physics2d convention) and
+// keeps all the load-and-reconcile logic colocated with the components it operates on.
+type State struct {
+	loaders  map[string]kindLoader // jsonFile → loader
+	catalog  map[string]Definition // Name() → loaded value
+	manifest map[string]string     // jsonFile → hash currently reflected in catalog
+}
+
+// NewState builds an empty State. Call AddKind for each registered kind before LoadAll.
+func NewState() *State {
+	return &State{
+		loaders:  map[string]kindLoader{},
+		catalog:  map[string]Definition{},
+		manifest: map[string]string{},
+	}
+}
+
+// AssembleFunc materializes raw bytes into a fully-loaded Definition: json.Unmarshal → Resolve (if
+// implemented) → Validate (if implemented). Used both at initial load and at reconcile re-fetches
+// so a snapshot-pinned version goes through the same hooks as a fresh load.
+//
+// resolverSource is the Source the Resolver hook (if any) uses to fetch additional files. By
+// convention this is always the local embed (never the operator), because Resolver-fetched files
+// are heavy, designer-bundled, build-time assets that don't fit a "designer edits a row in a web
+// UI" workflow.
+type AssembleFunc func(ctx context.Context, resolverSource Source, raw []byte) (Definition, error)
+
+// kindLoader is one entry in State.loaders, keyed by jsonFile: enough to assemble bytes into a
+// loaded Definition and key the result by Name().
+type kindLoader struct {
+	name     string
+	assemble AssembleFunc
+}
+
+// MakeAssemble returns the standard assemble function for kind T: json.Unmarshal into a fresh T,
+// run Resolve on a pointer (so mutations stick), run Validate on the value. Errors from any step
+// propagate to the caller (LoadAll and Reconcile both panic on them).
+func MakeAssemble[T Definition]() AssembleFunc {
+	return func(ctx context.Context, resolverSource Source, raw []byte) (Definition, error) {
+		var def T
+		if err := json.Unmarshal(raw, &def); err != nil {
+			return nil, err
+		}
+		if r, ok := any(&def).(Resolver); ok {
+			if err := r.Resolve(ctx, resolverSource); err != nil {
+				return nil, err
+			}
+		}
+		if v, ok := any(&def).(Validator); ok {
+			if err := v.Validate(); err != nil {
+				return nil, err
+			}
+		}
+		return def, nil
+	}
+}
+
+// AddKind enrolls a kind into the catalog. Panics on duplicate Name or JSONFile — both are wiring
+// bugs that would otherwise silently collide.
+func (s *State) AddKind(name, jsonFile string, assemble AssembleFunc) {
+	if existing, ok := s.loaders[jsonFile]; ok {
+		panic(eris.Errorf("data: JSON file %q already registered (by kind %q)", jsonFile, existing.name))
+	}
+	for _, l := range s.loaders {
+		if l.name == name {
+			panic(eris.Errorf("data: kind name %q already registered", name))
+		}
+	}
+	s.loaders[jsonFile] = kindLoader{name: name, assemble: assemble}
+}
+
+// Get looks up a kind in the catalog by name. Returns (value, true) on hit; (nil, false) on miss.
+// The generic data.Get[T] wraps this and panics on miss with a typed message.
+func (s *State) Get(name string) (Definition, bool) {
+	v, ok := s.catalog[name]
+	return v, ok
+}
+
+// MustGet returns the loaded value for the kind keyed by name, panicking with a clear message if
+// it was never registered. Used as the implementation of data.Get[T].
+func (s *State) MustGet(name string) Definition {
+	v, ok := s.catalog[name]
+	if !ok {
+		panic(fmt.Sprintf("data: kind %q not registered with this plugin", name))
+	}
+	return v
+}
+
+// LoadAll fetches every registered kind's JSON via primary, assembles it (handing resolverSource
+// to any Resolver hook), and stores the result in the catalog. Records the per-file manifest
+// hashes the primary source reported. Panics on any error — startup-time loading failures should
+// be loud and immediate.
+//
+// primary is the data source for each kind's JSONFile() (embed in dev, operator in prod).
+// resolverSource is what Resolver hooks fetch additional files through — always the local embed,
+// never the operator (see AssembleFunc doc).
+//
+// Iterates jsonFile in sorted order so boot-time log output is reproducible across runs.
+func (s *State) LoadAll(ctx context.Context, primary, resolverSource Source) {
+	for _, file := range slices.Sorted(maps.Keys(s.loaders)) {
+		l := s.loaders[file]
+		raw, gotHash, err := primary.Fetch(ctx, file, "")
+		if err != nil {
+			panic(eris.Wrapf(err, "data: fetching %q", file))
+		}
+		def, err := l.assemble(ctx, resolverSource, raw)
+		if err != nil {
+			panic(eris.Wrapf(err, "data: loading %q", file))
+		}
+		s.catalog[l.name] = def
+		s.manifest[file] = gotHash
+	}
+}
+
+// ReconcileState is the system state for the data plugin's per-tick reconcile pass.
+//
+// The embedded Exact search holds the ConfigManifest singleton; declaring this field is also what
+// registers ConfigManifest with Cardinal via system-field reflection.
+type ReconcileState struct {
+	cardinal.BaseSystemState
+	Manifest cardinal.Exact[struct {
+		Item cardinal.Ref[component.ConfigManifest]
+	}]
+}
+
+// Reconcile is the data plugin's per-tick reconcile pass. Runs every PreUpdate (cardinal's
+// earliest tick hook), fast-paths the steady state, and on a post-restore mismatch attempts to
+// re-fetch each changed file at the snapshot's hash so the world keeps running on the config it
+// was running before the restart.
+//
+// Lifecycle coverage with this one system:
+//   - Fresh boot: ErrSingleNoResult → create ConfigManifest from s.manifest.
+//   - Restart, same config: manifests match → no-op (one search + one map compare).
+//   - Restart, restored snapshot whose config differs: re-fetch each changed file at the
+//     snapshot's hash. Source can deliver → swap catalog atomically. Source errors (versioned
+//     source lost a version) → panic. Source returns wrong-hash content (single-version source,
+//     i.e. embed → rebuilt binary) → log a warning, keep current config, rewrite the component to
+//     s.manifest so the next snapshot is self-consistent and the warning doesn't re-fire.
+//   - cardinal.Reset()+Init() debug reload: wipes entities but Plugin.Register is not re-run, so
+//     the catalog persists. Next tick's reconcile sees ErrSingleNoResult and re-creates the
+//     ConfigManifest from s.manifest.
+//   - Restore from a pre-feature snapshot (no ConfigManifest): ErrSingleNoResult → create.
+//
+// All-or-nothing: a versioned source delivers every needed historical file or it panics; a
+// single-version source bails to the warn path on the first hash that doesn't match. No
+// half-old/half-new catalog state.
+//
+// primary is the data source for each kind's JSONFile() re-fetch at the snapshot's hash.
+// resolverSource is what Resolver hooks fetch additional files through (always local embed).
+func (s *State) Reconcile(rs *ReconcileState, primary, resolverSource Source) {
+	_, ent, err := rs.Manifest.Iter().Single()
+	switch {
+	case errors.Is(err, cardinal.ErrSingleNoResult):
+		_, ent = rs.Manifest.Create()
+		ent.Item.Set(component.ConfigManifest{Files: maps.Clone(s.manifest)})
+		return
+	case errors.Is(err, cardinal.ErrSingleMultipleResult):
+		panic(eris.New("data: more than one config-manifest singleton"))
+	case err != nil:
+		panic(eris.Wrap(err, "data: querying config-manifest singleton"))
+	}
+
+	snap := ent.Item.Get().Files
+	if maps.Equal(snap, s.manifest) {
+		return
+	}
+
+	ctx := context.Background()
+	temp := map[string]Definition{}
+	for file, snapHash := range snap {
+		if cur, ok := s.manifest[file]; ok && cur == snapHash {
+			continue
+		}
+		loader, owned := s.loaders[file]
+		if !owned {
+			continue
+		}
+		raw, gotHash, fetchErr := primary.Fetch(ctx, file, snapHash)
+		if fetchErr != nil {
+			panic(eris.Wrapf(fetchErr, "data: source cannot serve %q at hash %s required by snapshot", file, snapHash))
+		}
+		if gotHash != snapHash {
+			rs.Logger().Warn().
+				Interface("snapshot", snap).
+				Interface("current", s.manifest).
+				Msg("data: config changed since snapshot; resuming on current config")
+			ent.Item.Set(component.ConfigManifest{Files: maps.Clone(s.manifest)})
+			return
+		}
+		def, assembleErr := loader.assemble(ctx, resolverSource, raw)
+		if assembleErr != nil {
+			panic(eris.Wrapf(assembleErr, "data: loading %q at hash %s", file, snapHash))
+		}
+		temp[loader.name] = def
+	}
+
+	maps.Copy(s.catalog, temp)
+	for file, snapHash := range snap {
+		if _, owned := s.loaders[file]; owned {
+			s.manifest[file] = snapHash
+		}
+	}
+	ent.Item.Set(component.ConfigManifest{Files: maps.Clone(s.manifest)})
+}

--- a/pkg/plugin/data/testdata/abilities.json
+++ b/pkg/plugin/data/testdata/abilities.json
@@ -1,0 +1,6 @@
+{
+  "items": [
+    { "id": "fireball", "cooldown": 2.5 },
+    { "id": "frostbolt", "cooldown": 3.0 }
+  ]
+}

--- a/pkg/plugin/data/testdata/resolver_side.json
+++ b/pkg/plugin/data/testdata/resolver_side.json
@@ -1,0 +1,1 @@
+{"extra":"hello"}


### PR DESCRIPTION
## TL;DR

Adds a `data` Cardinal plugin that loads JSON configuration into a process-local in-memory catalog at world init, with snapshot-aware reconciliation so a restarted world resumes on the exact config it was running before the crash.

## What changed?

A new `pkg/plugin/data` package, split into a thin facade plus two sub-packages (matching the `lobby` / `physics2d` convention):

**`Plugin`** — the Cardinal plugin facade. Callers do `data.Register`[`T`](plugin) for each config kind, then `cardinal.RegisterPlugin(world, plugin)`. The catalog loads eagerly during registration, so `data.Get[T]()` is valid from anywhere in the game immediately after — no plugin handle is threaded through systems; `Get` resolves against the registered plugin internally.

**`Definition`** **/** **`Resolver`** **/** **`Validator`** — the interfaces a config kind implements.

- `Definition` (required): `Name()` (catalog key) + `JSONFile()` (source-relative path).
- `Resolver` (optional): fetches additional files the kind's JSON references — e.g. Tiled `.tmj` tilemaps that `map_levels.json` points at. **Resolver fetches always go through the local embedded filesystem, never the operator**, because these are heavy designer-bundled build-time assets that don't fit a "edit a row in a web UI" workflow.
- `Validator` (optional): enforces post-load invariants (duplicate IDs, required fields); a non-nil error panics at boot.

**`Source`** **/** **`EmbedSource`** — the abstraction over where bytes come from. `Fetch(ctx, file, hash)` returns the bytes plus the content hash the source attaches to them. `EmbedSource` serves `go:embed` files and computes a sha256 of the bytes. `PickSource` selects the implementation by environment, with a hook point for a future `OperatorSource` when operator/forge integration ships.

**`State`** — owns the catalog, the per-file manifest (`jsonFile → content hash`), and the reconcile logic. `LoadAll` fetches and assembles every registered kind at startup. `Reconcile` runs every `PreUpdate` tick and covers the full lifecycle: fresh boot, steady-state restart (no-op fast path), snapshot-restored restart whose config differs — re-fetching each changed file at the snapshot's exact hash from a versioned source, or logging a warning and keeping current config when a single-version source (the embed) can't serve history — `cardinal.Reset()` debug reload, and restore from a pre-feature snapshot.

**`component.ConfigManifest`** — the only snapshot-resident artifact the plugin owns: a `map[string]string` of JSON file path → content hash for whatever config the world is currently running. The reconcile system reads it back after a snapshot restore to detect and correct drift. Static config itself no longer lives in snapshots at all.

## How to test?

```
go test ./pkg/plugin/data/...

```

All cases are in `pkg/plugin/data/data_test.go`, using an embedded `testdata/` fixture plus in-process fake `Source` implementations — no external dependencies. Coverage: eager load at `RegisterPlugin`; `ConfigManifest` creation on a fresh world; re-fetch of a historical version on snapshot restore; warn-and-keep-current when a single-version source can't serve the snapshot's hash; panic on versioned-source fetch failure; panic on `Register`\-time fetch error; duplicate `Name()`/`JSONFile()` registration panics; custom `UnmarshalJSON`; `Validator`; and a `Resolver` test that proves Resolver fetches go through the local embed and never touch the primary source.

## Why make this change?

Game shards previously loaded JSON config through ad-hoc per-kind loader systems, each writing onto its own Cardinal singleton component. This plugin centralizes that into one reusable abstraction that is:

- **Snapshot-lean** — static config (byte-identical across replicas, never mutated at runtime) no longer gets re-serialized into every snapshot. The only resident artifact is a few-KB hash manifest.
- **Snapshot-safe** — a crash and restart never silently changes the rules of an in-flight game. The `ConfigManifest` + reconcile system guarantee the catalog matches whatever version the snapshot was running, re-fetching historical versions by content hash when needed.
- **Dev/prod portable** — `Source` decouples the load path from the storage backend. Local dev uses the embedded FS; operator/forge integration flips automatically in `PickSource` with no change to any shard's `main.go`.
- **Fail-loud** — fetch errors, unmarshal errors, validation errors, and unresolvable snapshot hashes all panic immediately rather than producing a quietly-broken runtime.