### PR TITLE
fix(telemetry): bump semconv to v1.39 to match OTel SDK 1.40 schema URL

### DIFF
--- a/pkg/telemetry/setup.go
+++ b/pkg/telemetry/setup.go
@@ -17,7 +17,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	"go.opentelemetry.io/otel/sdk/resource"
 	"go.opentelemetry.io/otel/sdk/trace"
-	semconv "go.opentelemetry.io/otel/semconv/v1.37.0"
+	semconv "go.opentelemetry.io/otel/semconv/v1.39.0"
 	otelTrace "go.opentelemetry.io/otel/trace"
 	"go.opentelemetry.io/otel/trace/noop"
 )
@@ -82,7 +82,9 @@ func newResource(opts Options) (*resource.Resource, error) {
 		resource.NewWithAttributes(semconv.SchemaURL, attrs...))
 }
 
-// resolveServiceVersion picks the value for the service.version resource attribute. OTEL_SERVICE_VERSION wins; otherwise the binary's main-module version, then vcs.revision from build info. Empty result = attribute omitted.
+// resolveServiceVersion picks the value for the service.version resource attribute.
+// OTEL_SERVICE_VERSION wins; otherwise the binary's main-module version, then
+// vcs.revision from build info. Empty result = attribute omitted.
 func resolveServiceVersion() string {
 	if v := os.Getenv("OTEL_SERVICE_VERSION"); v != "" {
 		return v
@@ -91,7 +93,8 @@ func resolveServiceVersion() string {
 	if !ok {
 		return ""
 	}
-	// "(devel)" is what the Go toolchain emits for an untagged main module; treat it as no-version and fall through to vcs.revision.
+	// "(devel)" is what the Go toolchain emits for an untagged main module;
+	// treat it as no-version and fall through to vcs.revision.
 	if v := info.Main.Version; v != "" && v != "(devel)" {
 		return v
 	}


### PR DESCRIPTION
## Summary

Fixes a runtime panic introduced when PR #894's OTel SDK bump (v1.38 → v1.40) made `resource.Default()` use schema URL `v1.39.0` while `pkg/telemetry/setup.go` still imported `semconv/v1.37.0`. `resource.Merge` errors on conflicting schema URLs, so every cardinal shard panics on boot:

```
panic: failed to initialize telemetry: failed to setup telemetry:
  conflicting Schema URL: https://opentelemetry.io/schemas/1.39.0
                      and https://opentelemetry.io/schemas/1.37.0
```

Caught locally while testing the rampage-backend bump in [Argus-Labs/rampage-backend#612](https://github.com/Argus-Labs/rampage-backend/pull/612) — every gameplay shard panicked at startup with the trace above.

## Change

One-line import bump: `semconv/v1.37.0` → `semconv/v1.39.0`. v1.39 is what OTel SDK 1.40's `resource.Default()` reports as its schema URL, so the merge succeeds.

The semconv subpackage ships inside `go.opentelemetry.io/otel` itself (already at v1.40.0 in go.mod), so no dependency churn.

## Test plan

- [x] Built a rampage gameplay shard against this branch in the local _testing/ workspace — boots cleanly through telemetry init
- [x] Confirmed shard's OTel exporter still publishes spans to the operator's OTLP receiver after the bump
- [x] CI lint + tests