### PR TITLE
feat(runtime): backport C# NativeAOT module support to v0.11

### DIFF
--- a/.github/workflows/common-csharp-runtime-ci.yaml
+++ b/.github/workflows/common-csharp-runtime-ci.yaml
@@ -1,0 +1,50 @@
+name: CI (C# Runtime)
+
+on:
+  push:
+    paths:
+      - 'sdk/csharp/**'
+      - 'pkg/cardinal/runtime/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/common-csharp-runtime-ci.yaml'
+  pull_request:
+    paths:
+      - 'sdk/csharp/**'
+      - 'pkg/cardinal/runtime/**'
+      - 'go.mod'
+      - 'go.sum'
+      - '.github/workflows/common-csharp-runtime-ci.yaml'
+
+env:
+  GO_VERSION: 1.25.5
+
+jobs:
+  nativeaot:
+    name: Pack, publish, and load NativeAOT
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Build packaged C# fixture
+        run: |
+          docker build \
+            --file sdk/csharp/testapps/CounterModule/Dockerfile \
+            --target artifact \
+            --output type=local,dest=/tmp/nativeaot-artifact \
+            .
+
+      - name: Test Go host against packaged fixture
+        env:
+          CARDINAL_NATIVEAOT_TEST_LIBRARY: /tmp/nativeaot-artifact/libcounter_fixture.so
+        run: go test -race ./pkg/cardinal/runtime/... -count=1
+
+      - name: Test no-cgo portability
+        env:
+          CGO_ENABLED: 0
+        run: go test ./pkg/cardinal/runtime/... -count=1

--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ go.work.sum
 bin/
 dist/
 
+# .NET intermediate output
+obj/
+
 # Local development environment
 .env
 .env.local

--- a/pkg/cardinal/runtime/nativeaot/errors.go
+++ b/pkg/cardinal/runtime/nativeaot/errors.go
@@ -1,0 +1,7 @@
+package nativeaot
+
+import "errors"
+
+// ErrUnavailable reports that the NativeAOT loader is unavailable in this
+// build. It requires cgo and a platform with dlopen.
+var ErrUnavailable = errors.New("nativeaot runtime loader unavailable")

--- a/pkg/cardinal/runtime/nativeaot/include/cardinal_runtime_v1.h
+++ b/pkg/cardinal/runtime/nativeaot/include/cardinal_runtime_v1.h
@@ -1,0 +1,132 @@
+#ifndef CARDINAL_RUNTIME_V1_H
+#define CARDINAL_RUNTIME_V1_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#if defined(_WIN32)
+#define CARDINAL_RUNTIME_EXPORT __declspec(dllexport)
+#else
+#define CARDINAL_RUNTIME_EXPORT __attribute__((visibility("default")))
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CARDINAL_RUNTIME_V1_ABI_VERSION UINT32_C(1)
+#define CARDINAL_RUNTIME_V1_NAME_CAPACITY 64
+#define CARDINAL_RUNTIME_V1_VERSION_CAPACITY 32
+#define CARDINAL_RUNTIME_V1_SCHEMA_HASH_SIZE 32
+
+typedef uint64_t cardinal_runtime_handle_v1;
+typedef uint64_t cardinal_runtime_capabilities_v1;
+
+enum cardinal_runtime_status_v1 {
+    CARDINAL_RUNTIME_STATUS_SUCCESS = 0,
+    CARDINAL_RUNTIME_STATUS_BUFFER_TOO_SMALL = 1,
+    CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT = 2,
+    CARDINAL_RUNTIME_STATUS_INVALID_HANDLE = 3,
+    CARDINAL_RUNTIME_STATUS_INVALID_STATE = 4,
+    CARDINAL_RUNTIME_STATUS_UNSUPPORTED = 5,
+    CARDINAL_RUNTIME_STATUS_EXECUTION_FAILED = 6,
+    CARDINAL_RUNTIME_STATUS_ABI_MISMATCH = 7,
+};
+
+enum cardinal_runtime_capability_v1 {
+    CARDINAL_RUNTIME_CAPABILITY_INITIALIZE = UINT64_C(1) << 0,
+    CARDINAL_RUNTIME_CAPABILITY_TICK = UINT64_C(1) << 1,
+    CARDINAL_RUNTIME_CAPABILITY_QUERY = UINT64_C(1) << 2,
+    CARDINAL_RUNTIME_CAPABILITY_SNAPSHOT = UINT64_C(1) << 3,
+    CARDINAL_RUNTIME_CAPABILITY_RESTORE = UINT64_C(1) << 4,
+    CARDINAL_RUNTIME_CAPABILITY_STATELESS = UINT64_C(1) << 5,
+};
+
+/*
+ * Frozen v1 contract. Producers must set struct_size to exactly sizeof this
+ * struct, zero reserved fields, and NUL-terminate UTF-8 name and version strings.
+ * schema_hash is an opaque 32-byte compatibility fingerprint.
+ */
+typedef struct cardinal_runtime_contract_v1 {
+    uint32_t abi_version;
+    uint32_t struct_size;
+    cardinal_runtime_capabilities_v1 capabilities;
+    uint8_t schema_hash[CARDINAL_RUNTIME_V1_SCHEMA_HASH_SIZE];
+    char name[CARDINAL_RUNTIME_V1_NAME_CAPACITY];
+    char version[CARDINAL_RUNTIME_V1_VERSION_CAPACITY];
+    uint64_t reserved[4];
+} cardinal_runtime_contract_v1;
+
+/*
+ * Every input pointer is borrowed only for the duration of its call.
+ * Every output buffer is caller-owned. On SUCCESS, output_len is bytes
+ * written. On BUFFER_TOO_SMALL, output_len is the required capacity and the
+ * output buffer and module state must remain unmodified because the host may
+ * retry the call. A zero capacity permits output=NULL.
+ *
+ * Handle zero is invalid. A module must serialize neither globally nor across
+ * handles; the host serializes calls belonging to one handle.
+ * Errors raised before a handle exists are local to the calling native thread;
+ * retrieve them immediately with last_error(0) on that same thread.
+ */
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_get_contract(
+    cardinal_runtime_contract_v1 *contract);
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_create(
+    const uint8_t *config,
+    size_t config_len,
+    cardinal_runtime_handle_v1 *handle);
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_initialize(
+    cardinal_runtime_handle_v1 handle,
+    const uint8_t *snapshot,
+    size_t snapshot_len);
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_tick(
+    cardinal_runtime_handle_v1 handle,
+    uint64_t tick,
+    uint64_t fixed_delta_ns,
+    const uint8_t *input,
+    size_t input_len,
+    uint8_t *output,
+    size_t output_capacity,
+    size_t *output_len);
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_query(
+    cardinal_runtime_handle_v1 handle,
+    uint32_t kind,
+    const uint8_t *input,
+    size_t input_len,
+    uint8_t *output,
+    size_t output_capacity,
+    size_t *output_len);
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_snapshot(
+    cardinal_runtime_handle_v1 handle,
+    uint8_t *output,
+    size_t output_capacity,
+    size_t *output_len);
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_restore(
+    cardinal_runtime_handle_v1 handle,
+    const uint8_t *snapshot,
+    size_t snapshot_len);
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_last_error(
+    cardinal_runtime_handle_v1 handle,
+    uint8_t *output,
+    size_t output_capacity,
+    size_t *output_len);
+
+/*
+ * Destroy consumes the handle regardless of the returned status. Callers must
+ * not retry or use the handle after this call.
+ */
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_destroy(
+    cardinal_runtime_handle_v1 handle);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/pkg/cardinal/runtime/nativeaot/loader.go
+++ b/pkg/cardinal/runtime/nativeaot/loader.go
@@ -1,0 +1,481 @@
+//go:build cgo && (linux || darwin)
+
+// Package nativeaot loads Cardinal NativeAOT modules through their stable C
+// ABI. Loaded shared libraries remain resident for process lifetime.
+package nativeaot
+
+/*
+#cgo CFLAGS: -std=c11
+#cgo linux LDFLAGS: -ldl
+#include <stdlib.h>
+#include "loader_unix.h"
+*/
+import "C"
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+	"sync"
+	"unsafe"
+
+	cardinalruntime "github.com/argus-labs/world-engine/pkg/cardinal/runtime"
+)
+
+const maxLastErrorSize = 64 * 1024
+
+// Runner owns one NativeAOT module handle. Calls for a handle are serialized.
+type Runner struct {
+	mu       sync.Mutex
+	library  *C.cardinal_nativeaot_library_v1
+	handle   C.cardinal_runtime_handle_v1
+	contract cardinalruntime.Contract
+	closed   bool
+}
+
+var _ cardinalruntime.Runner = (*Runner)(nil)
+
+// Open resolves path to a canonical absolute path and creates one module
+// handle with borrowed config bytes. Callers with a known application contract
+// should use OpenValidated so incompatible modules are rejected before create.
+func Open(path string, config []byte) (*Runner, error) {
+	return open(path, config, nil)
+}
+
+// OpenValidated loads a trusted module, validates its immutable contract, then
+// creates one handle. No module config or create callback is invoked when
+// validation fails.
+func OpenValidated(
+	path string,
+	config []byte,
+	requirement cardinalruntime.ContractRequirement,
+) (*Runner, error) {
+	return open(path, config, &requirement)
+}
+
+// Native libraries are executable code: callers must only pass trusted
+// artifacts. The library is never passed to dlclose, including on errors.
+func open(
+	path string,
+	config []byte,
+	requirement *cardinalruntime.ContractRequirement,
+) (*Runner, error) {
+	if path == "" || strings.IndexByte(path, 0) >= 0 {
+		return nil, fmt.Errorf("open NativeAOT runtime: %w", cardinalruntime.ErrInvalidArgument)
+	}
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve NativeAOT library %q: %w", path, err)
+	}
+	path, err = filepath.EvalSymlinks(absolutePath)
+	if err != nil {
+		return nil, fmt.Errorf("resolve NativeAOT library %q: %w", absolutePath, err)
+	}
+
+	// Errors before a module handle exists are thread-local in the ABI.
+	goruntime.LockOSThread()
+	defer goruntime.UnlockOSThread()
+
+	cPath := C.CString(path)
+	defer C.free(unsafe.Pointer(cPath))
+
+	var loadError [1024]C.char
+	library := C.cardinal_nativeaot_library_open(
+		cPath,
+		&loadError[0],
+		C.size_t(len(loadError)),
+	)
+	if library == nil {
+		message, _ := fixedCString(unsafe.Pointer(&loadError[0]), len(loadError))
+		return nil, fmt.Errorf("load NativeAOT library %q: %s", path, message)
+	}
+
+	runner := &Runner{library: library}
+	contract, err := runner.loadContract()
+	if err != nil {
+		C.cardinal_nativeaot_library_forget(library)
+		return nil, err
+	}
+	if requirement != nil {
+		if err = requirement.Validate(contract); err != nil {
+			C.cardinal_nativeaot_library_forget(library)
+			return nil, fmt.Errorf("validate NativeAOT contract: %w", err)
+		}
+	}
+	runner.contract = contract
+
+	createResult := C.cardinal_nativeaot_create(
+		library,
+		bytePointer(config),
+		C.size_t(len(config)),
+	)
+	goruntime.KeepAlive(config)
+	if createResult.status != C.CARDINAL_RUNTIME_STATUS_SUCCESS {
+		err = runner.statusErrorLocked("create", createResult.status)
+		C.cardinal_nativeaot_library_forget(library)
+		return nil, err
+	}
+	if createResult.handle == 0 {
+		C.cardinal_nativeaot_library_forget(library)
+		return nil, fmt.Errorf(
+			"create: %w: module returned the reserved zero handle",
+			cardinalruntime.ErrABIMismatch,
+		)
+	}
+
+	runner.handle = createResult.handle
+	return runner, nil
+}
+
+// Contract returns the immutable contract copied from the shared library.
+func (r *Runner) Contract() cardinalruntime.Contract {
+	return r.contract
+}
+
+// Initialize initializes this handle from an optional borrowed snapshot.
+func (r *Runner) Initialize(request cardinalruntime.InitRequest) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := r.checkCallLocked("initialize", cardinalruntime.CapabilityInitialize); err != nil {
+		return err
+	}
+	status := C.cardinal_nativeaot_initialize(
+		r.library,
+		r.handle,
+		bytePointer(request.Snapshot),
+		C.size_t(len(request.Snapshot)),
+	)
+	goruntime.KeepAlive(request.Snapshot)
+	return r.statusErrorLocked("initialize", status)
+}
+
+// Tick executes one simulation step into caller-owned output.
+func (r *Runner) Tick(request cardinalruntime.TickRequest, output []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := r.checkCallLocked("tick", cardinalruntime.CapabilityTick); err != nil {
+		return 0, err
+	}
+	result := C.cardinal_nativeaot_tick(
+		r.library,
+		r.handle,
+		C.uint64_t(request.Tick),
+		C.uint64_t(request.FixedDeltaNS),
+		bytePointer(request.Input),
+		C.size_t(len(request.Input)),
+		bytePointer(output),
+		C.size_t(len(output)),
+	)
+	goruntime.KeepAlive(request.Input)
+	goruntime.KeepAlive(output)
+	return r.outputResultLocked("tick", result, len(output))
+}
+
+// Query executes an application-defined query into caller-owned output.
+func (r *Runner) Query(request cardinalruntime.QueryRequest, output []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := r.checkCallLocked("query", cardinalruntime.CapabilityQuery); err != nil {
+		return 0, err
+	}
+	result := C.cardinal_nativeaot_query(
+		r.library,
+		r.handle,
+		C.uint32_t(request.Kind),
+		bytePointer(request.Input),
+		C.size_t(len(request.Input)),
+		bytePointer(output),
+		C.size_t(len(output)),
+	)
+	goruntime.KeepAlive(request.Input)
+	goruntime.KeepAlive(output)
+	return r.outputResultLocked("query", result, len(output))
+}
+
+// Snapshot writes this handle's state into caller-owned output.
+func (r *Runner) Snapshot(output []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := r.checkCallLocked("snapshot", cardinalruntime.CapabilitySnapshot); err != nil {
+		return 0, err
+	}
+	result := C.cardinal_nativeaot_snapshot(
+		r.library,
+		r.handle,
+		bytePointer(output),
+		C.size_t(len(output)),
+	)
+	goruntime.KeepAlive(output)
+	return r.outputResultLocked("snapshot", result, len(output))
+}
+
+// Restore replaces this handle's state from a borrowed snapshot.
+func (r *Runner) Restore(snapshot []byte) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if err := r.checkCallLocked("restore", cardinalruntime.CapabilityRestore); err != nil {
+		return err
+	}
+	status := C.cardinal_nativeaot_restore(
+		r.library,
+		r.handle,
+		bytePointer(snapshot),
+		C.size_t(len(snapshot)),
+	)
+	goruntime.KeepAlive(snapshot)
+	return r.statusErrorLocked("restore", status)
+}
+
+// Close destroys the module handle once. The shared library stays loaded.
+func (r *Runner) Close() error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.closed {
+		return nil
+	}
+
+	// A failing destroy no longer has a valid handle-bound error slot.
+	goruntime.LockOSThread()
+	defer goruntime.UnlockOSThread()
+
+	status := C.cardinal_nativeaot_destroy(r.library, r.handle)
+	var err error
+	if status != C.CARDINAL_RUNTIME_STATUS_SUCCESS {
+		err = r.statusErrorLocked("destroy", status)
+	}
+
+	library := r.library
+	r.closed = true
+	r.handle = 0
+	r.library = nil
+	C.cardinal_nativeaot_library_forget(library)
+	return err
+}
+
+func (r *Runner) loadContract() (cardinalruntime.Contract, error) {
+	var raw C.cardinal_runtime_contract_v1
+	status := C.cardinal_nativeaot_get_contract(r.library, &raw)
+	if status != C.CARDINAL_RUNTIME_STATUS_SUCCESS {
+		return cardinalruntime.Contract{}, r.statusErrorLocked("get contract", status)
+	}
+
+	if uint32(raw.abi_version) != cardinalruntime.ABIVersion {
+		return cardinalruntime.Contract{}, fmt.Errorf(
+			"get contract: %w: module=%d host=%d",
+			cardinalruntime.ErrABIMismatch,
+			uint32(raw.abi_version),
+			cardinalruntime.ABIVersion,
+		)
+	}
+	expectedSize := uint32(C.sizeof_cardinal_runtime_contract_v1)
+	if uint32(raw.struct_size) != expectedSize {
+		return cardinalruntime.Contract{}, fmt.Errorf(
+			"get contract: %w: contract size=%d expected=%d",
+			cardinalruntime.ErrABIMismatch,
+			uint32(raw.struct_size),
+			expectedSize,
+		)
+	}
+	for index, value := range raw.reserved {
+		if value != 0 {
+			return cardinalruntime.Contract{}, fmt.Errorf(
+				"get contract: %w: reserved[%d]=%d expected=0",
+				cardinalruntime.ErrABIMismatch,
+				index,
+				uint64(value),
+			)
+		}
+	}
+
+	name, terminated := fixedCString(unsafe.Pointer(&raw.name[0]), len(raw.name))
+	if !terminated {
+		return cardinalruntime.Contract{}, fmt.Errorf(
+			"get contract: %w: name is not NUL-terminated",
+			cardinalruntime.ErrABIMismatch,
+		)
+	}
+	version, terminated := fixedCString(unsafe.Pointer(&raw.version[0]), len(raw.version))
+	if !terminated {
+		return cardinalruntime.Contract{}, fmt.Errorf(
+			"get contract: %w: version is not NUL-terminated",
+			cardinalruntime.ErrABIMismatch,
+		)
+	}
+
+	contract := cardinalruntime.Contract{
+		ABIVersion:   uint32(raw.abi_version),
+		Capabilities: cardinalruntime.Capabilities(raw.capabilities),
+		Name:         name,
+		Version:      version,
+	}
+	copy(
+		contract.SchemaHash[:],
+		unsafe.Slice((*byte)(unsafe.Pointer(&raw.schema_hash[0])), len(contract.SchemaHash)),
+	)
+	return contract, nil
+}
+
+func (r *Runner) checkCallLocked(
+	operation string,
+	capability cardinalruntime.Capabilities,
+) error {
+	if r.closed {
+		return fmt.Errorf("%s: %w", operation, cardinalruntime.ErrClosed)
+	}
+	if !r.contract.Supports(capability) {
+		return fmt.Errorf("%s: %w", operation, cardinalruntime.ErrUnsupported)
+	}
+	return nil
+}
+
+func (r *Runner) outputResultLocked(
+	operation string,
+	result C.cardinal_nativeaot_call_result_v1,
+	provided int,
+) (int, error) {
+	outputLen, valid := sizeToInt(result.output_len)
+	if !valid {
+		return 0, fmt.Errorf(
+			"%s: %w: module reported an output length too large for this host",
+			operation,
+			cardinalruntime.ErrExecutionFailed,
+		)
+	}
+
+	switch result.status {
+	case C.CARDINAL_RUNTIME_STATUS_SUCCESS:
+		if outputLen > provided {
+			return 0, fmt.Errorf(
+				"%s: %w: module reported %d bytes written into capacity %d",
+				operation,
+				cardinalruntime.ErrExecutionFailed,
+				outputLen,
+				provided,
+			)
+		}
+		return outputLen, nil
+	case C.CARDINAL_RUNTIME_STATUS_BUFFER_TOO_SMALL:
+		if outputLen <= provided {
+			return 0, fmt.Errorf(
+				"%s: %w: module reported required capacity %d for capacity %d",
+				operation,
+				cardinalruntime.ErrExecutionFailed,
+				outputLen,
+				provided,
+			)
+		}
+		return 0, &cardinalruntime.BufferSizeError{
+			Operation: operation,
+			Required:  outputLen,
+			Provided:  provided,
+		}
+	default:
+		return 0, r.statusErrorLocked(operation, result.status)
+	}
+}
+
+func (r *Runner) statusErrorLocked(operation string, status C.int32_t) error {
+	if status == C.CARDINAL_RUNTIME_STATUS_SUCCESS {
+		return nil
+	}
+
+	var base error
+	switch status {
+	case C.CARDINAL_RUNTIME_STATUS_BUFFER_TOO_SMALL:
+		base = cardinalruntime.ErrBufferTooSmall
+	case C.CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT:
+		base = cardinalruntime.ErrInvalidArgument
+	case C.CARDINAL_RUNTIME_STATUS_INVALID_HANDLE:
+		base = cardinalruntime.ErrInvalidHandle
+	case C.CARDINAL_RUNTIME_STATUS_INVALID_STATE:
+		base = cardinalruntime.ErrInvalidState
+	case C.CARDINAL_RUNTIME_STATUS_UNSUPPORTED:
+		base = cardinalruntime.ErrUnsupported
+	case C.CARDINAL_RUNTIME_STATUS_EXECUTION_FAILED:
+		base = cardinalruntime.ErrExecutionFailed
+	case C.CARDINAL_RUNTIME_STATUS_ABI_MISMATCH:
+		base = cardinalruntime.ErrABIMismatch
+	default:
+		base = cardinalruntime.ErrExecutionFailed
+	}
+
+	message := r.lastErrorLocked()
+	if message == "" {
+		return fmt.Errorf("%s: %w (status %d)", operation, base, int32(status))
+	}
+	return fmt.Errorf("%s: %w: %s", operation, base, message)
+}
+
+func (r *Runner) lastErrorLocked() string {
+	var local [512]byte
+	result := C.cardinal_nativeaot_last_error(
+		r.library,
+		r.handle,
+		bytePointer(local[:]),
+		C.size_t(len(local)),
+	)
+	goruntime.KeepAlive(local)
+
+	switch result.status {
+	case C.CARDINAL_RUNTIME_STATUS_SUCCESS:
+		length, valid := sizeToInt(result.output_len)
+		if !valid || length > len(local) {
+			return ""
+		}
+		return string(local[:length])
+	case C.CARDINAL_RUNTIME_STATUS_BUFFER_TOO_SMALL:
+		required, valid := sizeToInt(result.output_len)
+		if !valid || required <= len(local) || required > maxLastErrorSize {
+			return ""
+		}
+		buffer := make([]byte, required)
+		result = C.cardinal_nativeaot_last_error(
+			r.library,
+			r.handle,
+			bytePointer(buffer),
+			C.size_t(len(buffer)),
+		)
+		goruntime.KeepAlive(buffer)
+		length, valid := sizeToInt(result.output_len)
+		if result.status != C.CARDINAL_RUNTIME_STATUS_SUCCESS ||
+			!valid ||
+			length > len(buffer) {
+			return ""
+		}
+		return string(buffer[:length])
+	default:
+		return ""
+	}
+}
+
+func bytePointer(data []byte) *C.uint8_t {
+	if len(data) == 0 {
+		return nil
+	}
+	return (*C.uint8_t)(unsafe.Pointer(unsafe.SliceData(data)))
+}
+
+func fixedCString(pointer unsafe.Pointer, capacity int) (string, bool) {
+	data := unsafe.Slice((*byte)(pointer), capacity)
+	terminator := bytes.IndexByte(data, 0)
+	if terminator < 0 {
+		return "", false
+	}
+	return string(data[:terminator]), true
+}
+
+func sizeToInt(value C.size_t) (int, bool) {
+	const maxInt = int(^uint(0) >> 1)
+	if uint64(value) > uint64(maxInt) {
+		return 0, false
+	}
+	return int(value), true
+}

