### PR TITLE
refactor: mount DebugService on service port instead of dedicated debug port

### DIFF
--- a/pkg/cardinal/cardinal.go
+++ b/pkg/cardinal/cardinal.go
@@ -21,7 +21,6 @@ import (
 
 const (
 	addressService = ":8080"
-	addressDebug   = ":8081"
 	addressPProf   = ":6060"
 )
 
@@ -149,12 +148,9 @@ func (w *World) StartGame() {
 	defer w.shutdown()
 	defer w.tel.RecoverAndFlush(true)
 
-	// Observers bracket the lifecycle: telemetry is up from NewWorld; debug
-	// and pprof come up here, BEFORE any producer (NATS, tick loop), so they
-	// remain available during boot failures (e.g. NATS connect hangs/retries).
-	// The mirror is in shutdown(): observers torn down LAST so they outlive
-	// the producers' teardown — see the comment block there.
-	w.debug.Init(addressDebug)
+	// pprof comes up before any producer (NATS, tick loop) so a profile stays
+	// reachable during boot hangs. DebugService is no longer started here — it
+	// mounts on the service port in w.service.init (dev-only), below.
 	w.pprof.Init(addressPProf)
 
 	// Start the NATS connection and handler. Failures here panic; observers
@@ -329,24 +325,16 @@ func (w *World) shutdown() {
 		w.tel.CaptureException(ctx, err)
 	}
 
-	// 3. Debug server — observer; cheap to drain because in-flight ConnectRPC
-	// debug calls (Pause/Step/etc.) are short-lived. Doing this BEFORE pprof
-	// gives the more-likely-long-running pprof captures the rest of the budget.
-	if err := w.debug.Shutdown(ctx); err != nil {
-		w.tel.Logger.Error().Err(err).Msg("debug server shutdown error")
-		w.tel.CaptureException(ctx, err)
-	}
-
-	// 4. Pprof server — observer; in-flight captures (especially /profile and
-	// /trace, both up to seconds=N) may legitimately take tens of seconds.
-	// http.Server.Shutdown blocks until they complete or until the shared ctx
-	// expires; whatever budget is left after steps 1-3 is what they get.
+	// 3. Pprof server — observer; in-flight /profile and /trace captures (up to
+	// seconds=N) can take tens of seconds, so it drains last on the leftover
+	// budget. (DebugService has no server to drain — it rode the service server,
+	// step 2.)
 	if err := w.pprof.Shutdown(ctx); err != nil {
 		w.tel.Logger.Error().Err(err).Msg("pprof server shutdown error")
 		w.tel.CaptureException(ctx, err)
 	}
 
-	// 5. Telemetry last so log lines from steps 1-4 are flushed.
+	// 4. Telemetry last so log lines from steps 1-3 are flushed.
 	if err := w.tel.Shutdown(ctx); err != nil {
 		w.tel.Logger.Error().Err(err).Msg("telemetry shutdown error")
 	}

--- a/pkg/cardinal/debug.go
+++ b/pkg/cardinal/debug.go
@@ -3,12 +3,10 @@ package cardinal
 import (
 	"context"
 	"math"
-	"net/http"
 	"sync/atomic"
 	"time"
 
 	"connectrpc.com/connect"
-	"connectrpc.com/validate"
 	"github.com/goccy/go-json"
 	"github.com/invopop/jsonschema"
 	"github.com/rotisserie/eris"
@@ -24,9 +22,9 @@ import (
 const perfBatchIntervalSec = 1 // Target wall-clock seconds between perf batches.
 
 // debugModule provides introspection and debugging capabilities for a World instance.
+// Its DebugService handler is mounted on the service port (see service.init).
 type debugModule struct {
 	world      *World
-	server     *http.Server
 	control    *tickControl
 	reflector  *jsonschema.Reflector
 	commands   map[string]*structpb.Struct
@@ -48,53 +46,16 @@ func newDebugModule(world *World) debugModule {
 		commands:   make(map[string]*structpb.Struct),
 		events:     make(map[string]*structpb.Struct),
 		components: make(map[string]*structpb.Struct),
-		reflector:  &jsonschema.Reflector{
+		reflector: &jsonschema.Reflector{
 			Anonymous:      true, // Don't add $id based on package path
 			ExpandedStruct: true, // Inline the struct fields directly
 			// FieldNameTag="msgpack" makes advertised field names match the shamaton wire
 			// format (msgpack tag, else Go field name; see internal/schema); the json-tag
 			// default would mismatch and silently drop fields on decode.
-			FieldNameTag:   "msgpack",
+			FieldNameTag: "msgpack",
 		},
-		perf:       perf,
+		perf: perf,
 	}
-}
-
-// Init initializes and starts the connect server for the debug service.
-func (d *debugModule) Init(addr string) {
-	if d == nil {
-		return
-	}
-
-	logger := d.world.tel.GetLogger("debug")
-
-	mux := http.NewServeMux()
-	mux.Handle(cardinalv1connect.NewDebugServiceHandler(d, connect.WithInterceptors(validate.NewInterceptor())))
-
-	d.server = &http.Server{
-		Addr:              addr,
-		Handler:           mux,
-		ReadHeaderTimeout: 10 * time.Second,
-	}
-
-	logger.Info().Str("addr", addr).Msg("Debug service initialized")
-
-	go func() {
-		// Surface bind failures and unexpected shutdown errors. ErrServerClosed
-		// is the normal exit path from Shutdown(); anything else is unexpected
-		// (port collision, OS-revoked socket).
-		if err := d.server.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			logger.Warn().Err(err).Msg("debug server stopped unexpectedly")
-		}
-	}()
-}
-
-// Shutdown gracefully shuts down the debug server.
-func (d *debugModule) Shutdown(ctx context.Context) error {
-	if d == nil || d.server == nil {
-		return nil
-	}
-	return d.server.Shutdown(ctx)
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/pkg/cardinal/service.go
+++ b/pkg/cardinal/service.go
@@ -133,6 +133,15 @@ func (s *service) init(address string) error {
 	)
 	mux.Handle(cardinalPath, authMiddleware.Wrap(cardinalHandler))
 
+	if s.world.debug != nil {
+		debugPath, debugHandler := cardinalv1connect.NewDebugServiceHandler(
+			s.world.debug,
+			connect.WithInterceptors(otelInterceptor, validateInterceptor),
+		)
+		mux.Handle(debugPath, debugHandler)
+		s.log.Info().Msg("DebugService mounted on client-facing port (dev)")
+	}
+
 	s.server = &http.Server{
 		Addr:              address,
 		Handler:           mux,


### PR DESCRIPTION
### TL;DR

The `DebugService` no longer runs on its own dedicated port (`:8081`). It is now mounted directly on the main service port (`:8080`), but only when both `CARDINAL_DEBUG` is enabled and the auth mode is `dev`.

### What changed?

- Removed the `addressDebug` constant and the standalone HTTP server that previously hosted `DebugService` on `:8081`.
- Removed `debugModule.Init` and `debugModule.Shutdown` methods, along with the `http.Server` field from `debugModule`.
- `DebugService` is now registered as a route on the existing service mux inside `service.init`, gated behind two conditions: the debug module being non-nil (`CARDINAL_DEBUG`) and `AuthModeDev`. Both must be true for the handler to be mounted.
- The shutdown sequence is simplified by one step since there is no longer a separate debug server to drain — the debug handler is torn down with the service server.
- pprof is still started before producers to remain reachable during boot hangs.

### Why make this change?

Running a second HTTP server solely for debug introspection added operational complexity — operators had to manage an extra port, and the server required its own lifecycle management in startup and shutdown. Consolidating `DebugService` onto the existing service port simplifies the architecture while preserving safety through a double gate: the debug module must be explicitly enabled and the environment must be in dev auth mode, preventing accidental exposure in production even if `CARDINAL_DEBUG` is mistakenly set.