### PR TITLE
refactor: publish immutable state view each tick so GetState is race-free and always current

### DIFF
--- a/pkg/cardinal/cardinal.go
+++ b/pkg/cardinal/cardinal.go
@@ -123,8 +123,7 @@ func NewWorld(opts WorldOptions) (*World, error) {
 
 	// Create the debug module only if debug is on.
 	if *options.Debug {
-		debug := newDebugModule(world)
-		world.debug = &debug
+		world.debug = newDebugModule(world)
 	}
 
 	// Create the pprof module only if pprof is on.
@@ -176,6 +175,9 @@ func (w *World) run(ctx context.Context) error {
 	if err := w.restore(ctx); err != nil {
 		return eris.Wrap(err, "failed to restore state from snapshot")
 	}
+
+	// Publish an initial view so GetState works before the first tick. Nil-safe: no-op when debug is off.
+	w.debug.captureState(w.currentTick.height, w.currentTick.timestamp)
 
 	logger := w.tel.GetLogger("shard")
 	logger.Info().Msg("starting core shard loop")
@@ -229,27 +231,41 @@ func (w *World) Tick(ctx context.Context, timestamp time.Time) {
 		w.tel.Logger.Warn().Err(err).Msg("errors encountered dispatching events")
 	}
 
-	// Publish snapshot.
-	if w.currentTick.height%uint64(w.options.SnapshotRate) == 0 {
-		snapshotCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
-		w.snapshot(snapshotCtx, timestamp)
-		cancel()
-	}
+	// Publish state to snapshot and debug module.
+	w.persistState(ctx, timestamp)
 
 	// Increment tick height.
 	w.currentTick.height++
 }
 
-// snapshot persists the world state as a best-effort operation. Snapshots are best effort only, and
-// we just log errors instead of returning it, which would cause the world to stop and restart,
-// effectively losing unsaved state. If a snapshot fails, the main loop still continues and we retry
-// in the next snapshot call.
-func (w *World) snapshot(ctx context.Context, timestamp time.Time) {
-	worldState, err := w.world.ToProto()
-	if err != nil {
-		w.tel.Logger.Warn().Err(err).Msg("failed to serialize world for snapshot")
+// persistState serializes world state and does best effort to publish snapshot and debug state view.
+// We just log errors instead of returning it, which would cause the world to stop and restart,
+// effectively losing unsaved state. If a state serialization fails, the main loop still
+// continues and we retry in the next persistState call.
+func (w *World) persistState(ctx context.Context, timestamp time.Time) {
+	snapshotDue := w.currentTick.height%uint64(w.options.SnapshotRate) == 0
+	if !snapshotDue && w.debug == nil {
 		return
 	}
+
+	worldState, err := w.world.ToProto()
+	if err != nil {
+		w.tel.Logger.Warn().Err(err).Msg("failed to serialize world state")
+		return
+	}
+
+	w.debug.publishState(worldState, w.currentTick.height, timestamp)
+	if snapshotDue {
+		w.snapshot(ctx, timestamp, worldState)
+	}
+}
+
+// snapshot writes an already-serialized world state to storage, best-effort: errors are logged, not
+// returned, so a failed write doesn't stop the world and lose unsaved state — the next snapshot retries.
+func (w *World) snapshot(ctx context.Context, timestamp time.Time, worldState *cardinalv1.WorldState) {
+	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
+	defer cancel()
+
 	data, err := proto.MarshalOptions{Deterministic: true}.Marshal(worldState)
 	if err != nil {
 		w.tel.Logger.Warn().Err(err).Msg("failed to marshal world state to bytes")
@@ -313,10 +329,12 @@ func (w *World) shutdown() {
 	// instead of being severed on the first cleanup step. Telemetry goes last
 	// so it can flush log lines emitted by every preceding step.
 
-	// 1. Final snapshot. Producer-side, fixed 2s sub-budget.
-	snapshotCtx, snapshotCancel := context.WithTimeout(ctx, 2*time.Second)
-	w.snapshot(snapshotCtx, time.Now())
-	snapshotCancel()
+	// 1. Final snapshot. Producer-side; serialize world state for snapshot.
+	if worldState, err := w.world.ToProto(); err != nil {
+		w.tel.Logger.Warn().Err(err).Msg("failed to serialize world for final snapshot")
+	} else {
+		w.snapshot(ctx, time.Now(), worldState)
+	}
 
 	// 2. Shard service (NATS) — drain queued commands/events. Typically quick,
 	// but the producer side should stop before observers do.
@@ -355,8 +373,9 @@ func (w *World) reset() {
 	w.currentTick.height = 0
 	w.currentTick.timestamp = time.Time{}
 
-	// Reset perf collector.
+	// Reset perf collector and refresh the state view.
 	w.debug.resetPerf()
+	w.debug.captureState(w.currentTick.height, w.currentTick.timestamp)
 }
 
 type Tick struct {

--- a/pkg/cardinal/cardinal.go
+++ b/pkg/cardinal/cardinal.go
@@ -3,6 +3,7 @@ package cardinal
 import (
 	"context"
 	"os/signal"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -17,6 +18,7 @@ import (
 	cardinalv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1"
 	"github.com/rotisserie/eris"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 const (
@@ -26,17 +28,18 @@ const (
 
 // World represents your game world and serves as the main entry point for Cardinal.
 type World struct {
-	world           *ecs.World            // The ECS world storing the game's state and systems
-	commands        command.Manager       // Receives commands for systems
-	events          event.Manager         // Collects and dispatches events
-	address         *micro.ServiceAddress // This world's NATS address
-	service         *service              // ConnectRPC direct client-facing service
-	snapshotStorage snapshot.Storage      // Snapshot storage
-	debug           *debugModule          // For debug only utils and services
-	pprof           *pprofModule          // Optional pprof HTTP server
-	currentTick     Tick                  // The current tick
-	options         WorldOptions          // Options
-	tel             telemetry.Telemetry   // Telemetry for logging and tracing
+	world           *ecs.World                          // The ECS world storing the game's state and systems
+	commands        command.Manager                     // Receives commands for systems
+	events          event.Manager                       // Collects and dispatches events
+	address         *micro.ServiceAddress               // This world's NATS address
+	service         *service                            // ConnectRPC direct client-facing service
+	snapshotStorage snapshot.Storage                    // Snapshot storage
+	state           atomic.Pointer[cardinalv1.Snapshot] // Latest world state; swap only, never mutate
+	debug           *debugModule                        // For debug only utils and services
+	pprof           *pprofModule                        // Optional pprof HTTP server
+	currentTick     Tick                                // The current tick
+	options         WorldOptions                        // Options
+	tel             telemetry.Telemetry                 // Telemetry for logging and tracing
 }
 
 // NewWorld creates a new game world with the specified configuration.
@@ -79,6 +82,9 @@ func NewWorld(opts WorldOptions) (*World, error) {
 		options:     options,
 		tel:         tel,
 	}
+
+	// Seed a valid empty state so GetState is always servable, even before the first tick.
+	world.state.Store(&cardinalv1.Snapshot{WorldState: &cardinalv1.WorldState{}})
 
 	// Set ECS on componet register callback (used for introspect).
 	world.world.OnComponentRegister(func(zero ecs.Component) error {
@@ -176,9 +182,6 @@ func (w *World) run(ctx context.Context) error {
 		return eris.Wrap(err, "failed to restore state from snapshot")
 	}
 
-	// Publish an initial view so GetState works before the first tick. Nil-safe: no-op when debug is off.
-	w.debug.captureState(w.currentTick.height, w.currentTick.timestamp)
-
 	logger := w.tel.GetLogger("shard")
 	logger.Info().Msg("starting core shard loop")
 
@@ -238,10 +241,10 @@ func (w *World) Tick(ctx context.Context, timestamp time.Time) {
 	w.currentTick.height++
 }
 
-// persistState serializes world state and does best effort to publish snapshot and debug state view.
-// We just log errors instead of returning it, which would cause the world to stop and restart,
-// effectively losing unsaved state. If a state serialization fails, the main loop still
-// continues and we retry in the next persistState call.
+// persistState serializes world state once and publishes it to w.state.
+// Best effort: we just log errors instead of returning them, which would cause the
+// world to stop and restart, effectively losing unsaved state. If a state serialization
+// fails, the main loop still continues and we retry in the next persistState call.
 func (w *World) persistState(ctx context.Context, timestamp time.Time) {
 	snapshotDue := w.currentTick.height%uint64(w.options.SnapshotRate) == 0
 	if !snapshotDue && w.debug == nil {
@@ -250,11 +253,15 @@ func (w *World) persistState(ctx context.Context, timestamp time.Time) {
 
 	worldState, err := w.world.ToProto()
 	if err != nil {
-		w.tel.Logger.Warn().Err(err).Msg("failed to serialize world state")
+		w.tel.Logger.Warn().Err(err).Msg("failed to serialize the world's state")
 		return
 	}
+	w.state.Store(&cardinalv1.Snapshot{
+		TickHeight: w.currentTick.height,
+		Timestamp:  timestamppb.New(timestamp),
+		WorldState: worldState,
+	})
 
-	w.debug.publishState(worldState, w.currentTick.height, timestamp)
 	if snapshotDue {
 		w.snapshot(ctx, timestamp, worldState)
 	}
@@ -308,8 +315,13 @@ func (w *World) restore(ctx context.Context) error {
 
 	// Only update shard state after successful restoration and validation.
 	w.currentTick.height = snap.TickHeight + 1
-	w.debug.resetPerf()
 
+	// Publish the unmarshaled proto as-is; it already is the restored state.
+	w.state.Store(&cardinalv1.Snapshot{
+		TickHeight: snap.TickHeight,
+		Timestamp:  timestamppb.New(snap.Timestamp),
+		WorldState: &worldState,
+	})
 	return nil
 }
 
@@ -373,9 +385,17 @@ func (w *World) reset() {
 	w.currentTick.height = 0
 	w.currentTick.timestamp = time.Time{}
 
-	// Reset perf collector and refresh the state view.
+	// Republish state so it doesn't describe the pre-reset world, and clear perf data.
+	if worldState, err := w.world.ToProto(); err != nil {
+		w.tel.Logger.Warn().Err(err).Msg("failed to serialize the world's state")
+	} else {
+		w.state.Store(&cardinalv1.Snapshot{
+			TickHeight: w.currentTick.height,
+			Timestamp:  timestamppb.New(w.currentTick.timestamp),
+			WorldState: worldState,
+		})
+	}
 	w.debug.resetPerf()
-	w.debug.captureState(w.currentTick.height, w.currentTick.timestamp)
 }
 
 type Tick struct {

--- a/pkg/cardinal/debug.go
+++ b/pkg/cardinal/debug.go
@@ -3,7 +3,6 @@ package cardinal
 import (
 	"context"
 	"math"
-	"slices"
 	"sync/atomic"
 	"time"
 
@@ -32,17 +31,6 @@ type debugModule struct {
 	events     map[string]*structpb.Struct
 	components map[string]*structpb.Struct
 	perf       *performance.Collector
-	// view is the latest world state snapshot, published by the tick goroutine.
-	// Handlers only Load it, so the single writer needs no further synchronization.
-	view atomic.Pointer[stateView]
-}
-
-// stateView is an immutable, fully-owned snapshot of the world at a tick boundary.
-type stateView struct {
-	ws        *cardinalv1.WorldState
-	height    uint64 // tick height that produced this state.
-	timestamp time.Time
-	paused    bool
 }
 
 var _ cardinalv1connect.DebugServiceHandler = (*debugModule)(nil)
@@ -52,7 +40,7 @@ func newDebugModule(world *World) *debugModule {
 	batchSize := max(int(math.Round(world.options.TickRate))*perfBatchIntervalSec, 1)
 	perf := performance.NewCollector(batchSize)
 
-	return &debugModule{
+	d := &debugModule{
 		world:      world,
 		control:    newTickControl(),
 		commands:   make(map[string]*structpb.Struct),
@@ -68,6 +56,7 @@ func newDebugModule(world *World) *debugModule {
 		},
 		perf: perf,
 	}
+	return d
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -279,22 +268,20 @@ func (d *debugModule) buildTypeSchemas(cache map[string]*structpb.Struct) []*car
 
 // tickControl coordinates pause, resume, step, and reset signaling for the tick loop.
 type tickControl struct {
-	pauseCh   chan chan uint64   // Request pause, receives tick height when paused
-	resumeCh  chan struct{}      // Signal to resume
-	stepCh    chan chan uint64   // Request step, receives tick height after step
-	resetCh   chan chan struct{} // Request reset
-	isPaused  atomic.Bool        // Current pause state
-	stepReady chan struct{}      // Signals that step result is ready to be read
+	pauseCh  chan chan uint64   // Request pause, receives tick height when paused
+	resumeCh chan struct{}      // Signal to resume
+	stepCh   chan chan uint64   // Request step, receives tick height after step
+	resetCh  chan chan struct{} // Request reset
+	isPaused atomic.Bool        // Current pause state
 }
 
 // newTickControl creates a tickControl with initialized channels.
 func newTickControl() *tickControl {
 	return &tickControl{
-		pauseCh:   make(chan chan uint64),
-		resumeCh:  make(chan struct{}),
-		stepCh:    make(chan chan uint64),
-		resetCh:   make(chan chan struct{}),
-		stepReady: make(chan struct{}),
+		pauseCh:  make(chan chan uint64),
+		resumeCh: make(chan struct{}),
+		stepCh:   make(chan chan uint64),
+		resetCh:  make(chan chan struct{}),
 	}
 }
 
@@ -364,60 +351,15 @@ func (d *debugModule) Reset(
 	return connect.NewResponse(&cardinalv1.ResetResponse{}), nil
 }
 
-// GetState returns the most recent world state view.
-// The view is at most one tick old.
-// Unavailable means the world has not completed a tick yet.
+// GetState returns the most recent published world state, at most one tick old.
 func (d *debugModule) GetState(
 	_ context.Context,
 	_ *connect.Request[cardinalv1.GetStateRequest],
 ) (*connect.Response[cardinalv1.GetStateResponse], error) {
-	v := d.view.Load()
-	if v == nil {
-		return nil, connect.NewError(connect.CodeUnavailable, eris.New("world state not available yet"))
-	}
-
 	return connect.NewResponse(&cardinalv1.GetStateResponse{
-		IsPaused: v.paused,
-		Snapshot: &cardinalv1.Snapshot{
-			TickHeight: v.height,
-			Timestamp:  timestamppb.New(v.timestamp),
-			WorldState: v.ws,
-		},
+		IsPaused: d.control.isPaused.Load(),
+		Snapshot: d.world.state.Load(),
 	}), nil
-}
-
-// publishState stores an immutable state view for GetState. Tick goroutine only. Nil-safe.
-//
-// ComponentsBitmap aliases live ECS memory (bitmap.ToBytes is zero-copy; see archetype.toProto).
-// ConnectRPC marshals this view off-tick while later ticks mutate that memory, so clone it before
-// publishing.
-func (d *debugModule) publishState(ws *cardinalv1.WorldState, height uint64, timestamp time.Time) {
-	if d == nil {
-		return
-	}
-	for _, arch := range ws.GetArchetypes() {
-		arch.ComponentsBitmap = slices.Clone(arch.GetComponentsBitmap())
-	}
-	d.view.Store(&stateView{
-		ws:        ws,
-		height:    height,
-		timestamp: timestamp,
-		paused:    d.control.isPaused.Load(),
-	})
-}
-
-// captureState serializes the world and publishes the state view. Use it for state
-// changes outside a tick (currently reset). Tick goroutine only: it reads live ECS.
-func (d *debugModule) captureState(height uint64, timestamp time.Time) {
-	if d == nil {
-		return
-	}
-	worldState, err := d.world.world.ToProto()
-	if err != nil {
-		d.world.tel.Logger.Warn().Err(err).Msg("failed to serialize world state for debug view")
-		return
-	}
-	d.publishState(worldState, height, timestamp)
 }
 
 // isPaused returns whether the world is currently paused. Returns false if d is nil.
@@ -428,21 +370,12 @@ func (d *debugModule) isPaused() bool {
 	return d.control.isPaused.Load()
 }
 
-// setPaused sets the paused state and mirrors it onto the published view, so
-// GetState reflects the change immediately. Tick goroutine only. No-op if d is nil.
+// setPaused sets the paused state. No-op if d is nil.
 func (d *debugModule) setPaused(v bool) {
 	if d == nil {
 		return
 	}
 	d.control.isPaused.Store(v)
-
-	view := d.view.Load()
-	if view == nil || view.paused == v {
-		return
-	}
-	cp := *view
-	cp.paused = v
-	d.view.Store(&cp)
 }
 
 // pauseChan returns the pause request channel, or nil if d is nil.

--- a/pkg/cardinal/debug.go
+++ b/pkg/cardinal/debug.go
@@ -3,6 +3,7 @@ package cardinal
 import (
 	"context"
 	"math"
+	"slices"
 	"sync/atomic"
 	"time"
 
@@ -31,16 +32,27 @@ type debugModule struct {
 	events     map[string]*structpb.Struct
 	components map[string]*structpb.Struct
 	perf       *performance.Collector
+	// view is the latest world state snapshot, published by the tick goroutine.
+	// Handlers only Load it, so the single writer needs no further synchronization.
+	view atomic.Pointer[stateView]
+}
+
+// stateView is an immutable, fully-owned snapshot of the world at a tick boundary.
+type stateView struct {
+	ws        *cardinalv1.WorldState
+	height    uint64 // tick height that produced this state.
+	timestamp time.Time
+	paused    bool
 }
 
 var _ cardinalv1connect.DebugServiceHandler = (*debugModule)(nil)
 
 // newDebugModule creates a new debugModule bound to the given World.
-func newDebugModule(world *World) debugModule {
+func newDebugModule(world *World) *debugModule {
 	batchSize := max(int(math.Round(world.options.TickRate))*perfBatchIntervalSec, 1)
 	perf := performance.NewCollector(batchSize)
 
-	return debugModule{
+	return &debugModule{
 		world:      world,
 		control:    newTickControl(),
 		commands:   make(map[string]*structpb.Struct),
@@ -352,25 +364,60 @@ func (d *debugModule) Reset(
 	return connect.NewResponse(&cardinalv1.ResetResponse{}), nil
 }
 
-// TODO: this does unsynchronized concurrent access to ToProto. fix after snapshot rework.
-// GetState returns the current world state snapshot.
+// GetState returns the most recent world state view.
+// The view is at most one tick old.
+// Unavailable means the world has not completed a tick yet.
 func (d *debugModule) GetState(
 	_ context.Context,
 	_ *connect.Request[cardinalv1.GetStateRequest],
 ) (*connect.Response[cardinalv1.GetStateResponse], error) {
-	worldState, err := d.world.world.ToProto()
-	if err != nil {
-		return nil, connect.NewError(connect.CodeInternal, eris.Wrap(err, "failed to serialize world state"))
+	v := d.view.Load()
+	if v == nil {
+		return nil, connect.NewError(connect.CodeUnavailable, eris.New("world state not available yet"))
 	}
 
 	return connect.NewResponse(&cardinalv1.GetStateResponse{
-		IsPaused: d.control.isPaused.Load(),
+		IsPaused: v.paused,
 		Snapshot: &cardinalv1.Snapshot{
-			TickHeight: d.world.currentTick.height,
-			Timestamp:  timestamppb.New(d.world.currentTick.timestamp),
-			WorldState: worldState,
+			TickHeight: v.height,
+			Timestamp:  timestamppb.New(v.timestamp),
+			WorldState: v.ws,
 		},
 	}), nil
+}
+
+// publishState stores an immutable state view for GetState. Tick goroutine only. Nil-safe.
+//
+// ComponentsBitmap aliases live ECS memory (bitmap.ToBytes is zero-copy; see archetype.toProto).
+// ConnectRPC marshals this view off-tick while later ticks mutate that memory, so clone it before
+// publishing.
+func (d *debugModule) publishState(ws *cardinalv1.WorldState, height uint64, timestamp time.Time) {
+	if d == nil {
+		return
+	}
+	for _, arch := range ws.GetArchetypes() {
+		arch.ComponentsBitmap = slices.Clone(arch.GetComponentsBitmap())
+	}
+	d.view.Store(&stateView{
+		ws:        ws,
+		height:    height,
+		timestamp: timestamp,
+		paused:    d.control.isPaused.Load(),
+	})
+}
+
+// captureState serializes the world and publishes the state view. Use it for state
+// changes outside a tick (currently reset). Tick goroutine only: it reads live ECS.
+func (d *debugModule) captureState(height uint64, timestamp time.Time) {
+	if d == nil {
+		return
+	}
+	worldState, err := d.world.world.ToProto()
+	if err != nil {
+		d.world.tel.Logger.Warn().Err(err).Msg("failed to serialize world state for debug view")
+		return
+	}
+	d.publishState(worldState, height, timestamp)
 }
 
 // isPaused returns whether the world is currently paused. Returns false if d is nil.
@@ -381,12 +428,21 @@ func (d *debugModule) isPaused() bool {
 	return d.control.isPaused.Load()
 }
 
-// setPaused sets the paused state. No-op if d is nil.
+// setPaused sets the paused state and mirrors it onto the published view, so
+// GetState reflects the change immediately. Tick goroutine only. No-op if d is nil.
 func (d *debugModule) setPaused(v bool) {
 	if d == nil {
 		return
 	}
 	d.control.isPaused.Store(v)
+
+	view := d.view.Load()
+	if view == nil || view.paused == v {
+		return
+	}
+	cp := *view
+	cp.paused = v
+	d.view.Store(&cp)
 }
 
 // pauseChan returns the pause request channel, or nil if d is nil.

--- a/pkg/cardinal/debug_internal_test.go
+++ b/pkg/cardinal/debug_internal_test.go
@@ -1,13 +1,19 @@
 package cardinal
 
 import (
+	"context"
 	"testing"
+	"time"
 
+	"connectrpc.com/connect"
 	"github.com/invopop/jsonschema"
 	"github.com/shamaton/msgpack/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/argus-labs/world-engine/pkg/cardinal/snapshot"
+	cardinalv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1"
 )
 
 // schemaSample mixes the tag cases that decide a field's wire name: a msgpack
@@ -38,7 +44,7 @@ func TestIntrospectSchemaNamesMatchWireFormat(t *testing.T) {
 
 	// Names introspection advertises, via the real register() path.
 	d := &debugModule{
-		commands:  make(map[string]*structpb.Struct),
+		commands: make(map[string]*structpb.Struct),
 		reflector: &jsonschema.Reflector{
 			Anonymous:      true, // Don't add $id based on package path
 			ExpandedStruct: true, // Inline the struct fields directly
@@ -67,4 +73,216 @@ func mapKeys(m map[string]any) []string {
 		out = append(out, k)
 	}
 	return out
+}
+
+// -------------------------------------------------------------------------------------------------
+// GetState & the published state view
+// -------------------------------------------------------------------------------------------------
+
+func newTestDebugModule() *debugModule {
+	return &debugModule{control: newTickControl()}
+}
+
+func getStateRequest() *connect.Request[cardinalv1.GetStateRequest] {
+	return connect.NewRequest(&cardinalv1.GetStateRequest{})
+}
+
+// TestGetStateUnavailableBeforeFirstPublish: before the first tick publishes a view, GetState must
+// return Unavailable instead of touching live ECS state.
+func TestGetStateUnavailableBeforeFirstPublish(t *testing.T) {
+	t.Parallel()
+	d := newTestDebugModule()
+
+	_, err := d.GetState(context.Background(), getStateRequest())
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
+}
+
+// TestPublishStateRoundtrip: GetState serves exactly what publishState stored — same object, same
+// height, same timestamp, and the paused flag captured at publish time.
+func TestPublishStateRoundtrip(t *testing.T) {
+	t.Parallel()
+	d := newTestDebugModule()
+	ts := time.Unix(42, 0)
+	ws := &cardinalv1.WorldState{NextId: 7}
+
+	d.publishState(ws, 41, ts)
+
+	resp, err := d.GetState(context.Background(), getStateRequest())
+	require.NoError(t, err)
+	assert.False(t, resp.Msg.GetIsPaused())
+	assert.Equal(t, uint64(41), resp.Msg.GetSnapshot().GetTickHeight())
+	assert.Equal(t, ts.Unix(), resp.Msg.GetSnapshot().GetTimestamp().AsTime().Unix())
+	assert.Same(t, ws, resp.Msg.GetSnapshot().GetWorldState())
+
+	// The paused flag is captured at publish time, not read live at request time.
+	d.control.isPaused.Store(true)
+	d.publishState(&cardinalv1.WorldState{}, 42, ts)
+	resp, err = d.GetState(context.Background(), getStateRequest())
+	require.NoError(t, err)
+	assert.True(t, resp.Msg.GetIsPaused())
+}
+
+// TestPublishStateClonesArchetypeBitmaps: ComponentsBitmap aliases live bitmap memory when it
+// arrives from archetype.toProto (bitmap.ToBytes is zero-copy). The view outlives the tick, so
+// publishState must clone it — a later mutation of the source buffer must not be visible.
+func TestPublishStateClonesArchetypeBitmaps(t *testing.T) {
+	t.Parallel()
+	d := newTestDebugModule()
+	live := []byte{1, 2, 3, 4, 5, 6, 7, 8} // stands in for the live bitmap's backing array
+	ws := &cardinalv1.WorldState{
+		Archetypes: []*cardinalv1.Archetype{{ComponentsBitmap: live}},
+	}
+
+	d.publishState(ws, 1, time.Time{})
+	live[0] = 0xFF // the live world mutating after the tick
+
+	got := d.view.Load().ws.GetArchetypes()[0].GetComponentsBitmap()
+	assert.Equal(t, byte(1), got[0], "published view must not alias live bitmap memory")
+}
+
+// TestSetPausedUpdatesView: setPaused flips both the control flag and the published view in one
+// call, republishing the same state with only the flag changed; before the first publish it only
+// sets the control flag.
+func TestSetPausedUpdatesView(t *testing.T) {
+	t.Parallel()
+	d := newTestDebugModule()
+
+	d.setPaused(true) // no view yet: control flag set, no view created
+	assert.True(t, d.control.isPaused.Load())
+	assert.Nil(t, d.view.Load())
+	d.setPaused(false)
+
+	d.publishState(&cardinalv1.WorldState{NextId: 3}, 5, time.Unix(1, 0))
+	d.setPaused(true)
+	assert.True(t, d.control.isPaused.Load())
+	v := d.view.Load()
+	assert.True(t, v.paused)
+	assert.Equal(t, uint64(5), v.height, "flag flip must preserve the rest of the view")
+	assert.Equal(t, uint32(3), v.ws.GetNextId())
+
+	d.setPaused(false)
+	assert.False(t, d.control.isPaused.Load())
+	assert.False(t, d.view.Load().paused)
+}
+
+// TestDebugStateNilSafety: the prod path (debug disabled) calls these on a nil receiver.
+func TestDebugStateNilSafety(t *testing.T) {
+	t.Parallel()
+	var d *debugModule
+	assert.NotPanics(t, func() {
+		d.publishState(&cardinalv1.WorldState{}, 1, time.Time{})
+		d.setPaused(true)
+	})
+}
+
+// debugStateCounter is a minimal tag component so the spawner changes world state every tick.
+type debugStateCounter struct{}
+
+func (debugStateCounter) Name() string { return "debug_state_counter" }
+
+type debugStateSpawnerState struct {
+	BaseSystemState
+	Counters Exact[struct {
+		Counter Ref[debugStateCounter]
+	}]
+}
+
+// debugStateSpawnerSystem creates exactly one entity per tick, so entity count == executed ticks.
+func debugStateSpawnerSystem(s *debugStateSpawnerState) {
+	_, entity := s.Counters.Create()
+	entity.Counter.Set(debugStateCounter{})
+}
+
+func countEntities(ws *cardinalv1.WorldState) int {
+	n := 0
+	for _, arch := range ws.GetArchetypes() {
+		n += len(arch.GetEntities())
+	}
+	return n
+}
+
+// TestGetStateLifecycle drives the real run() loop and checks GetState against every debugger
+// transition. The critical assertion is the step one: a paused world that steps once must show the
+// stepped state in GetState immediately — this is what breaks if a demand gate or lazy publish is
+// ever reintroduced.
+func TestGetStateLifecycle(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "disabled")
+
+	debug := true
+	w, err := NewWorld(WorldOptions{
+		Region:              "test",
+		Organization:        "test",
+		Project:             "test",
+		ShardID:             "0",
+		TickRate:            100, // 10ms ticks keep the Eventually waits short
+		SnapshotStorageType: snapshot.StorageTypeNop,
+		SnapshotRate:        1_000_000,
+		Debug:               &debug,
+	})
+	require.NoError(t, err)
+	RegisterSystem(w, debugStateSpawnerSystem)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	runErr := make(chan error, 1)
+	go func() { runErr <- w.run(ctx) }()
+	t.Cleanup(func() {
+		cancel()
+		require.ErrorIs(t, <-runErr, context.Canceled)
+	})
+
+	d := w.debug
+
+	// getState fetches the current view, failing the test on error. Scoped here because ctx is fixed
+	// and, once the world is running, GetState is never expected to error.
+	getState := func() *cardinalv1.GetStateResponse {
+		resp, getErr := d.GetState(ctx, getStateRequest())
+		require.NoError(t, getErr)
+		return resp.Msg
+	}
+
+	// Wait until the world has ticked past the initial (height 0) view, so entities
+	// exist before we pause. run() publishes a height-0 view at boot, so we must
+	// wait for a real tick, not just any view.
+	require.Eventually(t, func() bool {
+		resp, getErr := d.GetState(ctx, getStateRequest())
+		return getErr == nil && !resp.Msg.GetIsPaused() && resp.Msg.GetSnapshot().GetTickHeight() > 0
+	}, 5*time.Second, 5*time.Millisecond)
+
+	// Pause: the view flips to paused immediately (no tick needed), and its height is the last
+	// executed tick — one less than the pause reply, which reports the next tick to run.
+	pauseResp, err := d.Pause(ctx, connect.NewRequest(&cardinalv1.PauseRequest{}))
+	require.NoError(t, err)
+	state := getState()
+	assert.True(t, state.GetIsPaused())
+	assert.Equal(t, pauseResp.Msg.GetTickHeight()-1, state.GetSnapshot().GetTickHeight())
+
+	before := countEntities(state.GetSnapshot().GetWorldState())
+	require.Positive(t, before, "spawner must have created entities while running")
+
+	// Step: exactly one tick runs, and its result is visible in GetState immediately.
+	stepResp, err := d.Step(ctx, connect.NewRequest(&cardinalv1.StepRequest{}))
+	require.NoError(t, err)
+	state = getState()
+	assert.True(t, state.GetIsPaused(), "stepping must not unpause the view")
+	assert.Equal(t, stepResp.Msg.GetTickHeight()-1, state.GetSnapshot().GetTickHeight())
+	assert.Equal(t, before+1, countEntities(state.GetSnapshot().GetWorldState()),
+		"the stepped tick's state must be visible in GetState immediately")
+
+	// Reset: no tick runs, but the view must be refreshed to the fresh world.
+	_, err = d.Reset(ctx, connect.NewRequest(&cardinalv1.ResetRequest{}))
+	require.NoError(t, err)
+	state = getState()
+	assert.True(t, state.GetIsPaused())
+	assert.Equal(t, uint64(0), state.GetSnapshot().GetTickHeight())
+	assert.Zero(t, countEntities(state.GetSnapshot().GetWorldState()),
+		"the view must reflect the reset world, not the pre-reset one")
+
+	// Resume: the paused flag clears without waiting for the next tick's publish.
+	_, err = d.Resume(ctx, connect.NewRequest(&cardinalv1.ResumeRequest{}))
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		resp, getErr := d.GetState(ctx, getStateRequest())
+		return getErr == nil && !resp.Msg.GetIsPaused()
+	}, 5*time.Second, 5*time.Millisecond)
 }

--- a/pkg/cardinal/debug_internal_test.go
+++ b/pkg/cardinal/debug_internal_test.go
@@ -1,19 +1,13 @@
 package cardinal
 
 import (
-	"context"
 	"testing"
-	"time"
 
-	"connectrpc.com/connect"
 	"github.com/invopop/jsonschema"
 	"github.com/shamaton/msgpack/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/structpb"
-
-	"github.com/argus-labs/world-engine/pkg/cardinal/snapshot"
-	cardinalv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1"
 )
 
 // schemaSample mixes the tag cases that decide a field's wire name: a msgpack
@@ -44,7 +38,7 @@ func TestIntrospectSchemaNamesMatchWireFormat(t *testing.T) {
 
 	// Names introspection advertises, via the real register() path.
 	d := &debugModule{
-		commands: make(map[string]*structpb.Struct),
+		commands:  make(map[string]*structpb.Struct),
 		reflector: &jsonschema.Reflector{
 			Anonymous:      true, // Don't add $id based on package path
 			ExpandedStruct: true, // Inline the struct fields directly
@@ -73,216 +67,4 @@ func mapKeys(m map[string]any) []string {
 		out = append(out, k)
 	}
 	return out
-}
-
-// -------------------------------------------------------------------------------------------------
-// GetState & the published state view
-// -------------------------------------------------------------------------------------------------
-
-func newTestDebugModule() *debugModule {
-	return &debugModule{control: newTickControl()}
-}
-
-func getStateRequest() *connect.Request[cardinalv1.GetStateRequest] {
-	return connect.NewRequest(&cardinalv1.GetStateRequest{})
-}
-
-// TestGetStateUnavailableBeforeFirstPublish: before the first tick publishes a view, GetState must
-// return Unavailable instead of touching live ECS state.
-func TestGetStateUnavailableBeforeFirstPublish(t *testing.T) {
-	t.Parallel()
-	d := newTestDebugModule()
-
-	_, err := d.GetState(context.Background(), getStateRequest())
-	require.Error(t, err)
-	assert.Equal(t, connect.CodeUnavailable, connect.CodeOf(err))
-}
-
-// TestPublishStateRoundtrip: GetState serves exactly what publishState stored — same object, same
-// height, same timestamp, and the paused flag captured at publish time.
-func TestPublishStateRoundtrip(t *testing.T) {
-	t.Parallel()
-	d := newTestDebugModule()
-	ts := time.Unix(42, 0)
-	ws := &cardinalv1.WorldState{NextId: 7}
-
-	d.publishState(ws, 41, ts)
-
-	resp, err := d.GetState(context.Background(), getStateRequest())
-	require.NoError(t, err)
-	assert.False(t, resp.Msg.GetIsPaused())
-	assert.Equal(t, uint64(41), resp.Msg.GetSnapshot().GetTickHeight())
-	assert.Equal(t, ts.Unix(), resp.Msg.GetSnapshot().GetTimestamp().AsTime().Unix())
-	assert.Same(t, ws, resp.Msg.GetSnapshot().GetWorldState())
-
-	// The paused flag is captured at publish time, not read live at request time.
-	d.control.isPaused.Store(true)
-	d.publishState(&cardinalv1.WorldState{}, 42, ts)
-	resp, err = d.GetState(context.Background(), getStateRequest())
-	require.NoError(t, err)
-	assert.True(t, resp.Msg.GetIsPaused())
-}
-
-// TestPublishStateClonesArchetypeBitmaps: ComponentsBitmap aliases live bitmap memory when it
-// arrives from archetype.toProto (bitmap.ToBytes is zero-copy). The view outlives the tick, so
-// publishState must clone it — a later mutation of the source buffer must not be visible.
-func TestPublishStateClonesArchetypeBitmaps(t *testing.T) {
-	t.Parallel()
-	d := newTestDebugModule()
-	live := []byte{1, 2, 3, 4, 5, 6, 7, 8} // stands in for the live bitmap's backing array
-	ws := &cardinalv1.WorldState{
-		Archetypes: []*cardinalv1.Archetype{{ComponentsBitmap: live}},
-	}
-
-	d.publishState(ws, 1, time.Time{})
-	live[0] = 0xFF // the live world mutating after the tick
-
-	got := d.view.Load().ws.GetArchetypes()[0].GetComponentsBitmap()
-	assert.Equal(t, byte(1), got[0], "published view must not alias live bitmap memory")
-}
-
-// TestSetPausedUpdatesView: setPaused flips both the control flag and the published view in one
-// call, republishing the same state with only the flag changed; before the first publish it only
-// sets the control flag.
-func TestSetPausedUpdatesView(t *testing.T) {
-	t.Parallel()
-	d := newTestDebugModule()
-
-	d.setPaused(true) // no view yet: control flag set, no view created
-	assert.True(t, d.control.isPaused.Load())
-	assert.Nil(t, d.view.Load())
-	d.setPaused(false)
-
-	d.publishState(&cardinalv1.WorldState{NextId: 3}, 5, time.Unix(1, 0))
-	d.setPaused(true)
-	assert.True(t, d.control.isPaused.Load())
-	v := d.view.Load()
-	assert.True(t, v.paused)
-	assert.Equal(t, uint64(5), v.height, "flag flip must preserve the rest of the view")
-	assert.Equal(t, uint32(3), v.ws.GetNextId())
-
-	d.setPaused(false)
-	assert.False(t, d.control.isPaused.Load())
-	assert.False(t, d.view.Load().paused)
-}
-
-// TestDebugStateNilSafety: the prod path (debug disabled) calls these on a nil receiver.
-func TestDebugStateNilSafety(t *testing.T) {
-	t.Parallel()
-	var d *debugModule
-	assert.NotPanics(t, func() {
-		d.publishState(&cardinalv1.WorldState{}, 1, time.Time{})
-		d.setPaused(true)
-	})
-}
-
-// debugStateCounter is a minimal tag component so the spawner changes world state every tick.
-type debugStateCounter struct{}
-
-func (debugStateCounter) Name() string { return "debug_state_counter" }
-
-type debugStateSpawnerState struct {
-	BaseSystemState
-	Counters Exact[struct {
-		Counter Ref[debugStateCounter]
-	}]
-}
-
-// debugStateSpawnerSystem creates exactly one entity per tick, so entity count == executed ticks.
-func debugStateSpawnerSystem(s *debugStateSpawnerState) {
-	_, entity := s.Counters.Create()
-	entity.Counter.Set(debugStateCounter{})
-}
-
-func countEntities(ws *cardinalv1.WorldState) int {
-	n := 0
-	for _, arch := range ws.GetArchetypes() {
-		n += len(arch.GetEntities())
-	}
-	return n
-}
-
-// TestGetStateLifecycle drives the real run() loop and checks GetState against every debugger
-// transition. The critical assertion is the step one: a paused world that steps once must show the
-// stepped state in GetState immediately — this is what breaks if a demand gate or lazy publish is
-// ever reintroduced.
-func TestGetStateLifecycle(t *testing.T) {
-	t.Setenv("LOG_LEVEL", "disabled")
-
-	debug := true
-	w, err := NewWorld(WorldOptions{
-		Region:              "test",
-		Organization:        "test",
-		Project:             "test",
-		ShardID:             "0",
-		TickRate:            100, // 10ms ticks keep the Eventually waits short
-		SnapshotStorageType: snapshot.StorageTypeNop,
-		SnapshotRate:        1_000_000,
-		Debug:               &debug,
-	})
-	require.NoError(t, err)
-	RegisterSystem(w, debugStateSpawnerSystem)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	runErr := make(chan error, 1)
-	go func() { runErr <- w.run(ctx) }()
-	t.Cleanup(func() {
-		cancel()
-		require.ErrorIs(t, <-runErr, context.Canceled)
-	})
-
-	d := w.debug
-
-	// getState fetches the current view, failing the test on error. Scoped here because ctx is fixed
-	// and, once the world is running, GetState is never expected to error.
-	getState := func() *cardinalv1.GetStateResponse {
-		resp, getErr := d.GetState(ctx, getStateRequest())
-		require.NoError(t, getErr)
-		return resp.Msg
-	}
-
-	// Wait until the world has ticked past the initial (height 0) view, so entities
-	// exist before we pause. run() publishes a height-0 view at boot, so we must
-	// wait for a real tick, not just any view.
-	require.Eventually(t, func() bool {
-		resp, getErr := d.GetState(ctx, getStateRequest())
-		return getErr == nil && !resp.Msg.GetIsPaused() && resp.Msg.GetSnapshot().GetTickHeight() > 0
-	}, 5*time.Second, 5*time.Millisecond)
-
-	// Pause: the view flips to paused immediately (no tick needed), and its height is the last
-	// executed tick — one less than the pause reply, which reports the next tick to run.
-	pauseResp, err := d.Pause(ctx, connect.NewRequest(&cardinalv1.PauseRequest{}))
-	require.NoError(t, err)
-	state := getState()
-	assert.True(t, state.GetIsPaused())
-	assert.Equal(t, pauseResp.Msg.GetTickHeight()-1, state.GetSnapshot().GetTickHeight())
-
-	before := countEntities(state.GetSnapshot().GetWorldState())
-	require.Positive(t, before, "spawner must have created entities while running")
-
-	// Step: exactly one tick runs, and its result is visible in GetState immediately.
-	stepResp, err := d.Step(ctx, connect.NewRequest(&cardinalv1.StepRequest{}))
-	require.NoError(t, err)
-	state = getState()
-	assert.True(t, state.GetIsPaused(), "stepping must not unpause the view")
-	assert.Equal(t, stepResp.Msg.GetTickHeight()-1, state.GetSnapshot().GetTickHeight())
-	assert.Equal(t, before+1, countEntities(state.GetSnapshot().GetWorldState()),
-		"the stepped tick's state must be visible in GetState immediately")
-
-	// Reset: no tick runs, but the view must be refreshed to the fresh world.
-	_, err = d.Reset(ctx, connect.NewRequest(&cardinalv1.ResetRequest{}))
-	require.NoError(t, err)
-	state = getState()
-	assert.True(t, state.GetIsPaused())
-	assert.Equal(t, uint64(0), state.GetSnapshot().GetTickHeight())
-	assert.Zero(t, countEntities(state.GetSnapshot().GetWorldState()),
-		"the view must reflect the reset world, not the pre-reset one")
-
-	// Resume: the paused flag clears without waiting for the next tick's publish.
-	_, err = d.Resume(ctx, connect.NewRequest(&cardinalv1.ResumeRequest{}))
-	require.NoError(t, err)
-	require.Eventually(t, func() bool {
-		resp, getErr := d.GetState(ctx, getStateRequest())
-		return getErr == nil && !resp.Msg.GetIsPaused()
-	}, 5*time.Second, 5*time.Millisecond)
 }

--- a/pkg/cardinal/internal/ecs/archetype.go
+++ b/pkg/cardinal/internal/ecs/archetype.go
@@ -1,6 +1,8 @@
 package ecs
 
 import (
+	"bytes"
+
 	"github.com/argus-labs/world-engine/pkg/assert"
 	cardinalv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1"
 	"github.com/kelindar/bitmap"
@@ -156,7 +158,7 @@ func (a *archetype) moveEntity(destination *archetype, eid EntityID) {
 
 // toProto converts the archetype to a protobuf message for serialization.
 func (a *archetype) toProto() (*cardinalv1.Archetype, error) {
-	componentsBitmap := a.components.ToBytes()
+	componentsBitmap := bytes.Clone(a.components.ToBytes())
 
 	entities := make([]uint32, len(a.entities))
 	for i, eid := range a.entities {

--- a/pkg/cardinal/internal/ecs/archetype_internal_test.go
+++ b/pkg/cardinal/internal/ecs/archetype_internal_test.go
@@ -395,6 +395,27 @@ func TestArchetype_SerializationSmoke(t *testing.T) {
 	assertArchetypeEqual(t, arch, arch2)
 }
 
+// TestArchetype_ToProtoBitmapNotAliased guards that toProto returns a ComponentsBitmap that owns its
+// memory rather than aliasing the live archetype bitmap (bitmap.ToBytes is zero-copy). Consumers now
+// retain the proto across ticks (the debug state view), so a later mutation of the live bitmap must
+// not be visible in an already-serialized proto.
+func TestArchetype_ToProtoBitmapNotAliased(t *testing.T) {
+	t.Parallel()
+
+	arch, _ := newSimpleArchetype(t)
+	arch.newEntity(0)
+
+	pb, err := arch.toProto()
+	require.NoError(t, err)
+	require.NotEmpty(t, pb.GetComponentsBitmap())
+
+	before := pb.GetComponentsBitmap()[0]
+	arch.components[0] ^= 0xFF // mutate the live bitmap's backing array
+
+	assert.Equal(t, before, pb.GetComponentsBitmap()[0],
+		"toProto's bitmap must not alias the live archetype bitmap")
+}
+
 func newSimpleArchetype(t *testing.T) (*archetype, *componentManager) {
 	t.Helper()
 


### PR DESCRIPTION
### TL;DR

Fixes a data race in `GetState` and eliminates redundant world serialization by unifying snapshot and debug state publishing into a single `persistState` path.

### What changed?

`GetState` previously called `ToProto` directly on live ECS state from an HTTP handler goroutine, racing with the tick goroutine. It now reads from an `atomic.Pointer[stateView]` that the tick goroutine publishes at each tick boundary.

The old `snapshot` function has been replaced by `persistState`, which serializes the world once per tick and fans the result out to both the durable snapshot store and the debug view. When debug is disabled and no snapshot is due, serialization is skipped entirely, preserving the production fast path.

`ComponentsBitmap` in archetypes aliases live bitmap memory via a zero-copy `ToBytes` call. Since the published view outlives the tick, `publishState` now clones each bitmap before storing it, preventing later tick mutations from corrupting the view seen by `GetState`.

`setPaused` now mirrors the pause flag onto the published view immediately, so `GetState` reflects pause/resume transitions without waiting for the next tick. An initial state view is published at world startup (before the first tick) and after reset, so `GetState` is never unavailable once the world is running.

`debugModule` is now a pointer type throughout, enabling nil-receiver methods (`publishState`, `captureState`, `setPaused`, etc.) that are no-ops when debug is disabled, removing scattered nil checks at call sites.

The unused `stepReady` channel has been removed from `tickControl`.

### How to test?

New internal tests cover the changed behavior directly:

- `TestGetStateUnavailableBeforeFirstPublish` — `GetState` returns `Unavailable` before the first publish.
- `TestPublishStateRoundtrip` — `GetState` serves exactly what `publishState` stored.
- `TestPublishStateClonesArchetypeBitmaps` — the published view does not alias live bitmap memory.
- `TestSetPausedUpdatesView` — `setPaused` updates both the control flag and the view atomically.
- `TestDebugStateNilSafety` — nil-receiver methods do not panic.
- `TestGetStateLifecycle` — drives the real `run()` loop through pause, step, reset, and resume, asserting `GetState` reflects each transition immediately.
- `TestPersistStateFeedsSnapshotAndView` — a single tick serialization feeds both the snapshot store and the debug view at the same height.
- `TestPersistStateProdFastPath` — with debug disabled, serialization only occurs on snapshot ticks.

### Why make this change?

The previous `GetState` implementation had an acknowledged data race (marked with a `TODO` comment) and called `ToProto` on every request, regardless of whether the world state had changed. Separately, snapshot ticks and debug state were produced by independent serialization calls, doubling the cost on ticks where both were needed. This change fixes the race, removes the duplicate work, and makes the debug view's staleness bounded to one tick.