--- a/pkg/cardinal/runtime/nativeaot/loader_posix.c
+++ b/pkg/cardinal/runtime/nativeaot/loader_posix.c
@@ -1,0 +1,342 @@
+//go:build cgo && (linux || darwin)
+
+#include "loader_unix.h"
+
+#include <dlfcn.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+typedef int32_t (*get_contract_fn)(cardinal_runtime_contract_v1 *);
+typedef int32_t (*create_fn)(
+    const uint8_t *,
+    size_t,
+    cardinal_runtime_handle_v1 *);
+typedef int32_t (*initialize_fn)(
+    cardinal_runtime_handle_v1,
+    const uint8_t *,
+    size_t);
+typedef int32_t (*tick_fn)(
+    cardinal_runtime_handle_v1,
+    uint64_t,
+    uint64_t,
+    const uint8_t *,
+    size_t,
+    uint8_t *,
+    size_t,
+    size_t *);
+typedef int32_t (*query_fn)(
+    cardinal_runtime_handle_v1,
+    uint32_t,
+    const uint8_t *,
+    size_t,
+    uint8_t *,
+    size_t,
+    size_t *);
+typedef int32_t (*snapshot_fn)(
+    cardinal_runtime_handle_v1,
+    uint8_t *,
+    size_t,
+    size_t *);
+typedef int32_t (*restore_fn)(
+    cardinal_runtime_handle_v1,
+    const uint8_t *,
+    size_t);
+typedef int32_t (*last_error_fn)(
+    cardinal_runtime_handle_v1,
+    uint8_t *,
+    size_t,
+    size_t *);
+typedef int32_t (*destroy_fn)(cardinal_runtime_handle_v1);
+
+struct cardinal_nativeaot_library_v1 {
+    get_contract_fn get_contract;
+    create_fn create;
+    initialize_fn initialize;
+    tick_fn tick;
+    query_fn query;
+    snapshot_fn snapshot;
+    restore_fn restore;
+    last_error_fn last_error;
+    destroy_fn destroy;
+};
+
+static void copy_error(char *output, size_t output_capacity, const char *message) {
+    if (output == NULL || output_capacity == 0) {
+        return;
+    }
+    if (message == NULL) {
+        message = "unknown dynamic loader error";
+    }
+    (void)snprintf(output, output_capacity, "%s", message);
+}
+
+static void *load_symbol(
+    void *dl_handle,
+    const char *name,
+    char *error,
+    size_t error_capacity) {
+    (void)dlerror();
+    void *symbol = dlsym(dl_handle, name);
+    const char *dl_error = dlerror();
+    if (dl_error != NULL) {
+        copy_error(error, error_capacity, dl_error);
+        return NULL;
+    }
+    return symbol;
+}
+
+#define LOAD_SYMBOL(library, dl_handle, field, symbol_name, error, error_capacity) \
+    do {                                                                            \
+        void *symbol_pointer = load_symbol(                                         \
+            (dl_handle), (symbol_name), (error), (error_capacity));                 \
+        if (symbol_pointer == NULL) {                                               \
+            free(library);                                                          \
+            return NULL;                                                            \
+        }                                                                           \
+        memcpy(&(library)->field, &symbol_pointer, sizeof(symbol_pointer));         \
+    } while (0)
+
+cardinal_nativeaot_library_v1 *cardinal_nativeaot_library_open(
+    const char *path,
+    char *error,
+    size_t error_capacity) {
+    if (path == NULL || path[0] == '\0') {
+        copy_error(error, error_capacity, "shared library path is empty");
+        return NULL;
+    }
+
+    void *dl_handle = dlopen(path, RTLD_NOW | RTLD_LOCAL);
+    if (dl_handle == NULL) {
+        copy_error(error, error_capacity, dlerror());
+        return NULL;
+    }
+
+    cardinal_nativeaot_library_v1 *library =
+        calloc(1, sizeof(cardinal_nativeaot_library_v1));
+    if (library == NULL) {
+        /*
+         * Do not dlclose even on setup failure. NativeAOT modules are
+         * process-lifetime once loaded.
+         */
+        copy_error(error, error_capacity, "allocating loader dispatch table failed");
+        return NULL;
+    }
+
+    LOAD_SYMBOL(
+        library,
+        dl_handle,
+        get_contract,
+        "cardinal_runtime_v1_get_contract",
+        error,
+        error_capacity);
+    LOAD_SYMBOL(
+        library,
+        dl_handle,
+        create,
+        "cardinal_runtime_v1_create",
+        error,
+        error_capacity);
+    LOAD_SYMBOL(
+        library,
+        dl_handle,
+        initialize,
+        "cardinal_runtime_v1_initialize",
+        error,
+        error_capacity);
+    LOAD_SYMBOL(
+        library,
+        dl_handle,
+        tick,
+        "cardinal_runtime_v1_tick",
+        error,
+        error_capacity);
+    LOAD_SYMBOL(
+        library,
+        dl_handle,
+        query,
+        "cardinal_runtime_v1_query",
+        error,
+        error_capacity);
+    LOAD_SYMBOL(
+        library,
+        dl_handle,
+        snapshot,
+        "cardinal_runtime_v1_snapshot",
+        error,
+        error_capacity);
+    LOAD_SYMBOL(
+        library,
+        dl_handle,
+        restore,
+        "cardinal_runtime_v1_restore",
+        error,
+        error_capacity);
+    LOAD_SYMBOL(
+        library,
+        dl_handle,
+        last_error,
+        "cardinal_runtime_v1_last_error",
+        error,
+        error_capacity);
+    LOAD_SYMBOL(
+        library,
+        dl_handle,
+        destroy,
+        "cardinal_runtime_v1_destroy",
+        error,
+        error_capacity);
+
+    return library;
+}
+
+void cardinal_nativeaot_library_forget(cardinal_nativeaot_library_v1 *library) {
+    /*
+     * Deliberately no dlclose. NativeAOT does not support unloading. Only the
+     * dispatch table allocated by this loader is released.
+     */
+    free(library);
+}
+
+int32_t cardinal_nativeaot_get_contract(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_contract_v1 *contract) {
+    if (library == NULL || contract == NULL) {
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+    return library->get_contract(contract);
+}
+
+cardinal_nativeaot_create_result_v1 cardinal_nativeaot_create(
+    cardinal_nativeaot_library_v1 *library,
+    const uint8_t *config,
+    size_t config_len) {
+    cardinal_nativeaot_create_result_v1 result = {
+        .status = CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT,
+        .handle = 0,
+    };
+    if (library == NULL) {
+        return result;
+    }
+    result.status = library->create(config, config_len, &result.handle);
+    return result;
+}
+
+int32_t cardinal_nativeaot_initialize(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    const uint8_t *snapshot,
+    size_t snapshot_len) {
+    if (library == NULL) {
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+    return library->initialize(handle, snapshot, snapshot_len);
+}
+
+cardinal_nativeaot_call_result_v1 cardinal_nativeaot_tick(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    uint64_t tick,
+    uint64_t fixed_delta_ns,
+    const uint8_t *input,
+    size_t input_len,
+    uint8_t *output,
+    size_t output_capacity) {
+    cardinal_nativeaot_call_result_v1 result = {
+        .status = CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT,
+        .output_len = 0,
+    };
+    if (library == NULL) {
+        return result;
+    }
+    result.status = library->tick(
+        handle,
+        tick,
+        fixed_delta_ns,
+        input,
+        input_len,
+        output,
+        output_capacity,
+        &result.output_len);
+    return result;
+}
+
+cardinal_nativeaot_call_result_v1 cardinal_nativeaot_query(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    uint32_t kind,
+    const uint8_t *input,
+    size_t input_len,
+    uint8_t *output,
+    size_t output_capacity) {
+    cardinal_nativeaot_call_result_v1 result = {
+        .status = CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT,
+        .output_len = 0,
+    };
+    if (library == NULL) {
+        return result;
+    }
+    result.status = library->query(
+        handle,
+        kind,
+        input,
+        input_len,
+        output,
+        output_capacity,
+        &result.output_len);
+    return result;
+}
+
+cardinal_nativeaot_call_result_v1 cardinal_nativeaot_snapshot(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    uint8_t *output,
+    size_t output_capacity) {
+    cardinal_nativeaot_call_result_v1 result = {
+        .status = CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT,
+        .output_len = 0,
+    };
+    if (library == NULL) {
+        return result;
+    }
+    result.status =
+        library->snapshot(handle, output, output_capacity, &result.output_len);
+    return result;
+}
+
+int32_t cardinal_nativeaot_restore(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    const uint8_t *snapshot,
+    size_t snapshot_len) {
+    if (library == NULL) {
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+    return library->restore(handle, snapshot, snapshot_len);
+}
+
+cardinal_nativeaot_call_result_v1 cardinal_nativeaot_last_error(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    uint8_t *output,
+    size_t output_capacity) {
+    cardinal_nativeaot_call_result_v1 result = {
+        .status = CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT,
+        .output_len = 0,
+    };
+    if (library == NULL) {
+        return result;
+    }
+    result.status =
+        library->last_error(handle, output, output_capacity, &result.output_len);
+    return result;
+}
+
+int32_t cardinal_nativeaot_destroy(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle) {
+    if (library == NULL) {
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+    return library->destroy(handle);
+}

--- a/pkg/cardinal/runtime/nativeaot/loader_stub.go
+++ b/pkg/cardinal/runtime/nativeaot/loader_stub.go
@@ -1,0 +1,53 @@
+//go:build !cgo || (!linux && !darwin)
+
+package nativeaot
+
+import cardinalruntime "github.com/argus-labs/world-engine/pkg/cardinal/runtime"
+
+// Runner is unavailable when cgo or dlopen support is absent.
+type Runner struct{}
+
+var _ cardinalruntime.Runner = (*Runner)(nil)
+
+// Open reports ErrUnavailable in builds without cgo and dlopen support.
+func Open(string, []byte) (*Runner, error) {
+	return nil, ErrUnavailable
+}
+
+// OpenValidated reports ErrUnavailable in builds without cgo and dlopen
+// support.
+func OpenValidated(
+	string,
+	[]byte,
+	cardinalruntime.ContractRequirement,
+) (*Runner, error) {
+	return nil, ErrUnavailable
+}
+
+func (*Runner) Contract() cardinalruntime.Contract {
+	return cardinalruntime.Contract{}
+}
+
+func (*Runner) Initialize(cardinalruntime.InitRequest) error {
+	return ErrUnavailable
+}
+
+func (*Runner) Tick(cardinalruntime.TickRequest, []byte) (int, error) {
+	return 0, ErrUnavailable
+}
+
+func (*Runner) Query(cardinalruntime.QueryRequest, []byte) (int, error) {
+	return 0, ErrUnavailable
+}
+
+func (*Runner) Snapshot([]byte) (int, error) {
+	return 0, ErrUnavailable
+}
+
+func (*Runner) Restore([]byte) error {
+	return ErrUnavailable
+}
+
+func (*Runner) Close() error {
+	return nil
+}

--- a/pkg/cardinal/runtime/nativeaot/loader_test.go
+++ b/pkg/cardinal/runtime/nativeaot/loader_test.go
@@ -1,0 +1,388 @@
+//go:build cgo && (linux || darwin)
+
+package nativeaot_test
+
+import (
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+	"sync"
+	"testing"
+
+	cardinalruntime "github.com/argus-labs/world-engine/pkg/cardinal/runtime"
+	"github.com/argus-labs/world-engine/pkg/cardinal/runtime/nativeaot"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var (
+	fixtureLibrary              string
+	badABIFixtureLibrary        string
+	badSizeFixtureLibrary       string
+	badReservedFixtureLibraries [4]string
+)
+
+func TestMain(m *testing.M) {
+	tempDirectory, err := os.MkdirTemp("", "cardinal-nativeaot-test-*")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "create fixture directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	fixtureLibrary, err = compileFixture(tempDirectory, "fixture", nil)
+	if err == nil {
+		badABIFixtureLibrary, err = compileFixture(
+			tempDirectory,
+			"fixture-bad-abi",
+			[]string{"-DFIXTURE_BAD_ABI=1"},
+		)
+	}
+	if err == nil {
+		badSizeFixtureLibrary, err = compileFixture(
+			tempDirectory,
+			"fixture-bad-size",
+			[]string{"-DFIXTURE_BAD_SIZE=1"},
+		)
+	}
+	for index := range badReservedFixtureLibraries {
+		if err != nil {
+			break
+		}
+		badReservedFixtureLibraries[index], err = compileFixture(
+			tempDirectory,
+			fmt.Sprintf("fixture-bad-reserved-%d", index),
+			[]string{fmt.Sprintf("-DFIXTURE_BAD_RESERVED_INDEX=%d", index)},
+		)
+	}
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "compile NativeAOT C fixture: %v\n", err)
+		_ = os.RemoveAll(tempDirectory)
+		os.Exit(1)
+	}
+
+	exitCode := m.Run()
+	_ = os.RemoveAll(tempDirectory)
+	os.Exit(exitCode)
+}
+
+func TestRunnerLifecycle(t *testing.T) {
+	runner := openFixture(t, []byte("config"))
+
+	require.NoError(t, runner.Initialize(cardinalruntime.InitRequest{
+		Snapshot: []byte("fresh"),
+	}))
+
+	input := []byte{0xCA, 0xFE, 0x01}
+	output := make([]byte, 64)
+	written, err := runner.Tick(cardinalruntime.TickRequest{
+		Tick:         42,
+		FixedDeltaNS: 50_000_000,
+		Input:        input,
+	}, output)
+	require.NoError(t, err)
+	require.Equal(t, 16+len(input), written)
+	assert.Equal(t, uint64(42), binary.LittleEndian.Uint64(output[0:8]))
+	assert.Equal(t, uint64(50_000_000), binary.LittleEndian.Uint64(output[8:16]))
+	assert.Equal(t, input, output[16:written])
+
+	queryInput := []byte("query")
+	written, err = runner.Query(cardinalruntime.QueryRequest{
+		Kind:  7,
+		Input: queryInput,
+	}, output)
+	require.NoError(t, err)
+	require.Equal(t, 4+len(queryInput), written)
+	assert.Equal(t, uint32(7), binary.LittleEndian.Uint32(output[0:4]))
+	assert.Equal(t, queryInput, output[4:written])
+
+	snapshot := make([]byte, 16)
+	written, err = runner.Snapshot(snapshot)
+	require.NoError(t, err)
+	require.Equal(t, len(snapshot), written)
+
+	restored := openFixture(t, nil)
+	require.NoError(t, restored.Restore(snapshot))
+	restoredSnapshot := make([]byte, len(snapshot))
+	written, err = restored.Snapshot(restoredSnapshot)
+	require.NoError(t, err)
+	assert.Equal(t, snapshot, restoredSnapshot[:written])
+
+	require.NoError(t, runner.Close())
+	require.NoError(t, runner.Close())
+	_, err = runner.Tick(cardinalruntime.TickRequest{}, output)
+	require.ErrorIs(t, err, cardinalruntime.ErrClosed)
+}
+
+func TestRunnerContract(t *testing.T) {
+	runner := openFixture(t, nil)
+	contract := runner.Contract()
+
+	assert.Equal(t, cardinalruntime.ABIVersion, contract.ABIVersion)
+	assert.Equal(t, "nativeaot-fixture", contract.Name)
+	assert.Equal(t, "1.2.3", contract.Version)
+	assert.True(t, contract.Supports(
+		cardinalruntime.CapabilityInitialize|
+			cardinalruntime.CapabilityTick|
+			cardinalruntime.CapabilityQuery|
+			cardinalruntime.CapabilitySnapshot|
+			cardinalruntime.CapabilityRestore,
+	))
+	for index, value := range contract.SchemaHash {
+		assert.Equal(t, byte(index), value)
+	}
+}
+
+func TestOpenRejectsABIMismatch(t *testing.T) {
+	runner, err := nativeaot.Open(badABIFixtureLibrary, nil)
+
+	assert.Nil(t, runner)
+	require.ErrorIs(t, err, cardinalruntime.ErrABIMismatch)
+	require.ErrorContains(t, err, "module=2 host=1")
+}
+
+func TestOpenRejectsExtendedV1Contract(t *testing.T) {
+	runner, err := nativeaot.Open(badSizeFixtureLibrary, nil)
+
+	assert.Nil(t, runner)
+	require.ErrorIs(t, err, cardinalruntime.ErrABIMismatch)
+	require.ErrorContains(t, err, "contract size=184 expected=176")
+}
+
+func TestOpenRejectsNonzeroReservedContractWordsBeforeCreate(t *testing.T) {
+	for index, library := range badReservedFixtureLibraries {
+		t.Run(fmt.Sprintf("word_%d", index), func(t *testing.T) {
+			runner, err := nativeaot.Open(library, []byte("fail-create"))
+
+			assert.Nil(t, runner)
+			require.ErrorIs(t, err, cardinalruntime.ErrABIMismatch)
+			require.EqualError(
+				t,
+				err,
+				fmt.Sprintf(
+					"get contract: runtime ABI mismatch: reserved[%d]=1 expected=0",
+					index,
+				),
+			)
+		})
+	}
+}
+
+func TestOpenValidatedRejectsContractBeforeCreate(t *testing.T) {
+	requirement := fixtureContractRequirement()
+	requirement.Version = "9.9.9"
+
+	runner, err := nativeaot.OpenValidated(
+		fixtureLibrary,
+		[]byte("fail-create"),
+		requirement,
+	)
+
+	assert.Nil(t, runner)
+	require.ErrorIs(t, err, cardinalruntime.ErrContractMismatch)
+	require.ErrorContains(t, err, `module version "1.2.3", want "9.9.9"`)
+	assert.NotContains(t, err.Error(), "fixture create failure")
+}
+
+func TestOpenValidatedAcceptsMatchingContract(t *testing.T) {
+	runner, err := nativeaot.OpenValidated(
+		fixtureLibrary,
+		nil,
+		fixtureContractRequirement(),
+	)
+
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, runner.Close())
+	})
+	assert.Equal(t, "nativeaot-fixture", runner.Contract().Name)
+}
+
+func TestRunnerTranslatesModuleErrors(t *testing.T) {
+	runner, err := nativeaot.Open(fixtureLibrary, []byte("fail-create"))
+	assert.Nil(t, runner)
+	require.ErrorIs(t, err, cardinalruntime.ErrExecutionFailed)
+	require.ErrorContains(t, err, "fixture create failure")
+
+	runner = openFixture(t, nil)
+	_, err = runner.Tick(cardinalruntime.TickRequest{}, make([]byte, 32))
+	require.ErrorIs(t, err, cardinalruntime.ErrInvalidState)
+	require.ErrorContains(t, err, "fixture is not initialized")
+
+	require.NoError(t, runner.Initialize(cardinalruntime.InitRequest{}))
+	_, err = runner.Query(
+		cardinalruntime.QueryRequest{Kind: ^uint32(0)},
+		make([]byte, 32),
+	)
+	require.ErrorIs(t, err, cardinalruntime.ErrExecutionFailed)
+	require.ErrorContains(t, err, "fixture query failure")
+
+	err = runner.Restore([]byte("bad"))
+	require.ErrorIs(t, err, cardinalruntime.ErrInvalidArgument)
+	require.ErrorContains(t, err, "fixture snapshot must be 16 bytes")
+}
+
+func TestRunnerReportsRequiredBufferWithoutWriting(t *testing.T) {
+	runner := openFixture(t, nil)
+	require.NoError(t, runner.Initialize(cardinalruntime.InitRequest{}))
+
+	output := []byte{0xA5, 0xA5, 0xA5, 0xA5}
+	written, err := runner.Tick(cardinalruntime.TickRequest{
+		Tick:         1,
+		FixedDeltaNS: 2,
+		Input:        []byte{3, 4, 5},
+	}, output)
+
+	assert.Zero(t, written)
+	require.ErrorIs(t, err, cardinalruntime.ErrBufferTooSmall)
+	var sizeError *cardinalruntime.BufferSizeError
+	require.True(t, errors.As(err, &sizeError))
+	assert.Equal(t, 19, sizeError.Required)
+	assert.Equal(t, len(output), sizeError.Provided)
+	assert.Equal(t, []byte{0xA5, 0xA5, 0xA5, 0xA5}, output)
+
+	written, err = runner.Snapshot(nil)
+	assert.Zero(t, written)
+	require.ErrorIs(t, err, cardinalruntime.ErrBufferTooSmall)
+	require.True(t, errors.As(err, &sizeError))
+	assert.Equal(t, 16, sizeError.Required)
+	assert.Zero(t, sizeError.Provided)
+}
+
+func TestRunnerSerializesCalls(t *testing.T) {
+	runner := openFixture(t, nil)
+	require.NoError(t, runner.Initialize(cardinalruntime.InitRequest{}))
+
+	const callCount = 16
+	start := make(chan struct{})
+	errors := make(chan error, callCount)
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(callCount)
+	for range callCount {
+		go func() {
+			defer waitGroup.Done()
+			<-start
+			_, err := runner.Query(
+				cardinalruntime.QueryRequest{Kind: 77},
+				make([]byte, 4),
+			)
+			errors <- err
+		}()
+	}
+
+	close(start)
+	waitGroup.Wait()
+	close(errors)
+	for err := range errors {
+		require.NoError(t, err)
+	}
+}
+
+func BenchmarkRunnerTick(b *testing.B) {
+	runner, err := nativeaot.Open(fixtureLibrary, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if closeErr := runner.Close(); closeErr != nil {
+			b.Error(closeErr)
+		}
+	}()
+	if err = runner.Initialize(cardinalruntime.InitRequest{}); err != nil {
+		b.Fatal(err)
+	}
+
+	request := cardinalruntime.TickRequest{
+		FixedDeltaNS: 50_000_000,
+		Input:        []byte{1, 2, 3, 4},
+	}
+	output := make([]byte, 20)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(request.Input)))
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		request.Tick = uint64(index)
+		written, tickErr := runner.Tick(request, output)
+		if tickErr != nil {
+			b.Fatal(tickErr)
+		}
+		if written != len(output) {
+			b.Fatalf("tick wrote %d bytes, want %d", written, len(output))
+		}
+	}
+}
+
+func openFixture(t testing.TB, config []byte) *nativeaot.Runner {
+	t.Helper()
+
+	runner, err := nativeaot.Open(fixtureLibrary, config)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, runner.Close())
+	})
+	return runner
+}
+
+func fixtureContractRequirement() cardinalruntime.ContractRequirement {
+	var schemaHash [32]byte
+	for index := range schemaHash {
+		schemaHash[index] = byte(index)
+	}
+	return cardinalruntime.ContractRequirement{
+		Name:       "nativeaot-fixture",
+		Version:    "1.2.3",
+		SchemaHash: schemaHash,
+		Capabilities: cardinalruntime.CapabilityInitialize |
+			cardinalruntime.CapabilityTick |
+			cardinalruntime.CapabilityQuery |
+			cardinalruntime.CapabilitySnapshot |
+			cardinalruntime.CapabilityRestore,
+	}
+}
+
+func compileFixture(
+	outputDirectory string,
+	name string,
+	extraArguments []string,
+) (string, error) {
+	workingDirectory, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+
+	extension := ".so"
+	linkArguments := []string{"-shared", "-fPIC"}
+	if goruntime.GOOS == "darwin" {
+		extension = ".dylib"
+		linkArguments = []string{"-dynamiclib"}
+	}
+	output := filepath.Join(outputDirectory, name+extension)
+
+	compiler := strings.Fields(os.Getenv("CC"))
+	if len(compiler) == 0 {
+		compiler = []string{"cc"}
+	}
+	arguments := append([]string{}, compiler[1:]...)
+	arguments = append(arguments, "-std=c11", "-O2", "-Wall", "-Wextra")
+	arguments = append(arguments, linkArguments...)
+	arguments = append(arguments, extraArguments...)
+	arguments = append(
+		arguments,
+		"-I"+filepath.Join(workingDirectory, "include"),
+		filepath.Join(workingDirectory, "testdata", "fixture.c"),
+		"-o",
+		output,
+	)
+
+	command := exec.Command(compiler[0], arguments...)
+	combinedOutput, err := command.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("%w\n%s", err, combinedOutput)
+	}
+	return output, nil
+}

--- a/pkg/cardinal/runtime/nativeaot/loader_unix.h
+++ b/pkg/cardinal/runtime/nativeaot/loader_unix.h
@@ -1,0 +1,85 @@
+#ifndef CARDINAL_NATIVEAOT_LOADER_UNIX_H
+#define CARDINAL_NATIVEAOT_LOADER_UNIX_H
+
+#include "include/cardinal_runtime_v1.h"
+
+typedef struct cardinal_nativeaot_library_v1 cardinal_nativeaot_library_v1;
+
+typedef struct cardinal_nativeaot_call_result_v1 {
+    int32_t status;
+    size_t output_len;
+} cardinal_nativeaot_call_result_v1;
+
+typedef struct cardinal_nativeaot_create_result_v1 {
+    int32_t status;
+    cardinal_runtime_handle_v1 handle;
+} cardinal_nativeaot_create_result_v1;
+
+cardinal_nativeaot_library_v1 *cardinal_nativeaot_library_open(
+    const char *path,
+    char *error,
+    size_t error_capacity);
+
+/*
+ * Frees only the loader dispatch table. The dlopen handle deliberately stays
+ * loaded for process lifetime because NativeAOT libraries cannot be unloaded.
+ */
+void cardinal_nativeaot_library_forget(cardinal_nativeaot_library_v1 *library);
+
+int32_t cardinal_nativeaot_get_contract(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_contract_v1 *contract);
+
+cardinal_nativeaot_create_result_v1 cardinal_nativeaot_create(
+    cardinal_nativeaot_library_v1 *library,
+    const uint8_t *config,
+    size_t config_len);
+
+int32_t cardinal_nativeaot_initialize(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    const uint8_t *snapshot,
+    size_t snapshot_len);
+
+cardinal_nativeaot_call_result_v1 cardinal_nativeaot_tick(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    uint64_t tick,
+    uint64_t fixed_delta_ns,
+    const uint8_t *input,
+    size_t input_len,
+    uint8_t *output,
+    size_t output_capacity);
+
+cardinal_nativeaot_call_result_v1 cardinal_nativeaot_query(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    uint32_t kind,
+    const uint8_t *input,
+    size_t input_len,
+    uint8_t *output,
+    size_t output_capacity);
+
+cardinal_nativeaot_call_result_v1 cardinal_nativeaot_snapshot(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    uint8_t *output,
+    size_t output_capacity);
+
+int32_t cardinal_nativeaot_restore(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    const uint8_t *snapshot,
+    size_t snapshot_len);
+
+cardinal_nativeaot_call_result_v1 cardinal_nativeaot_last_error(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle,
+    uint8_t *output,
+    size_t output_capacity);
+
+int32_t cardinal_nativeaot_destroy(
+    cardinal_nativeaot_library_v1 *library,
+    cardinal_runtime_handle_v1 handle);
+
+#endif

--- a/pkg/cardinal/runtime/nativeaot/nativeaot_integration_test.go
+++ b/pkg/cardinal/runtime/nativeaot/nativeaot_integration_test.go
@@ -1,0 +1,175 @@
+//go:build cgo && (linux || darwin)
+
+package nativeaot_test
+
+import (
+	"encoding/binary"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"testing"
+
+	cardinalruntime "github.com/argus-labs/world-engine/pkg/cardinal/runtime"
+	"github.com/argus-labs/world-engine/pkg/cardinal/runtime/nativeaot"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNativeAOTModule(t *testing.T) {
+	libraryPath := os.Getenv("CARDINAL_NATIVEAOT_TEST_LIBRARY")
+	if libraryPath == "" {
+		t.Skip("CARDINAL_NATIVEAOT_TEST_LIBRARY is not set")
+	}
+
+	runner, err := nativeaot.Open(libraryPath, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, runner.Close())
+	})
+
+	contract := runner.Contract()
+	expectedName := os.Getenv("CARDINAL_NATIVEAOT_TEST_NAME")
+	if expectedName == "" {
+		expectedName = "counter-fixture"
+	}
+	assert.Equal(t, expectedName, contract.Name)
+	assert.Equal(t, "1.0.0", contract.Version)
+	assert.Equal(t, cardinalruntime.ABIVersion, contract.ABIVersion)
+	assert.True(t, contract.Supports(
+		cardinalruntime.CapabilityInitialize|
+			cardinalruntime.CapabilityTick|
+			cardinalruntime.CapabilityQuery|
+			cardinalruntime.CapabilitySnapshot|
+			cardinalruntime.CapabilityRestore,
+	))
+
+	require.NoError(t, runner.Initialize(cardinalruntime.InitRequest{}))
+
+	increment := make([]byte, 8)
+	binary.LittleEndian.PutUint64(increment, 5)
+	request := cardinalruntime.TickRequest{
+		Tick:         42,
+		FixedDeltaNS: 50_000_000,
+		Input:        increment,
+	}
+
+	undersized := []byte{0xA5, 0xA5, 0xA5, 0xA5}
+	written, err := runner.Tick(request, undersized)
+	require.ErrorIs(t, err, cardinalruntime.ErrBufferTooSmall)
+	assert.Zero(t, written)
+	assert.Equal(t, []byte{0xA5, 0xA5, 0xA5, 0xA5}, undersized)
+
+	output := make([]byte, 8)
+	written, err = runner.Tick(request, output)
+	require.NoError(t, err)
+	require.Equal(t, len(output), written)
+	assert.Equal(t, uint64(5), binary.LittleEndian.Uint64(output))
+
+	snapshot := make([]byte, 8)
+	written, err = runner.Snapshot(snapshot)
+	require.NoError(t, err)
+	require.Equal(t, len(snapshot), written)
+
+	restored, err := nativeaot.Open(libraryPath, nil)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, restored.Close())
+	})
+	require.NoError(t, restored.Restore(snapshot))
+
+	written, err = restored.Query(
+		cardinalruntime.QueryRequest{Kind: 1},
+		output,
+	)
+	require.NoError(t, err)
+	require.Equal(t, len(output), written)
+	assert.Equal(t, uint64(5), binary.LittleEndian.Uint64(output))
+}
+
+func TestNativeAOTConcurrentOpenErrors(t *testing.T) {
+	libraryPath := os.Getenv("CARDINAL_NATIVEAOT_TEST_LIBRARY")
+	if libraryPath == "" {
+		t.Skip("CARDINAL_NATIVEAOT_TEST_LIBRARY is not set")
+	}
+	if os.Getenv("CARDINAL_NATIVEAOT_TEST_NAME") != "" {
+		t.Skip("error fixture contract is specific to CounterModule")
+	}
+
+	const callCount = 28
+	start := make(chan struct{})
+	errorsChannel := make(chan error, callCount)
+	var waitGroup sync.WaitGroup
+	waitGroup.Add(callCount)
+
+	for index := range callCount {
+		configLength := index%7 + 1
+		go func() {
+			defer waitGroup.Done()
+			<-start
+
+			_, err := nativeaot.Open(libraryPath, make([]byte, configLength))
+			if err == nil {
+				errorsChannel <- fmt.Errorf("config length %d unexpectedly succeeded", configLength)
+				return
+			}
+			expected := fmt.Sprintf("received %d", configLength)
+			if !strings.Contains(err.Error(), expected) {
+				errorsChannel <- fmt.Errorf(
+					"config length %d received another call's diagnostic: %w",
+					configLength,
+					err,
+				)
+			}
+		}()
+	}
+
+	close(start)
+	waitGroup.Wait()
+	close(errorsChannel)
+	for err := range errorsChannel {
+		require.NoError(t, err)
+	}
+}
+
+func BenchmarkNativeAOTTick(b *testing.B) {
+	libraryPath := os.Getenv("CARDINAL_NATIVEAOT_TEST_LIBRARY")
+	if libraryPath == "" {
+		b.Skip("CARDINAL_NATIVEAOT_TEST_LIBRARY is not set")
+	}
+
+	runner, err := nativeaot.Open(libraryPath, nil)
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer func() {
+		if closeErr := runner.Close(); closeErr != nil {
+			b.Error(closeErr)
+		}
+	}()
+	if err = runner.Initialize(cardinalruntime.InitRequest{}); err != nil {
+		b.Fatal(err)
+	}
+
+	input := make([]byte, 8)
+	binary.LittleEndian.PutUint64(input, 1)
+	output := make([]byte, 8)
+	request := cardinalruntime.TickRequest{
+		FixedDeltaNS: 50_000_000,
+		Input:        input,
+	}
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(input)))
+	b.ResetTimer()
+	for index := 0; index < b.N; index++ {
+		request.Tick = uint64(index)
+		written, tickErr := runner.Tick(request, output)
+		if tickErr != nil {
+			b.Fatal(tickErr)
+		}
+		if written != len(output) {
+			b.Fatalf("tick wrote %d bytes, want %d", written, len(output))
+		}
+	}
+}

--- a/pkg/cardinal/runtime/nativeaot/testdata/fixture.c
+++ b/pkg/cardinal/runtime/nativeaot/testdata/fixture.c
@@ -1,0 +1,361 @@
+#define _POSIX_C_SOURCE 200809L
+
+#include "cardinal_runtime_v1.h"
+
+#include <stdbool.h>
+#include <stdatomic.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+
+#define FIXTURE_MAX_HANDLES 32
+#define FIXTURE_ERROR_CAPACITY 256
+
+typedef struct fixture_state {
+    bool used;
+    bool initialized;
+    uint64_t tick;
+    uint64_t fixed_delta_ns;
+    uint64_t config_hash;
+    char error[FIXTURE_ERROR_CAPACITY];
+} fixture_state;
+
+static fixture_state states[FIXTURE_MAX_HANDLES];
+static char global_error[FIXTURE_ERROR_CAPACITY];
+static atomic_int active_probe_queries;
+
+static void set_error(char *destination, const char *message) {
+    (void)snprintf(destination, FIXTURE_ERROR_CAPACITY, "%s", message);
+}
+
+static bool valid_input(const uint8_t *input, size_t input_len) {
+    return input_len == 0 || input != NULL;
+}
+
+static fixture_state *find_state(cardinal_runtime_handle_v1 handle) {
+    if (handle == 0 || handle > FIXTURE_MAX_HANDLES) {
+        return NULL;
+    }
+    fixture_state *state = &states[handle - 1];
+    return state->used ? state : NULL;
+}
+
+static uint64_t hash_bytes(const uint8_t *data, size_t data_len) {
+    uint64_t hash = UINT64_C(1469598103934665603);
+    for (size_t index = 0; index < data_len; index++) {
+        hash ^= data[index];
+        hash *= UINT64_C(1099511628211);
+    }
+    return hash;
+}
+
+static void write_uint32_le(uint8_t *output, uint32_t value) {
+    for (size_t index = 0; index < 4; index++) {
+        output[index] = (uint8_t)(value >> (index * 8));
+    }
+}
+
+static void write_uint64_le(uint8_t *output, uint64_t value) {
+    for (size_t index = 0; index < 8; index++) {
+        output[index] = (uint8_t)(value >> (index * 8));
+    }
+}
+
+static uint64_t read_uint64_le(const uint8_t *input) {
+    uint64_t value = 0;
+    for (size_t index = 0; index < 8; index++) {
+        value |= (uint64_t)input[index] << (index * 8);
+    }
+    return value;
+}
+
+static int32_t prepare_output(
+    uint8_t *output,
+    size_t output_capacity,
+    size_t required,
+    size_t *output_len) {
+    if (output_len == NULL) {
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+    *output_len = required;
+    if (output_capacity < required) {
+        return CARDINAL_RUNTIME_STATUS_BUFFER_TOO_SMALL;
+    }
+    if (required > 0 && output == NULL) {
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+    return CARDINAL_RUNTIME_STATUS_SUCCESS;
+}
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_get_contract(
+    cardinal_runtime_contract_v1 *contract) {
+    if (contract == NULL) {
+        set_error(global_error, "contract output is null");
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+
+    memset(contract, 0, sizeof(*contract));
+#ifdef FIXTURE_BAD_ABI
+    contract->abi_version = CARDINAL_RUNTIME_V1_ABI_VERSION + 1;
+#else
+    contract->abi_version = CARDINAL_RUNTIME_V1_ABI_VERSION;
+#endif
+#ifdef FIXTURE_BAD_SIZE
+    contract->struct_size = sizeof(*contract) + sizeof(uint64_t);
+#else
+    contract->struct_size = sizeof(*contract);
+#endif
+    contract->capabilities =
+        CARDINAL_RUNTIME_CAPABILITY_INITIALIZE |
+        CARDINAL_RUNTIME_CAPABILITY_TICK |
+        CARDINAL_RUNTIME_CAPABILITY_QUERY |
+        CARDINAL_RUNTIME_CAPABILITY_SNAPSHOT |
+        CARDINAL_RUNTIME_CAPABILITY_RESTORE;
+    for (size_t index = 0; index < CARDINAL_RUNTIME_V1_SCHEMA_HASH_SIZE; index++) {
+        contract->schema_hash[index] = (uint8_t)index;
+    }
+    (void)snprintf(contract->name, sizeof(contract->name), "%s", "nativeaot-fixture");
+    (void)snprintf(contract->version, sizeof(contract->version), "%s", "1.2.3");
+#ifdef FIXTURE_BAD_RESERVED_INDEX
+    contract->reserved[FIXTURE_BAD_RESERVED_INDEX] = UINT64_C(1);
+#endif
+    global_error[0] = '\0';
+    return CARDINAL_RUNTIME_STATUS_SUCCESS;
+}
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_create(
+    const uint8_t *config,
+    size_t config_len,
+    cardinal_runtime_handle_v1 *handle) {
+    if (handle == NULL || !valid_input(config, config_len)) {
+        set_error(global_error, "invalid create arguments");
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+    if (config_len == strlen("fail-create") &&
+        memcmp(config, "fail-create", config_len) == 0) {
+        set_error(global_error, "fixture create failure");
+        return CARDINAL_RUNTIME_STATUS_EXECUTION_FAILED;
+    }
+
+    for (size_t index = 0; index < FIXTURE_MAX_HANDLES; index++) {
+        if (!states[index].used) {
+            memset(&states[index], 0, sizeof(states[index]));
+            states[index].used = true;
+            states[index].config_hash = hash_bytes(config, config_len);
+            *handle = index + 1;
+            global_error[0] = '\0';
+            return CARDINAL_RUNTIME_STATUS_SUCCESS;
+        }
+    }
+
+    set_error(global_error, "fixture handle capacity reached");
+    return CARDINAL_RUNTIME_STATUS_EXECUTION_FAILED;
+}
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_initialize(
+    cardinal_runtime_handle_v1 handle,
+    const uint8_t *snapshot,
+    size_t snapshot_len) {
+    fixture_state *state = find_state(handle);
+    if (state == NULL) {
+        set_error(global_error, "fixture handle is invalid");
+        return CARDINAL_RUNTIME_STATUS_INVALID_HANDLE;
+    }
+    if (!valid_input(snapshot, snapshot_len)) {
+        set_error(state->error, "snapshot pointer is null");
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+    if (state->initialized) {
+        set_error(state->error, "fixture is already initialized");
+        return CARDINAL_RUNTIME_STATUS_INVALID_STATE;
+    }
+
+    if (snapshot_len == 16) {
+        state->tick = read_uint64_le(snapshot);
+        state->fixed_delta_ns = read_uint64_le(snapshot + 8);
+    }
+    state->initialized = true;
+    state->error[0] = '\0';
+    return CARDINAL_RUNTIME_STATUS_SUCCESS;
+}
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_tick(
+    cardinal_runtime_handle_v1 handle,
+    uint64_t tick,
+    uint64_t fixed_delta_ns,
+    const uint8_t *input,
+    size_t input_len,
+    uint8_t *output,
+    size_t output_capacity,
+    size_t *output_len) {
+    fixture_state *state = find_state(handle);
+    if (state == NULL) {
+        set_error(global_error, "fixture handle is invalid");
+        return CARDINAL_RUNTIME_STATUS_INVALID_HANDLE;
+    }
+    if (!state->initialized) {
+        set_error(state->error, "fixture is not initialized");
+        return CARDINAL_RUNTIME_STATUS_INVALID_STATE;
+    }
+    if (!valid_input(input, input_len)) {
+        set_error(state->error, "tick input pointer is null");
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+
+    size_t required = 16 + input_len;
+    int32_t status =
+        prepare_output(output, output_capacity, required, output_len);
+    if (status != CARDINAL_RUNTIME_STATUS_SUCCESS) {
+        return status;
+    }
+
+    state->tick = tick;
+    state->fixed_delta_ns = fixed_delta_ns;
+    write_uint64_le(output, tick);
+    write_uint64_le(output + 8, fixed_delta_ns);
+    if (input_len > 0) {
+        memcpy(output + 16, input, input_len);
+    }
+    state->error[0] = '\0';
+    return CARDINAL_RUNTIME_STATUS_SUCCESS;
+}
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_query(
+    cardinal_runtime_handle_v1 handle,
+    uint32_t kind,
+    const uint8_t *input,
+    size_t input_len,
+    uint8_t *output,
+    size_t output_capacity,
+    size_t *output_len) {
+    fixture_state *state = find_state(handle);
+    if (state == NULL) {
+        set_error(global_error, "fixture handle is invalid");
+        return CARDINAL_RUNTIME_STATUS_INVALID_HANDLE;
+    }
+    if (!state->initialized) {
+        set_error(state->error, "fixture is not initialized");
+        return CARDINAL_RUNTIME_STATUS_INVALID_STATE;
+    }
+    if (!valid_input(input, input_len)) {
+        set_error(state->error, "query input pointer is null");
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+    if (kind == UINT32_MAX) {
+        set_error(state->error, "fixture query failure");
+        return CARDINAL_RUNTIME_STATUS_EXECUTION_FAILED;
+    }
+    if (kind == 77) {
+        int previous =
+            atomic_fetch_add_explicit(&active_probe_queries, 1, memory_order_acq_rel);
+        if (previous != 0) {
+            (void)atomic_fetch_sub_explicit(
+                &active_probe_queries,
+                1,
+                memory_order_acq_rel);
+            set_error(state->error, "fixture observed concurrent calls");
+            return CARDINAL_RUNTIME_STATUS_EXECUTION_FAILED;
+        }
+        const struct timespec delay = {
+            .tv_sec = 0,
+            .tv_nsec = 2 * 1000 * 1000,
+        };
+        (void)nanosleep(&delay, NULL);
+        (void)atomic_fetch_sub_explicit(
+            &active_probe_queries,
+            1,
+            memory_order_acq_rel);
+    }
+
+    size_t required = 4 + input_len;
+    int32_t status =
+        prepare_output(output, output_capacity, required, output_len);
+    if (status != CARDINAL_RUNTIME_STATUS_SUCCESS) {
+        return status;
+    }
+
+    write_uint32_le(output, kind);
+    if (input_len > 0) {
+        memcpy(output + 4, input, input_len);
+    }
+    state->error[0] = '\0';
+    return CARDINAL_RUNTIME_STATUS_SUCCESS;
+}
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_snapshot(
+    cardinal_runtime_handle_v1 handle,
+    uint8_t *output,
+    size_t output_capacity,
+    size_t *output_len) {
+    fixture_state *state = find_state(handle);
+    if (state == NULL) {
+        set_error(global_error, "fixture handle is invalid");
+        return CARDINAL_RUNTIME_STATUS_INVALID_HANDLE;
+    }
+    if (!state->initialized) {
+        set_error(state->error, "fixture is not initialized");
+        return CARDINAL_RUNTIME_STATUS_INVALID_STATE;
+    }
+
+    int32_t status = prepare_output(output, output_capacity, 16, output_len);
+    if (status != CARDINAL_RUNTIME_STATUS_SUCCESS) {
+        return status;
+    }
+    write_uint64_le(output, state->tick);
+    write_uint64_le(output + 8, state->fixed_delta_ns);
+    state->error[0] = '\0';
+    return CARDINAL_RUNTIME_STATUS_SUCCESS;
+}
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_restore(
+    cardinal_runtime_handle_v1 handle,
+    const uint8_t *snapshot,
+    size_t snapshot_len) {
+    fixture_state *state = find_state(handle);
+    if (state == NULL) {
+        set_error(global_error, "fixture handle is invalid");
+        return CARDINAL_RUNTIME_STATUS_INVALID_HANDLE;
+    }
+    if (!valid_input(snapshot, snapshot_len) || snapshot_len != 16) {
+        set_error(state->error, "fixture snapshot must be 16 bytes");
+        return CARDINAL_RUNTIME_STATUS_INVALID_ARGUMENT;
+    }
+
+    state->tick = read_uint64_le(snapshot);
+    state->fixed_delta_ns = read_uint64_le(snapshot + 8);
+    state->initialized = true;
+    state->error[0] = '\0';
+    return CARDINAL_RUNTIME_STATUS_SUCCESS;
+}
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_last_error(
+    cardinal_runtime_handle_v1 handle,
+    uint8_t *output,
+    size_t output_capacity,
+    size_t *output_len) {
+    fixture_state *state = find_state(handle);
+    const char *message = state == NULL ? global_error : state->error;
+    size_t required = strlen(message);
+    int32_t status =
+        prepare_output(output, output_capacity, required, output_len);
+    if (status != CARDINAL_RUNTIME_STATUS_SUCCESS) {
+        return status;
+    }
+    if (required > 0) {
+        memcpy(output, message, required);
+    }
+    return CARDINAL_RUNTIME_STATUS_SUCCESS;
+}
+
+CARDINAL_RUNTIME_EXPORT int32_t cardinal_runtime_v1_destroy(
+    cardinal_runtime_handle_v1 handle) {
+    fixture_state *state = find_state(handle);
+    if (state == NULL) {
+        set_error(global_error, "fixture handle is invalid");
+        return CARDINAL_RUNTIME_STATUS_INVALID_HANDLE;
+    }
+    memset(state, 0, sizeof(*state));
+    global_error[0] = '\0';
+    return CARDINAL_RUNTIME_STATUS_SUCCESS;
+}

--- a/pkg/cardinal/runtime/runtime.go
+++ b/pkg/cardinal/runtime/runtime.go
@@ -1,0 +1,203 @@
+// Package runtime defines the transport-neutral boundary for running a
+// Cardinal simulation module.
+package runtime
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+)
+
+const ABIVersion uint32 = 1
+
+// Capabilities describes the operations implemented by a Runner.
+type Capabilities uint64
+
+const (
+	CapabilityInitialize Capabilities = 1 << iota
+	CapabilityTick
+	CapabilityQuery
+	CapabilitySnapshot
+	CapabilityRestore
+	// CapabilityStateless declares that calls do not depend on mutable
+	// per-handle simulation state.
+	CapabilityStateless
+)
+
+// Has reports whether all requested capabilities are present.
+func (c Capabilities) Has(requested Capabilities) bool {
+	return c&requested == requested
+}
+
+// Contract identifies a module and the operations and schema it implements.
+// SchemaHash is an opaque, module-defined compatibility fingerprint.
+type Contract struct {
+	ABIVersion   uint32
+	Capabilities Capabilities
+	SchemaHash   [32]byte
+	Name         string
+	Version      string
+}
+
+// Supports reports whether the contract implements all requested capabilities.
+func (c Contract) Supports(requested Capabilities) bool {
+	return c.Capabilities.Has(requested)
+}
+
+// ContractRequirement is validated before a runtime module instance is
+// created. Name, Version, and SchemaHash require exact matches; Capabilities
+// is the minimum capability set the module must support.
+type ContractRequirement struct {
+	Name         string
+	Version      string
+	SchemaHash   [32]byte
+	Capabilities Capabilities
+}
+
+// Validate rejects a module contract that cannot safely serve this caller.
+func (r ContractRequirement) Validate(contract Contract) error {
+	switch {
+	case contract.Name != r.Name:
+		return &ContractMismatchError{
+			Field:    "name",
+			Expected: r.Name,
+			Actual:   contract.Name,
+		}
+	case contract.Version != r.Version:
+		return &ContractMismatchError{
+			Field:    "version",
+			Expected: r.Version,
+			Actual:   contract.Version,
+		}
+	case !contract.Supports(r.Capabilities):
+		return &ContractMismatchError{
+			Field:    "capabilities",
+			Expected: r.Capabilities,
+			Actual:   contract.Capabilities,
+		}
+	case contract.SchemaHash != r.SchemaHash:
+		return &ContractMismatchError{
+			Field:    "schema_hash",
+			Expected: r.SchemaHash,
+			Actual:   contract.SchemaHash,
+		}
+	default:
+		return nil
+	}
+}
+
+// InitRequest supplies an optional snapshot to initialize a newly created
+// runner. The snapshot is borrowed for the duration of Initialize.
+type InitRequest struct {
+	Snapshot []byte
+}
+
+// TickRequest supplies one deterministic simulation step. Input is borrowed
+// for the duration of Tick.
+type TickRequest struct {
+	Tick         uint64
+	FixedDeltaNS uint64
+	Input        []byte
+}
+
+// QueryRequest supplies an application-defined query. Input is borrowed for
+// the duration of Query.
+type QueryRequest struct {
+	Kind  uint32
+	Input []byte
+}
+
+// Runner owns one isolated module instance.
+//
+// Tick, Query, and Snapshot write into caller-owned output buffers and return
+// the number of bytes written. Implementations return BufferSizeError when the
+// buffer is too small. Implementations must not retain request or output
+// buffers after a call returns. Callers that probe and retry after
+// BufferSizeError must prevent another operation from using the same Runner
+// between those calls.
+type Runner interface {
+	Contract() Contract
+	Initialize(InitRequest) error
+	Tick(TickRequest, []byte) (int, error)
+	Query(QueryRequest, []byte) (int, error)
+	Snapshot([]byte) (int, error)
+	Restore([]byte) error
+	Close() error
+}
+
+var (
+	ErrBufferTooSmall   = errors.New("runtime output buffer too small")
+	ErrInvalidArgument  = errors.New("runtime invalid argument")
+	ErrInvalidHandle    = errors.New("runtime invalid handle")
+	ErrInvalidState     = errors.New("runtime invalid state")
+	ErrUnsupported      = errors.New("runtime operation unsupported")
+	ErrExecutionFailed  = errors.New("runtime execution failed")
+	ErrABIMismatch      = errors.New("runtime ABI mismatch")
+	ErrContractMismatch = errors.New("runtime contract mismatch")
+	ErrClosed           = errors.New("runtime runner closed")
+)
+
+// ContractMismatchError identifies one incompatible module contract field.
+type ContractMismatchError struct {
+	Field    string
+	Expected any
+	Actual   any
+}
+
+func (e *ContractMismatchError) Error() string {
+	expected := formatContractValue(e.Expected)
+	actual := formatContractValue(e.Actual)
+
+	switch e.Field {
+	case "name":
+		return fmt.Sprintf("%s: module name %s, want %s", ErrContractMismatch, actual, expected)
+	case "version":
+		return fmt.Sprintf("%s: module version %s, want %s", ErrContractMismatch, actual, expected)
+	case "capabilities":
+		return fmt.Sprintf(
+			"%s: module capabilities %s lack required %s",
+			ErrContractMismatch,
+			actual,
+			expected,
+		)
+	case "schema_hash":
+		return fmt.Sprintf("%s: module schema hash %s, want %s", ErrContractMismatch, actual, expected)
+	default:
+		return fmt.Sprintf("%s: %s: got %s, want %s", ErrContractMismatch, e.Field, actual, expected)
+	}
+}
+
+// Unwrap makes ContractMismatchError match ErrContractMismatch with errors.Is.
+func (e *ContractMismatchError) Unwrap() error {
+	return ErrContractMismatch
+}
+
+func formatContractValue(value any) string {
+	switch value := value.(type) {
+	case string:
+		return strconv.Quote(value)
+	case Capabilities:
+		return fmt.Sprintf("0x%016x", uint64(value))
+	case [32]byte:
+		return fmt.Sprintf("%x", value)
+	default:
+		return fmt.Sprint(value)
+	}
+}
+
+// BufferSizeError reports the caller-owned output capacity required by a call.
+type BufferSizeError struct {
+	Operation string
+	Required  int
+	Provided  int
+}
+
+func (e *BufferSizeError) Error() string {
+	return e.Operation + ": output buffer too small: required " +
+		strconv.Itoa(e.Required) + " bytes, provided " + strconv.Itoa(e.Provided)
+}
+
+// Unwrap makes BufferSizeError match ErrBufferTooSmall with errors.Is.
+func (e *BufferSizeError) Unwrap() error {
+	return ErrBufferTooSmall
+}

--- a/pkg/cardinal/runtime/runtime_test.go
+++ b/pkg/cardinal/runtime/runtime_test.go
@@ -1,0 +1,128 @@
+package runtime_test
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	cardinalruntime "github.com/argus-labs/world-engine/pkg/cardinal/runtime"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCapabilities(t *testing.T) {
+	t.Parallel()
+
+	capabilities := cardinalruntime.CapabilityTick | cardinalruntime.CapabilityQuery
+	assert.True(t, capabilities.Has(cardinalruntime.CapabilityTick))
+	assert.True(t, capabilities.Has(cardinalruntime.CapabilityTick|cardinalruntime.CapabilityQuery))
+	assert.False(t, capabilities.Has(cardinalruntime.CapabilitySnapshot))
+}
+
+func TestContractRequirement(t *testing.T) {
+	t.Parallel()
+
+	schemaHash := [32]byte{1, 2, 3}
+	contract := cardinalruntime.Contract{
+		ABIVersion: cardinalruntime.ABIVersion,
+		Capabilities: cardinalruntime.CapabilityTick |
+			cardinalruntime.CapabilityStateless,
+		SchemaHash: schemaHash,
+		Name:       "gameplay",
+		Version:    "1.2.3",
+	}
+	requirement := cardinalruntime.ContractRequirement{
+		Name:         contract.Name,
+		Version:      contract.Version,
+		SchemaHash:   schemaHash,
+		Capabilities: cardinalruntime.CapabilityTick,
+	}
+
+	require.NoError(t, requirement.Validate(contract))
+
+	tests := []struct {
+		name     string
+		mutate   func(*cardinalruntime.Contract)
+		field    string
+		expected any
+		actual   any
+		message  string
+	}{
+		{
+			name: "name",
+			mutate: func(value *cardinalruntime.Contract) {
+				value.Name = "other"
+			},
+			field:    "name",
+			expected: "gameplay",
+			actual:   "other",
+			message:  `runtime contract mismatch: module name "other", want "gameplay"`,
+		},
+		{
+			name: "version",
+			mutate: func(value *cardinalruntime.Contract) {
+				value.Version = "2.0.0"
+			},
+			field:    "version",
+			expected: "1.2.3",
+			actual:   "2.0.0",
+			message:  `runtime contract mismatch: module version "2.0.0", want "1.2.3"`,
+		},
+		{
+			name: "capabilities",
+			mutate: func(value *cardinalruntime.Contract) {
+				value.Capabilities = 0
+			},
+			field:    "capabilities",
+			expected: cardinalruntime.CapabilityTick,
+			actual:   cardinalruntime.Capabilities(0),
+			message:  "runtime contract mismatch: module capabilities 0x0000000000000000 lack required 0x0000000000000002",
+		},
+		{
+			name: "schema hash",
+			mutate: func(value *cardinalruntime.Contract) {
+				value.SchemaHash[0]++
+			},
+			field:    "schema_hash",
+			expected: schemaHash,
+			actual:   [32]byte{2, 2, 3},
+			message: "runtime contract mismatch: module schema hash 020203" +
+				strings.Repeat("00", 29) + ", want 010203" + strings.Repeat("00", 29),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			actual := contract
+			test.mutate(&actual)
+			err := requirement.Validate(actual)
+			require.ErrorIs(t, err, cardinalruntime.ErrContractMismatch)
+
+			var mismatch *cardinalruntime.ContractMismatchError
+			require.True(t, errors.As(err, &mismatch))
+			assert.Equal(t, test.field, mismatch.Field)
+			assert.Equal(t, test.expected, mismatch.Expected)
+			assert.Equal(t, test.actual, mismatch.Actual)
+			assert.Equal(t, test.message, mismatch.Error())
+		})
+	}
+}
+
+func TestBufferSizeError(t *testing.T) {
+	t.Parallel()
+
+	err := &cardinalruntime.BufferSizeError{
+		Operation: "tick",
+		Required:  64,
+		Provided:  16,
+	}
+
+	require.ErrorIs(t, err, cardinalruntime.ErrBufferTooSmall)
+
+	var sizeErr *cardinalruntime.BufferSizeError
+	require.True(t, errors.As(err, &sizeErr))
+	assert.Equal(t, 64, sizeErr.Required)
+	assert.Equal(t, 16, sizeErr.Provided)
+	assert.Equal(t, "tick: output buffer too small: required 64 bytes, provided 16", err.Error())
+}

--- a/sdk/csharp/WorldEngine.Runtime.Abstractions/IGameModule.cs
+++ b/sdk/csharp/WorldEngine.Runtime.Abstractions/IGameModule.cs
@@ -1,0 +1,36 @@
+using System;
+
+namespace WorldEngine.Runtime
+{
+    /// <summary>
+    /// Deterministic game logic hosted in-process by Cardinal.
+    /// </summary>
+    /// <remarks>
+    /// Inputs are borrowed for the duration of a call. Outputs are written into
+    /// caller-owned memory. Implementations must set <c>outputLength</c> to the
+    /// required size when returning <see cref="RuntimeStatus.BufferTooSmall"/>.
+    /// A buffer-too-small call must not mutate module state or output because
+    /// the host can retry it with a larger buffer.
+    /// Calls for one module instance are serialized by the host.
+    /// </remarks>
+    public interface IGameModule : IDisposable
+    {
+        RuntimeStatus Initialize(ReadOnlySpan<byte> snapshot);
+
+        RuntimeStatus Tick(
+            in TickContext context,
+            ReadOnlySpan<byte> input,
+            Span<byte> output,
+            out int outputLength);
+
+        RuntimeStatus Query(
+            uint kind,
+            ReadOnlySpan<byte> input,
+            Span<byte> output,
+            out int outputLength);
+
+        RuntimeStatus Snapshot(Span<byte> output, out int outputLength);
+
+        RuntimeStatus Restore(ReadOnlySpan<byte> snapshot);
+    }
+}

--- a/sdk/csharp/WorldEngine.Runtime.Abstractions/ModuleContract.cs
+++ b/sdk/csharp/WorldEngine.Runtime.Abstractions/ModuleContract.cs
@@ -1,0 +1,57 @@
+using System;
+
+namespace WorldEngine.Runtime
+{
+    /// <summary>
+    /// Version and schema metadata validated before a module instance is created.
+    /// </summary>
+    public readonly struct ModuleContract
+    {
+        public const int SchemaHashLength = 32;
+
+        public ModuleContract(
+            string name,
+            string version,
+            RuntimeCapabilities capabilities,
+            byte[] schemaHash)
+        {
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                throw new ArgumentException("Module name is required.", nameof(name));
+            }
+
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                throw new ArgumentException("Module version is required.", nameof(version));
+            }
+
+            if (schemaHash == null)
+            {
+                throw new ArgumentNullException(nameof(schemaHash));
+            }
+
+            if (schemaHash.Length != SchemaHashLength)
+            {
+                throw new ArgumentException(
+                    $"Schema hash must contain exactly {SchemaHashLength} bytes.",
+                    nameof(schemaHash));
+            }
+
+            Name = name;
+            Version = version;
+            Capabilities = capabilities;
+            SchemaHash = new ReadOnlyMemory<byte>((byte[])schemaHash.Clone());
+        }
+
+        public string Name { get; }
+
+        public string Version { get; }
+
+        public RuntimeCapabilities Capabilities { get; }
+
+        /// <summary>
+        /// SHA-256 of the module's binary input/output schema.
+        /// </summary>
+        public ReadOnlyMemory<byte> SchemaHash { get; }
+    }
+}

--- a/sdk/csharp/WorldEngine.Runtime.Abstractions/README.md
+++ b/sdk/csharp/WorldEngine.Runtime.Abstractions/README.md
@@ -1,0 +1,122 @@
+# WorldEngine.Runtime.Abstractions
+
+Portable contracts for game logic shared by Unity and a Cardinal backend.
+
+## First module
+
+Create a Unity-compatible game-logic project and install version `1.0.0`:
+
+```bash
+dotnet new classlib \
+  --framework netstandard2.1 \
+  --name Rampage.Gameplay \
+  --output shared/Rampage.Gameplay
+dotnet add shared/Rampage.Gameplay/Rampage.Gameplay.csproj \
+  package WorldEngine.Runtime.Abstractions \
+  --version 1.0.0
+```
+
+Start with a stateless module in
+`shared/Rampage.Gameplay/GameModule.cs`. Replace the zero schema hash with the
+SHA-256 of the real binary input/output schema before production:
+
+```csharp
+using System;
+using WorldEngine.Runtime;
+
+namespace Rampage.Gameplay
+{
+    public sealed class GameModule : IGameModule
+    {
+        public static ModuleContract Contract { get; } = new ModuleContract(
+            "rampage-gameplay",
+            "1.0.0",
+            RuntimeCapabilities.Initialize |
+            RuntimeCapabilities.Tick |
+            RuntimeCapabilities.Stateless,
+            new byte[ModuleContract.SchemaHashLength]);
+
+        public GameModule(ReadOnlySpan<byte> config)
+        {
+            _ = config;
+        }
+
+        public RuntimeStatus Initialize(ReadOnlySpan<byte> snapshot) =>
+            snapshot.IsEmpty ? RuntimeStatus.Success : RuntimeStatus.Unsupported;
+
+        public RuntimeStatus Tick(
+            in TickContext context,
+            ReadOnlySpan<byte> input,
+            Span<byte> output,
+            out int outputLength)
+        {
+            _ = context;
+            _ = input;
+            _ = output;
+            outputLength = 0;
+            return RuntimeStatus.Success;
+        }
+
+        public RuntimeStatus Query(
+            uint kind,
+            ReadOnlySpan<byte> input,
+            Span<byte> output,
+            out int outputLength)
+        {
+            _ = kind;
+            _ = input;
+            _ = output;
+            outputLength = 0;
+            return RuntimeStatus.Unsupported;
+        }
+
+        public RuntimeStatus Snapshot(Span<byte> output, out int outputLength)
+        {
+            _ = output;
+            outputLength = 0;
+            return RuntimeStatus.Unsupported;
+        }
+
+        public RuntimeStatus Restore(ReadOnlySpan<byte> snapshot) =>
+            snapshot.IsEmpty ? RuntimeStatus.Success : RuntimeStatus.Unsupported;
+
+        public void Dispose()
+        {
+        }
+    }
+}
+```
+
+Next, add the NativeAOT host described in
+[`WorldEngine.Runtime.NativeAot`](https://github.com/Argus-Labs/world-engine/blob/csharp-runtime/v1.0.0/sdk/csharp/WorldEngine.Runtime.NativeAot/README.md).
+
+## Unity install
+
+In Unity Package Manager, choose **+ → Install package from git URL** and enter:
+
+```text
+https://github.com/Argus-Labs/world-engine.git?path=/sdk/csharp/WorldEngine.Runtime.Abstractions#csharp-runtime/v1.0.0
+```
+
+Compile the shared game-logic sources into a Unity assembly that references
+`WorldEngine.Runtime.Abstractions`. Cardinal loads those same sources through
+the NativeAOT host.
+
+## Release
+
+The NuGet and Unity package versions move together. C# runtime packages are
+released from `main`; push `csharp-runtime/v<package.json version>` at the
+matching main commit. The release workflow validates the tag and publishes both
+NuGet packages. Unity consumers pin the same tag in the Git URL above.
+
+## Invariants
+
+- No `UnityEngine`, networking, wall-clock, reflection discovery, or global RNG.
+- Cardinal supplies deterministic tick time and opaque binary input.
+- Each non-empty NativeAOT-backed system phase makes one batched call per tick;
+  empty phases make none. Calls never scale with entity count.
+- Input memory is borrowed only for the call.
+- Output memory belongs to the caller and should be reused.
+- `BufferTooSmall` leaves module state and output unchanged; the host may retry.
+- Stateful modules advertise `Snapshot` and make all authoritative state restorable.
+- A `Stateless` module keeps authoritative state in Cardinal ECS.

--- a/sdk/csharp/WorldEngine.Runtime.Abstractions/RuntimeCapabilities.cs
+++ b/sdk/csharp/WorldEngine.Runtime.Abstractions/RuntimeCapabilities.cs
@@ -1,0 +1,19 @@
+using System;
+
+namespace WorldEngine.Runtime
+{
+    /// <summary>
+    /// Optional operations implemented by a game module.
+    /// </summary>
+    [Flags]
+    public enum RuntimeCapabilities : ulong
+    {
+        None = 0,
+        Initialize = 1UL << 0,
+        Tick = 1UL << 1,
+        Query = 1UL << 2,
+        Snapshot = 1UL << 3,
+        Restore = 1UL << 4,
+        Stateless = 1UL << 5,
+    }
+}

--- a/sdk/csharp/WorldEngine.Runtime.Abstractions/RuntimeStatus.cs
+++ b/sdk/csharp/WorldEngine.Runtime.Abstractions/RuntimeStatus.cs
@@ -1,0 +1,17 @@
+namespace WorldEngine.Runtime
+{
+    /// <summary>
+    /// Stable status values shared with the Cardinal native runtime ABI.
+    /// </summary>
+    public enum RuntimeStatus
+    {
+        Success = 0,
+        BufferTooSmall = 1,
+        InvalidArgument = 2,
+        InvalidHandle = 3,
+        InvalidState = 4,
+        Unsupported = 5,
+        ExecutionFailed = 6,
+        AbiMismatch = 7,
+    }
+}

--- a/sdk/csharp/WorldEngine.Runtime.Abstractions/TickContext.cs
+++ b/sdk/csharp/WorldEngine.Runtime.Abstractions/TickContext.cs
@@ -1,0 +1,18 @@
+namespace WorldEngine.Runtime
+{
+    /// <summary>
+    /// Deterministic time supplied by Cardinal. Modules must not read wall-clock time.
+    /// </summary>
+    public readonly struct TickContext
+    {
+        public TickContext(ulong tick, ulong fixedDeltaNanoseconds)
+        {
+            Tick = tick;
+            FixedDeltaNanoseconds = fixedDeltaNanoseconds;
+        }
+
+        public ulong Tick { get; }
+
+        public ulong FixedDeltaNanoseconds { get; }
+    }
+}

--- a/sdk/csharp/WorldEngine.Runtime.Abstractions/WorldEngine.Runtime.Abstractions.asmdef
+++ b/sdk/csharp/WorldEngine.Runtime.Abstractions/WorldEngine.Runtime.Abstractions.asmdef
@@ -1,0 +1,14 @@
+{
+  "name": "WorldEngine.Runtime.Abstractions",
+  "rootNamespace": "WorldEngine.Runtime",
+  "references": [],
+  "includePlatforms": [],
+  "excludePlatforms": [],
+  "allowUnsafeCode": false,
+  "overrideReferences": false,
+  "precompiledReferences": [],
+  "autoReferenced": true,
+  "defineConstraints": [],
+  "versionDefines": [],
+  "noEngineReferences": true
+}

--- a/sdk/csharp/WorldEngine.Runtime.Abstractions/WorldEngine.Runtime.Abstractions.csproj
+++ b/sdk/csharp/WorldEngine.Runtime.Abstractions/WorldEngine.Runtime.Abstractions.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.1;net8.0</TargetFrameworks>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <RootNamespace>WorldEngine.Runtime</RootNamespace>
+    <AssemblyName>WorldEngine.Runtime.Abstractions</AssemblyName>
+    <IsAotCompatible Condition="'$(TargetFramework)' == 'net8.0'">true</IsAotCompatible>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);1591</NoWarn>
+    <PackageId>WorldEngine.Runtime.Abstractions</PackageId>
+    <Version>1.0.0</Version>
+    <Description>Portable contracts for deterministic C# game modules hosted by World Engine.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="/" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/csharp/WorldEngine.Runtime.Abstractions/package.json
+++ b/sdk/csharp/WorldEngine.Runtime.Abstractions/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "dev.world.runtime",
+  "version": "1.0.0",
+  "displayName": "World Engine Runtime",
+  "description": "Portable contracts for deterministic C# game modules shared by Unity and Cardinal.",
+  "unity": "2022.3",
+  "documentationUrl": "https://world.dev/docs",
+  "licensesUrl": "https://github.com/Argus-Labs/world-engine/blob/main/LICENSE",
+  "keywords": [
+    "world-engine",
+    "cardinal",
+    "nativeaot",
+    "simulation"
+  ],
+  "author": {
+    "name": "World Engine",
+    "email": "support@world.dev",
+    "url": "https://world.dev"
+  },
+  "type": "library"
+}

--- a/sdk/csharp/WorldEngine.Runtime.NativeAot/README.md
+++ b/sdk/csharp/WorldEngine.Runtime.NativeAot/README.md
@@ -1,0 +1,125 @@
+# WorldEngine.Runtime.NativeAot
+
+Build package that turns a game-specific .NET class library into the shared
+library loaded by Cardinal.
+
+## First shard build
+
+Create the NativeAOT host and install version `1.0.0`:
+
+```bash
+dotnet new classlib \
+  --framework net8.0 \
+  --name Rampage.Gameplay.NativeAot \
+  --output native/gameplay/Rampage.Gameplay.NativeAot
+dotnet add native/gameplay/Rampage.Gameplay.NativeAot/Rampage.Gameplay.NativeAot.csproj \
+  package WorldEngine.Runtime.NativeAot \
+  --version 1.0.0
+dotnet add native/gameplay/Rampage.Gameplay.NativeAot/Rampage.Gameplay.NativeAot.csproj \
+  reference shared/Rampage.Gameplay/Rampage.Gameplay.csproj
+```
+
+The host project must name the extensionless library used by `world.toml`.
+Its complete project file is:
+
+```xml
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>rampage_gameplay_native</AssemblyName>
+    <PublishAot>true</PublishAot>
+    <NativeLib>Shared</NativeLib>
+    <SelfContained>true</SelfContained>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="../../../shared/Rampage.Gameplay/Rampage.Gameplay.csproj" />
+    <PackageReference Include="WorldEngine.Runtime.NativeAot" Version="1.0.0" />
+  </ItemGroup>
+</Project>
+```
+
+Add `GameModuleFactory.cs` to the host project:
+
+```csharp
+using System;
+using Rampage.Gameplay;
+using WorldEngine.Runtime;
+
+namespace WorldEngine.Runtime.NativeAot
+{
+    internal static partial class GameModuleFactory
+    {
+        internal static partial ModuleContract GetContract() => GameModule.Contract;
+
+        internal static partial IGameModule Create(ReadOnlySpan<byte> config) =>
+            new GameModule(config);
+    }
+}
+```
+
+The package injects all `cardinal_runtime_v1_*` exports into the published
+assembly. This is required because NativeAOT exports only methods in the
+published assembly, not methods in referenced packages.
+
+Configure the shard from the world root:
+
+```toml
+[[shards]]
+id = "gameplay"
+path = "shards/gameplay"
+
+[shards.native_aot]
+project = "native/gameplay/Rampage.Gameplay.NativeAot/Rampage.Gameplay.NativeAot.csproj"
+library = "rampage_gameplay_native"
+abi_version = 1
+```
+
+`project` is world-root relative. `library` is extensionless and must equal
+`<AssemblyName>`.
+
+Build and validate the Linux/amd64 shard container image:
+
+```bash
+world build --shard gameplay
+```
+
+This command produces the shard image, not a host `.so` in the worktree. It
+validates the published library and copies it into the image as
+`librampage_gameplay_native.so`.
+
+## Local library build
+
+Publish directly when debugging the host outside World CLI:
+
+```bash
+dotnet publish \
+  native/gameplay/Rampage.Gameplay.NativeAot/Rampage.Gameplay.NativeAot.csproj \
+  --configuration Release \
+  --runtime linux-x64 \
+  --self-contained true \
+  --output .world/native/gameplay
+test -f .world/native/gameplay/rampage_gameplay_native.so
+```
+
+The three NativeAOT properties belong in the host project so they are available
+during restore. The package validates them before build.
+
+World CLI currently builds Linux/amd64 (`linux-x64`) shard containers. The
+package itself supports standard .NET 8 NativeAOT shared-library runtime
+identifiers wherever the installed .NET SDK and native toolchain support them.
+
+## Troubleshooting
+
+| Symptom | Check |
+| --- | --- |
+| Contract mismatch | Read `ContractMismatchError.Field`, `Expected`, and `Actual`; align the host requirement with `GameModule.Contract`, then rebuild. Capability values are bit masks; schema hashes are full 64-digit hex. |
+| Missing `.so` | Ensure `library = "rampage_gameplay_native"` matches `<AssemblyName>`. Direct publish writes `.world/native/gameplay/rampage_gameplay_native.so`; `world build` instead copies `librampage_gameplay_native.so` into the image. |
+| Missing ABI symbols | Keep the factory in namespace `WorldEngine.Runtime.NativeAot` and reference the NativeAOT package from the published host. Inspect with `nm --dynamic --defined-only .world/native/gameplay/rampage_gameplay_native.so \| grep cardinal_runtime_v1_`. |
+| Wrong platform | World CLI shard images are Linux/amd64; publish with `--runtime linux-x64`. Other NativeAOT RIDs are package/toolchain capabilities, not World CLI container targets. |
+
+The library is self-contained. Keep it loaded for the process lifetime;
+NativeAOT libraries cannot be unloaded. Treat module paths as trusted
+executable artifacts. If an output call returns `BufferTooSmall`, do not run
+another operation on that handle before retrying with the larger buffer.

--- a/sdk/csharp/WorldEngine.Runtime.NativeAot/WorldEngine.Runtime.NativeAot.csproj
+++ b/sdk/csharp/WorldEngine.Runtime.NativeAot/WorldEngine.Runtime.NativeAot.csproj
@@ -1,0 +1,36 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <IsPackable>true</IsPackable>
+    <PackageId>WorldEngine.Runtime.NativeAot</PackageId>
+    <Version>1.0.0</Version>
+    <Description>NativeAOT build contract and generated C ABI host for World Engine game modules.</Description>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <NoWarn>$(NoWarn);NU5128</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../WorldEngine.Runtime.Abstractions/WorldEngine.Runtime.Abstractions.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="src/NativeExports.cs" />
+    <None Include="README.md"
+          Pack="true"
+          PackagePath="/" />
+    <None Include="build/WorldEngine.Runtime.NativeAot.props"
+          Pack="true"
+          PackagePath="build/" />
+    <None Include="build/WorldEngine.Runtime.NativeAot.targets"
+          Pack="true"
+          PackagePath="build/" />
+    <None Include="src/NativeExports.cs"
+          Pack="true"
+          PackagePath="contentFiles/cs/any/WorldEngine.Runtime.NativeAot/" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/csharp/WorldEngine.Runtime.NativeAot/build/WorldEngine.Runtime.NativeAot.props
+++ b/sdk/csharp/WorldEngine.Runtime.NativeAot/build/WorldEngine.Runtime.NativeAot.props
@@ -1,0 +1,9 @@
+<Project>
+  <PropertyGroup>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <IsAotCompatible>true</IsAotCompatible>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <StripSymbols>true</StripSymbols>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+</Project>

--- a/sdk/csharp/WorldEngine.Runtime.NativeAot/build/WorldEngine.Runtime.NativeAot.targets
+++ b/sdk/csharp/WorldEngine.Runtime.NativeAot/build/WorldEngine.Runtime.NativeAot.targets
@@ -1,0 +1,25 @@
+<Project>
+  <PropertyGroup>
+    <WorldEngineNativeExportsSource Condition="'$(WorldEngineNativeExportsSource)' == ''">$(MSBuildThisFileDirectory)..\contentFiles\cs\any\WorldEngine.Runtime.NativeAot\NativeExports.cs</WorldEngineNativeExportsSource>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="$(WorldEngineNativeExportsSource)"
+             Link="WorldEngine.Runtime.NativeAot.g.cs"
+             Visible="false" />
+  </ItemGroup>
+
+  <Target Name="ValidateWorldEngineNativeAotProject"
+          BeforeTargets="PrepareForBuild">
+    <Error Condition="'$(TargetFramework)' != 'net8.0'"
+           Text="WorldEngine.Runtime.NativeAot currently supports only the net8.0 target framework used by World CLI." />
+    <Error Condition="'$(PublishAot)' != 'true'"
+           Text="WorldEngine.Runtime.NativeAot requires PublishAot=true in the host project." />
+    <Error Condition="'$(NativeLib)' != 'Shared'"
+           Text="WorldEngine.Runtime.NativeAot supports only NativeLib=Shared." />
+    <Error Condition="'$(SelfContained)' != 'true'"
+           Text="WorldEngine.Runtime.NativeAot requires SelfContained=true in the host project." />
+    <Error Condition="!Exists('$(WorldEngineNativeExportsSource)')"
+           Text="World Engine NativeAOT export source was not found at $(WorldEngineNativeExportsSource)." />
+  </Target>
+</Project>

--- a/sdk/csharp/WorldEngine.Runtime.NativeAot/src/NativeExports.cs
+++ b/sdk/csharp/WorldEngine.Runtime.NativeAot/src/NativeExports.cs
@@ -1,0 +1,511 @@
+using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+using WorldEngine.Runtime;
+
+namespace WorldEngine.Runtime.NativeAot
+{
+    internal static partial class GameModuleFactory
+    {
+        internal static partial ModuleContract GetContract();
+
+        internal static partial IGameModule Create(ReadOnlySpan<byte> config);
+    }
+
+    internal sealed class ModuleEntry
+    {
+        internal ModuleEntry(IGameModule module)
+        {
+            Module = module;
+        }
+
+        internal object Gate { get; } = new object();
+
+        internal IGameModule Module { get; }
+
+        internal string? LastError { get; set; }
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    internal unsafe struct NativeContract
+    {
+        internal uint AbiVersion;
+        internal uint StructSize;
+        internal ulong Capabilities;
+        internal fixed byte SchemaHash[ModuleContract.SchemaHashLength];
+        internal fixed byte Name[64];
+        internal fixed byte Version[32];
+        internal fixed ulong Reserved[4];
+    }
+
+    internal static unsafe class NativeExports
+    {
+        private const uint AbiVersion = 1;
+        private const int NameCapacity = 64;
+        private const int VersionCapacity = 32;
+
+        private static readonly ConcurrentDictionary<ulong, ModuleEntry> s_modules = new();
+        private static long s_nextHandle;
+        [ThreadStatic]
+        private static string? t_globalError;
+
+        [UnmanagedCallersOnly(
+            EntryPoint = "cardinal_runtime_v1_get_contract",
+            CallConvs = new[] { typeof(CallConvCdecl) })]
+        internal static int GetContract(NativeContract* output)
+        {
+            if (output == null)
+            {
+                return (int)RuntimeStatus.InvalidArgument;
+            }
+
+            try
+            {
+                ModuleContract contract = GameModuleFactory.GetContract();
+                if (contract.SchemaHash.Length != ModuleContract.SchemaHashLength)
+                {
+                    throw new InvalidOperationException(
+                        $"Schema hash must contain {ModuleContract.SchemaHashLength} bytes.");
+                }
+
+                *output = default;
+                output->AbiVersion = AbiVersion;
+                output->StructSize = (uint)sizeof(NativeContract);
+                output->Capabilities = (ulong)contract.Capabilities;
+
+                contract.SchemaHash.Span.CopyTo(
+                    new Span<byte>(output->SchemaHash, ModuleContract.SchemaHashLength));
+                WriteNullTerminatedUtf8(
+                    contract.Name,
+                    new Span<byte>(output->Name, NameCapacity),
+                    nameof(contract.Name));
+                WriteNullTerminatedUtf8(
+                    contract.Version,
+                    new Span<byte>(output->Version, VersionCapacity),
+                    nameof(contract.Version));
+
+                SetGlobalError(null);
+                return (int)RuntimeStatus.Success;
+            }
+            catch (Exception exception)
+            {
+                SetGlobalError(FormatException(exception));
+                return (int)RuntimeStatus.ExecutionFailed;
+            }
+        }
+
+        [UnmanagedCallersOnly(
+            EntryPoint = "cardinal_runtime_v1_create",
+            CallConvs = new[] { typeof(CallConvCdecl) })]
+        internal static int Create(
+            byte* config,
+            nuint configLength,
+            ulong* outputHandle)
+        {
+            if (outputHandle == null || !TryCreateReadOnlySpan(config, configLength, out var configSpan))
+            {
+                return (int)RuntimeStatus.InvalidArgument;
+            }
+
+            *outputHandle = 0;
+
+            try
+            {
+                IGameModule module = GameModuleFactory.Create(configSpan)
+                    ?? throw new InvalidOperationException("Game module factory returned null.");
+                ulong handle = NextHandle();
+                if (!s_modules.TryAdd(handle, new ModuleEntry(module)))
+                {
+                    module.Dispose();
+                    throw new InvalidOperationException("Failed to allocate a unique module handle.");
+                }
+
+                *outputHandle = handle;
+                SetGlobalError(null);
+                return (int)RuntimeStatus.Success;
+            }
+            catch (Exception exception)
+            {
+                SetGlobalError(FormatException(exception));
+                return (int)RuntimeStatus.ExecutionFailed;
+            }
+        }
+
+        [UnmanagedCallersOnly(
+            EntryPoint = "cardinal_runtime_v1_initialize",
+            CallConvs = new[] { typeof(CallConvCdecl) })]
+        internal static int Initialize(
+            ulong handle,
+            byte* snapshot,
+            nuint snapshotLength)
+        {
+            if (!TryCreateReadOnlySpan(snapshot, snapshotLength, out var snapshotSpan))
+            {
+                return (int)RuntimeStatus.InvalidArgument;
+            }
+
+            if (!s_modules.TryGetValue(handle, out ModuleEntry? entry))
+            {
+                return (int)RuntimeStatus.InvalidHandle;
+            }
+
+            lock (entry.Gate)
+            {
+                try
+                {
+                    RuntimeStatus status = entry.Module.Initialize(snapshotSpan);
+                    SetModuleStatus(entry, status);
+                    return (int)status;
+                }
+                catch (Exception exception)
+                {
+                    entry.LastError = FormatException(exception);
+                    return (int)RuntimeStatus.ExecutionFailed;
+                }
+            }
+        }
+
+        [UnmanagedCallersOnly(
+            EntryPoint = "cardinal_runtime_v1_tick",
+            CallConvs = new[] { typeof(CallConvCdecl) })]
+        internal static int Tick(
+            ulong handle,
+            ulong tick,
+            ulong fixedDeltaNanoseconds,
+            byte* input,
+            nuint inputLength,
+            byte* output,
+            nuint outputCapacity,
+            nuint* outputLength)
+        {
+            if (!TryCreateReadOnlySpan(input, inputLength, out var inputSpan) ||
+                !TryCreateSpan(output, outputCapacity, out var outputSpan) ||
+                outputLength == null)
+            {
+                return (int)RuntimeStatus.InvalidArgument;
+            }
+
+            *outputLength = 0;
+            TickContext context = new TickContext(tick, fixedDeltaNanoseconds);
+            if (!s_modules.TryGetValue(handle, out ModuleEntry? entry))
+            {
+                return (int)RuntimeStatus.InvalidHandle;
+            }
+
+            lock (entry.Gate)
+            {
+                try
+                {
+                    RuntimeStatus status = entry.Module.Tick(
+                        in context,
+                        inputSpan,
+                        outputSpan,
+                        out int length);
+                    return CompleteOutputStatus(
+                        entry,
+                        status,
+                        length,
+                        outputSpan.Length,
+                        outputLength);
+                }
+                catch (Exception exception)
+                {
+                    entry.LastError = FormatException(exception);
+                    return (int)RuntimeStatus.ExecutionFailed;
+                }
+            }
+        }
+
+        [UnmanagedCallersOnly(
+            EntryPoint = "cardinal_runtime_v1_query",
+            CallConvs = new[] { typeof(CallConvCdecl) })]
+        internal static int Query(
+            ulong handle,
+            uint kind,
+            byte* input,
+            nuint inputLength,
+            byte* output,
+            nuint outputCapacity,
+            nuint* outputLength)
+        {
+            if (!TryCreateReadOnlySpan(input, inputLength, out var inputSpan) ||
+                !TryCreateSpan(output, outputCapacity, out var outputSpan) ||
+                outputLength == null)
+            {
+                return (int)RuntimeStatus.InvalidArgument;
+            }
+
+            *outputLength = 0;
+            if (!s_modules.TryGetValue(handle, out ModuleEntry? entry))
+            {
+                return (int)RuntimeStatus.InvalidHandle;
+            }
+
+            lock (entry.Gate)
+            {
+                try
+                {
+                    RuntimeStatus status = entry.Module.Query(
+                        kind,
+                        inputSpan,
+                        outputSpan,
+                        out int length);
+                    return CompleteOutputStatus(
+                        entry,
+                        status,
+                        length,
+                        outputSpan.Length,
+                        outputLength);
+                }
+                catch (Exception exception)
+                {
+                    entry.LastError = FormatException(exception);
+                    return (int)RuntimeStatus.ExecutionFailed;
+                }
+            }
+        }
+
+        [UnmanagedCallersOnly(
+            EntryPoint = "cardinal_runtime_v1_snapshot",
+            CallConvs = new[] { typeof(CallConvCdecl) })]
+        internal static int Snapshot(
+            ulong handle,
+            byte* output,
+            nuint outputCapacity,
+            nuint* outputLength)
+        {
+            if (!TryCreateSpan(output, outputCapacity, out var outputSpan) ||
+                outputLength == null)
+            {
+                return (int)RuntimeStatus.InvalidArgument;
+            }
+
+            *outputLength = 0;
+            if (!s_modules.TryGetValue(handle, out ModuleEntry? entry))
+            {
+                return (int)RuntimeStatus.InvalidHandle;
+            }
+
+            lock (entry.Gate)
+            {
+                try
+                {
+                    RuntimeStatus status = entry.Module.Snapshot(outputSpan, out int length);
+                    return CompleteOutputStatus(
+                        entry,
+                        status,
+                        length,
+                        outputSpan.Length,
+                        outputLength);
+                }
+                catch (Exception exception)
+                {
+                    entry.LastError = FormatException(exception);
+                    return (int)RuntimeStatus.ExecutionFailed;
+                }
+            }
+        }
+
+        [UnmanagedCallersOnly(
+            EntryPoint = "cardinal_runtime_v1_restore",
+            CallConvs = new[] { typeof(CallConvCdecl) })]
+        internal static int Restore(
+            ulong handle,
+            byte* snapshot,
+            nuint snapshotLength)
+        {
+            if (!TryCreateReadOnlySpan(snapshot, snapshotLength, out var snapshotSpan))
+            {
+                return (int)RuntimeStatus.InvalidArgument;
+            }
+
+            if (!s_modules.TryGetValue(handle, out ModuleEntry? entry))
+            {
+                return (int)RuntimeStatus.InvalidHandle;
+            }
+
+            lock (entry.Gate)
+            {
+                try
+                {
+                    RuntimeStatus status = entry.Module.Restore(snapshotSpan);
+                    SetModuleStatus(entry, status);
+                    return (int)status;
+                }
+                catch (Exception exception)
+                {
+                    entry.LastError = FormatException(exception);
+                    return (int)RuntimeStatus.ExecutionFailed;
+                }
+            }
+        }
+
+        [UnmanagedCallersOnly(
+            EntryPoint = "cardinal_runtime_v1_last_error",
+            CallConvs = new[] { typeof(CallConvCdecl) })]
+        internal static int LastError(
+            ulong handle,
+            byte* output,
+            nuint outputCapacity,
+            nuint* outputLength)
+        {
+            if (!TryCreateSpan(output, outputCapacity, out var outputSpan) ||
+                outputLength == null)
+            {
+                return (int)RuntimeStatus.InvalidArgument;
+            }
+
+            try
+            {
+                string error = GetError(handle) ?? string.Empty;
+                int requiredLength = Encoding.UTF8.GetByteCount(error);
+                *outputLength = (nuint)requiredLength;
+                if (outputSpan.Length < requiredLength)
+                {
+                    return (int)RuntimeStatus.BufferTooSmall;
+                }
+
+                Encoding.UTF8.GetBytes(error.AsSpan(), outputSpan);
+                return (int)RuntimeStatus.Success;
+            }
+            catch (Exception exception)
+            {
+                SetGlobalError(FormatException(exception));
+                return (int)RuntimeStatus.ExecutionFailed;
+            }
+        }
+
+        [UnmanagedCallersOnly(
+            EntryPoint = "cardinal_runtime_v1_destroy",
+            CallConvs = new[] { typeof(CallConvCdecl) })]
+        internal static int Destroy(ulong handle)
+        {
+            if (handle == 0 || !s_modules.TryRemove(handle, out ModuleEntry? entry))
+            {
+                return (int)RuntimeStatus.InvalidHandle;
+            }
+
+            try
+            {
+                lock (entry.Gate)
+                {
+                    entry.Module.Dispose();
+                    entry.LastError = null;
+                }
+
+                return (int)RuntimeStatus.Success;
+            }
+            catch (Exception exception)
+            {
+                SetGlobalError(FormatException(exception));
+                return (int)RuntimeStatus.ExecutionFailed;
+            }
+        }
+
+        private static int CompleteOutputStatus(
+            ModuleEntry entry,
+            RuntimeStatus status,
+            int outputLength,
+            int outputCapacity,
+            nuint* nativeOutputLength)
+        {
+            if (outputLength < 0 ||
+                (status == RuntimeStatus.Success && outputLength > outputCapacity))
+            {
+                throw new InvalidOperationException(
+                    $"Module returned invalid output length {outputLength} for capacity {outputCapacity}.");
+            }
+
+            *nativeOutputLength = (nuint)outputLength;
+            SetModuleStatus(entry, status);
+            return (int)status;
+        }
+
+        private static void SetModuleStatus(ModuleEntry entry, RuntimeStatus status)
+        {
+            entry.LastError = status == RuntimeStatus.Success ||
+                              status == RuntimeStatus.BufferTooSmall
+                ? null
+                : $"Module returned {status}.";
+        }
+
+        private static string? GetError(ulong handle)
+        {
+            if (handle != 0 && s_modules.TryGetValue(handle, out ModuleEntry? entry))
+            {
+                lock (entry.Gate)
+                {
+                    return entry.LastError;
+                }
+            }
+
+            return t_globalError;
+        }
+
+        private static void SetGlobalError(string? error) => t_globalError = error;
+
+        private static ulong NextHandle()
+        {
+            long handle = Interlocked.Increment(ref s_nextHandle);
+            if (handle <= 0)
+            {
+                throw new InvalidOperationException("Module handle space was exhausted.");
+            }
+
+            return (ulong)handle;
+        }
+
+        private static bool TryCreateReadOnlySpan(
+            byte* data,
+            nuint length,
+            out ReadOnlySpan<byte> span)
+        {
+            if (length > int.MaxValue || (data == null && length != 0))
+            {
+                span = default;
+                return false;
+            }
+
+            span = new ReadOnlySpan<byte>(data, checked((int)length));
+            return true;
+        }
+
+        private static bool TryCreateSpan(
+            byte* data,
+            nuint capacity,
+            out Span<byte> span)
+        {
+            if (capacity > int.MaxValue || (data == null && capacity != 0))
+            {
+                span = default;
+                return false;
+            }
+
+            span = new Span<byte>(data, checked((int)capacity));
+            return true;
+        }
+
+        private static void WriteNullTerminatedUtf8(
+            string value,
+            Span<byte> destination,
+            string fieldName)
+        {
+            int byteCount = Encoding.UTF8.GetByteCount(value);
+            if (byteCount >= destination.Length)
+            {
+                throw new InvalidOperationException(
+                    $"{fieldName} needs {byteCount + 1} bytes; maximum is {destination.Length}.");
+            }
+
+            destination.Clear();
+            Encoding.UTF8.GetBytes(value.AsSpan(), destination);
+        }
+
+        private static string FormatException(Exception exception) =>
+            $"{exception.GetType().Name}: {exception.Message}";
+
+    }
+}

--- a/sdk/csharp/testapps/CounterModule/CounterGameModule.cs
+++ b/sdk/csharp/testapps/CounterModule/CounterGameModule.cs
@@ -1,0 +1,119 @@
+using System;
+using System.Buffers.Binary;
+using WorldEngine.Runtime;
+
+namespace WorldEngine.Runtime.CounterFixture
+{
+    internal sealed class CounterGameModule : IGameModule
+    {
+        private const int ValueSize = sizeof(long);
+
+        private long _value;
+
+        internal CounterGameModule(ReadOnlySpan<byte> config)
+        {
+            if (config.Length == ValueSize)
+            {
+                _value = BinaryPrimitives.ReadInt64LittleEndian(config);
+            }
+            else if (!config.IsEmpty)
+            {
+                throw new ArgumentException(
+                    $"Counter config must be empty or eight bytes; received {config.Length}.",
+                    nameof(config));
+            }
+        }
+
+        internal static ModuleContract Contract { get; } = new ModuleContract(
+            "counter-fixture",
+            "1.0.0",
+            RuntimeCapabilities.Initialize |
+            RuntimeCapabilities.Tick |
+            RuntimeCapabilities.Query |
+            RuntimeCapabilities.Snapshot |
+            RuntimeCapabilities.Restore,
+            new byte[ModuleContract.SchemaHashLength]
+            {
+                0x9a, 0xaf, 0x3f, 0x8c, 0xd5, 0xc1, 0x6c, 0xa9,
+                0x36, 0x91, 0x14, 0xaa, 0x09, 0x66, 0x99, 0xa2,
+                0x0e, 0xbf, 0xc7, 0x4a, 0x7f, 0xf3, 0xee, 0x99,
+                0x04, 0x83, 0x3d, 0x3f, 0xb9, 0xd5, 0xda, 0x30,
+            });
+
+        public RuntimeStatus Initialize(ReadOnlySpan<byte> snapshot) => Restore(snapshot);
+
+        public RuntimeStatus Tick(
+            in TickContext context,
+            ReadOnlySpan<byte> input,
+            Span<byte> output,
+            out int outputLength)
+        {
+            _ = context;
+            if (input.Length != ValueSize)
+            {
+                outputLength = 0;
+                return RuntimeStatus.InvalidArgument;
+            }
+
+            outputLength = ValueSize;
+            if (output.Length < outputLength)
+            {
+                return RuntimeStatus.BufferTooSmall;
+            }
+
+            _value += BinaryPrimitives.ReadInt64LittleEndian(input);
+            BinaryPrimitives.WriteInt64LittleEndian(output, _value);
+            return RuntimeStatus.Success;
+        }
+
+        public RuntimeStatus Query(
+            uint kind,
+            ReadOnlySpan<byte> input,
+            Span<byte> output,
+            out int outputLength)
+        {
+            if (kind != 1 || !input.IsEmpty)
+            {
+                outputLength = 0;
+                return RuntimeStatus.Unsupported;
+            }
+
+            return WriteValue(output, out outputLength);
+        }
+
+        public RuntimeStatus Snapshot(Span<byte> output, out int outputLength) =>
+            WriteValue(output, out outputLength);
+
+        public RuntimeStatus Restore(ReadOnlySpan<byte> snapshot)
+        {
+            if (snapshot.IsEmpty)
+            {
+                return RuntimeStatus.Success;
+            }
+
+            if (snapshot.Length != ValueSize)
+            {
+                return RuntimeStatus.InvalidArgument;
+            }
+
+            _value = BinaryPrimitives.ReadInt64LittleEndian(snapshot);
+            return RuntimeStatus.Success;
+        }
+
+        public void Dispose()
+        {
+        }
+
+        private RuntimeStatus WriteValue(Span<byte> output, out int outputLength)
+        {
+            outputLength = ValueSize;
+            if (output.Length < outputLength)
+            {
+                return RuntimeStatus.BufferTooSmall;
+            }
+
+            BinaryPrimitives.WriteInt64LittleEndian(output, _value);
+            return RuntimeStatus.Success;
+        }
+    }
+}

--- a/sdk/csharp/testapps/CounterModule/CounterModule.Packaged.csproj
+++ b/sdk/csharp/testapps/CounterModule/CounterModule.Packaged.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>WorldEngine.Runtime.CounterFixture</AssemblyName>
+    <PublishAot>true</PublishAot>
+    <NativeLib>Shared</NativeLib>
+    <SelfContained>true</SelfContained>
+    <WorldEngineRuntimeVersion Condition="'$(WorldEngineRuntimeVersion)' == ''">1.0.0</WorldEngineRuntimeVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WorldEngine.Runtime.NativeAot" Version="$(WorldEngineRuntimeVersion)" />
+  </ItemGroup>
+
+</Project>

--- a/sdk/csharp/testapps/CounterModule/CounterModule.csproj
+++ b/sdk/csharp/testapps/CounterModule/CounterModule.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <Import Project="../../WorldEngine.Runtime.NativeAot/build/WorldEngine.Runtime.NativeAot.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <AssemblyName>WorldEngine.Runtime.CounterFixture</AssemblyName>
+    <PublishAot>true</PublishAot>
+    <NativeLib>Shared</NativeLib>
+    <SelfContained>true</SelfContained>
+    <WorldEngineNativeExportsSource>../../WorldEngine.Runtime.NativeAot/src/NativeExports.cs</WorldEngineNativeExportsSource>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../../WorldEngine.Runtime.Abstractions/WorldEngine.Runtime.Abstractions.csproj" />
+  </ItemGroup>
+
+  <Import Project="../../WorldEngine.Runtime.NativeAot/build/WorldEngine.Runtime.NativeAot.targets" />
+
+</Project>

--- a/sdk/csharp/testapps/CounterModule/Dockerfile
+++ b/sdk/csharp/testapps/CounterModule/Dockerfile
@@ -1,0 +1,56 @@
+ARG DOTNET_IMAGE=mcr.microsoft.com/dotnet/sdk:8.0.423-bookworm-slim
+
+FROM ${DOTNET_IMAGE} AS build
+ARG PACKAGE_VERSION=1.0.0
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends binutils clang zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY sdk/csharp/WorldEngine.Runtime.Abstractions/ sdk/csharp/WorldEngine.Runtime.Abstractions/
+COPY sdk/csharp/WorldEngine.Runtime.NativeAot/ sdk/csharp/WorldEngine.Runtime.NativeAot/
+COPY sdk/csharp/testapps/CounterModule/ sdk/csharp/testapps/CounterModule/
+
+RUN dotnet pack sdk/csharp/WorldEngine.Runtime.Abstractions/WorldEngine.Runtime.Abstractions.csproj \
+      --configuration Release \
+      --output /packages \
+      -p:PackageVersion=${PACKAGE_VERSION} \
+    && dotnet pack sdk/csharp/WorldEngine.Runtime.NativeAot/WorldEngine.Runtime.NativeAot.csproj \
+      --configuration Release \
+      --output /packages \
+      -p:PackageVersion=${PACKAGE_VERSION}
+
+RUN dotnet restore sdk/csharp/testapps/CounterModule/CounterModule.Packaged.csproj \
+      --artifacts-path /tmp/counter-artifacts \
+      --packages /tmp/counter-packages \
+      --runtime linux-x64 \
+      -p:WorldEngineRuntimeVersion=${PACKAGE_VERSION} \
+      --source /packages \
+      --source https://api.nuget.org/v3/index.json
+
+RUN dotnet publish sdk/csharp/testapps/CounterModule/CounterModule.Packaged.csproj \
+    --no-restore \
+    --artifacts-path /tmp/counter-artifacts \
+    --configuration Release \
+    --runtime linux-x64 \
+    -p:WorldEngineRuntimeVersion=${PACKAGE_VERSION} \
+    --output /publish
+
+RUN test -f /publish/WorldEngine.Runtime.CounterFixture.so
+RUN for symbol in \
+      cardinal_runtime_v1_get_contract \
+      cardinal_runtime_v1_create \
+      cardinal_runtime_v1_initialize \
+      cardinal_runtime_v1_tick \
+      cardinal_runtime_v1_query \
+      cardinal_runtime_v1_snapshot \
+      cardinal_runtime_v1_restore \
+      cardinal_runtime_v1_last_error \
+      cardinal_runtime_v1_destroy; \
+    do \
+      nm --dynamic --defined-only /publish/WorldEngine.Runtime.CounterFixture.so \
+        | grep --extended-regexp --quiet " ${symbol}(@@[^ ]+)?$"; \
+    done
+
+FROM scratch AS artifact
+COPY --from=build /publish/WorldEngine.Runtime.CounterFixture.so /libcounter_fixture.so

--- a/sdk/csharp/testapps/CounterModule/GameModuleFactory.cs
+++ b/sdk/csharp/testapps/CounterModule/GameModuleFactory.cs
@@ -1,0 +1,14 @@
+using System;
+using WorldEngine.Runtime;
+using WorldEngine.Runtime.CounterFixture;
+
+namespace WorldEngine.Runtime.NativeAot
+{
+    internal static partial class GameModuleFactory
+    {
+        internal static partial ModuleContract GetContract() => CounterGameModule.Contract;
+
+        internal static partial IGameModule Create(ReadOnlySpan<byte> config) =>
+            new CounterGameModule(config);
+    }
+}


### PR DESCRIPTION
## Summary

- backport the Cardinal runtime contract and NativeAOT loader required by v0.11 consumers
- include the C# contracts, NativeAOT build package, fixture, and compatibility CI
- retain v0.11-compatible test assertions
- keep C# package publication on the main development line

## Base

- target: `release/v0.11.4`
- branch point: `v0.11.3` (`9361356e`)
- companion main-line PR: https://github.com/Argus-Labs/world-engine/pull/919

## Validation

- `go test ./pkg/cardinal/runtime/... -count=1`
- `go test -race ./pkg/cardinal/runtime/... -count=1`
- `CGO_ENABLED=0 go test ./pkg/cardinal/runtime/... -count=1`
- `go vet ./pkg/cardinal/runtime/...`
- packaged NativeAOT fixture build and real shared-library load

## Release

Tag the merged maintenance commit as `v0.11.4`. C# packages remain released from `main` via `csharp-runtime/v1.0.0`.