### PR TITLE
feat(cardinal): add struct system registration

### DIFF
--- a/pkg/cardinal/bench_internal_test.go
+++ b/pkg/cardinal/bench_internal_test.go
@@ -3,6 +3,7 @@ package cardinal
 import (
 	"bytes"
 	"encoding/gob"
+	"reflect"
 	"testing"
 
 	"github.com/argus-labs/world-engine/pkg/cardinal/internal/ecs"
@@ -786,7 +787,7 @@ func newBenchWorld() *World {
 
 func mustInitSystemFields[T any](b testing.TB, world *World, state *T) {
 	b.Helper()
-	err := initSystemFields(state, world)
+	err := initSystemFields(reflect.ValueOf(state).Elem(), world)
 	if err != nil {
 		b.Fatalf("failed to initialize system fields: %v", err)
 	}

--- a/pkg/cardinal/debug_internal_test.go
+++ b/pkg/cardinal/debug_internal_test.go
@@ -2,6 +2,7 @@ package cardinal
 
 import (
 	"context"
+	"reflect"
 	"sync"
 	"testing"
 	"time"
@@ -204,7 +205,7 @@ func newDebugStateWorld(t *testing.T) (*World, *snapshotEntities) {
 	require.NotNil(t, w.debug)
 
 	state := &snapshotEntities{}
-	require.NoError(t, initSystemFields(state, w))
+	require.NoError(t, initSystemFields(reflect.ValueOf(state).Elem(), w))
 	w.world.Init()
 	return w, state
 }

--- a/pkg/cardinal/system.go
+++ b/pkg/cardinal/system.go
@@ -19,6 +19,13 @@ import (
 
 type EntityID = ecs.EntityID
 
+// System is a stateful Cardinal system. Implement it with a Run method on a
+// pointer to a struct that embeds BaseSystemState.
+type System interface {
+	Run()
+	cardinalSystem()
+}
+
 func RegisterSystem[T any](world *World, system func(*T), opts ...SystemOption) {
 	cfg := newSystemConfig()
 	for _, opt := range opts {
@@ -40,32 +47,76 @@ func RegisterSystem[T any](world *World, system func(*T), opts ...SystemOption) 
 	}
 
 	name := fmt.Sprintf("%T", system)
-	fn := func() { system(state) }
+	registerSystem(world, name, cfg.hook, func() { system(state) })
+}
 
-	// If debug is enabled, wrap the system function with performance instrumentation.
+// RegisterSystemV2 registers a caller-owned system instance. The instance must
+// be a non-nil pointer to a struct that embeds BaseSystemState.
+func RegisterSystemV2(world *World, system System, opts ...SystemOption) {
+	cfg := newSystemConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	value := reflect.ValueOf(system)
+	if value.Kind() != reflect.Pointer || value.IsNil() || value.Elem().Kind() != reflect.Struct {
+		panic(eris.Errorf("system %T must be a non-nil pointer to a struct", system))
+	}
+
+	state := value.Elem()
+	stateType := state.Type()
+	if _, ok := stateType.MethodByName("Run"); ok {
+		panic(eris.Errorf("system %T Run method must use a pointer receiver", system))
+	}
+
+	baseField, ok := stateType.FieldByName("BaseSystemState")
+	if !ok || len(baseField.Index) != 1 || !baseField.Anonymous ||
+		baseField.Type != reflect.TypeFor[BaseSystemState]() {
+		panic(eris.Errorf("system %T must embed cardinal.BaseSystemState", system))
+	}
+
+	if err := initSystemV2Fields(state, world); err != nil {
+		panic(eris.Wrapf(err, "error initializing system fields"))
+	}
+
+	registerSystem(world, fmt.Sprintf("%T", system), cfg.hook, system.Run)
+}
+
+func registerSystem(world *World, name string, hook SystemHook, run func()) {
+	fn := run
+
+	// If debug is enabled, wrap the system with performance instrumentation.
 	if world.debug != nil {
 		fn = func() {
 			ts := world.currentTick.timestamp
 			startTime := ts.Add(time.Since(ts))
-			system(state)
+			run()
 			endTime := ts.Add(time.Since(ts))
 			world.debug.recordSpan(performance.TickSpan{
 				TickHeight: world.currentTick.height,
 				SystemName: name,
-				SystemHook: uint8(cfg.hook),
+				SystemHook: uint8(hook),
 				StartTime:  startTime,
 				EndTime:    endTime,
 			})
 		}
 	}
 
-	err := ecs.RegisterSystem(world.world, name, cfg.hook, fn)
+	err := ecs.RegisterSystem(world.world, name, hook, fn)
 	if err != nil {
 		panic(eris.Wrapf(err, "error registering system"))
 	}
 }
 
 func initSystemFields[T any](state *T, world *World) error {
+	return initSystemFieldValues(reflect.ValueOf(state).Elem(), world, false)
+}
+
+func initSystemV2Fields(state reflect.Value, world *World) error {
+	return initSystemFieldValues(state, world, true)
+}
+
+func initSystemFieldValues(state reflect.Value, world *World, allowPrivateState bool) error {
 	meta := systemInitMetadata{
 		world:        world,
 		commands:     make(map[string]struct{}),
@@ -74,18 +125,26 @@ func initSystemFields[T any](state *T, world *World) error {
 	}
 
 	// For each field in the system state, initialize the field and collect its dependencies.
-	value := reflect.ValueOf(state).Elem()
-	for i := range value.NumField() {
-		field := value.Field(i)
-		fieldType := value.Type().Field(i)
+	for i := range state.NumField() {
+		field := state.Field(i)
+		fieldType := state.Type().Field(i)
 
-		// Ignore private implementation state, but keep private Cardinal dependencies
-		// as fail-fast configuration errors.
-		if !fieldType.IsExported() {
-			if field.Addr().Type().Implements(reflect.TypeFor[systemField]()) {
+		if allowPrivateState && !fieldType.IsExported() {
+			systemFieldType := reflect.TypeFor[systemField]()
+			if field.Type().Implements(systemFieldType) ||
+				field.Addr().Type().Implements(systemFieldType) {
 				return eris.Errorf("field %s must be exported", fieldType.Name)
 			}
 			continue
+		}
+
+		if allowPrivateState && field.Type().Implements(reflect.TypeFor[systemField]()) {
+			return eris.Errorf("field %s must be declared as a value", fieldType.Name)
+		}
+
+		// If the field is not exported, return an error.
+		if !field.CanAddr() {
+			return eris.Errorf("field %s must be exported", fieldType.Name)
 		}
 
 		fieldInstance := field.Addr().Interface()
@@ -175,6 +234,8 @@ func WithHook(hook SystemHook) SystemOption {
 type BaseSystemState struct {
 	world *World
 }
+
+func (*BaseSystemState) cardinalSystem() {}
 
 func (b *BaseSystemState) init(meta *systemInitMetadata) error {
 	b.world = meta.world

--- a/pkg/cardinal/system.go
+++ b/pkg/cardinal/system.go
@@ -79,9 +79,13 @@ func initSystemFields[T any](state *T, world *World) error {
 		field := value.Field(i)
 		fieldType := value.Type().Field(i)
 
-		// If the field is not exported, return an error.
-		if !field.CanAddr() {
-			return eris.Errorf("field %s must be exported", fieldType.Name)
+		// Ignore private implementation state, but keep private Cardinal dependencies
+		// as fail-fast configuration errors.
+		if !fieldType.IsExported() {
+			if field.Addr().Type().Implements(reflect.TypeFor[systemField]()) {
+				return eris.Errorf("field %s must be exported", fieldType.Name)
+			}
+			continue
 		}
 
 		fieldInstance := field.Addr().Interface()

--- a/pkg/cardinal/system.go
+++ b/pkg/cardinal/system.go
@@ -52,7 +52,7 @@ func RegisterSystem[T any](world *World, system func(*T), opts ...SystemOption) 
 
 // RegisterSystemV2 registers a caller-owned system instance. The instance must
 // be a non-nil pointer to a struct that embeds BaseSystemState.
-func RegisterSystemV2(world *World, s System, opts ...SystemOption) {
+func RegisterSystemV2[S System](world *World, s S, opts ...SystemOption) {
 	cfg := newSystemConfig()
 	for _, opt := range opts {
 		opt(&cfg)

--- a/pkg/cardinal/system.go
+++ b/pkg/cardinal/system.go
@@ -20,6 +20,13 @@ import (
 
 type EntityID = ecs.EntityID
 
+// System is a stateful Cardinal system. Implement it with a Run method on a
+// pointer to a struct that embeds BaseSystemState.
+type System interface {
+	Run()
+	cardinalSystem()
+}
+
 func RegisterSystem[T any](world *World, system func(*T), opts ...SystemOption) {
 	cfg := newSystemConfig()
 	for _, opt := range opts {
@@ -41,32 +48,76 @@ func RegisterSystem[T any](world *World, system func(*T), opts ...SystemOption) 
 	}
 
 	name := fmt.Sprintf("%T", system)
-	fn := func() { system(state) }
+	registerSystem(world, name, cfg.hook, func() { system(state) })
+}
 
-	// If debug is enabled, wrap the system function with performance instrumentation.
+// RegisterSystemV2 registers a caller-owned system instance. The instance must
+// be a non-nil pointer to a struct that embeds BaseSystemState.
+func RegisterSystemV2(world *World, system System, opts ...SystemOption) {
+	cfg := newSystemConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	value := reflect.ValueOf(system)
+	if value.Kind() != reflect.Pointer || value.IsNil() || value.Elem().Kind() != reflect.Struct {
+		panic(eris.Errorf("system %T must be a non-nil pointer to a struct", system))
+	}
+
+	state := value.Elem()
+	stateType := state.Type()
+	if _, ok := stateType.MethodByName("Run"); ok {
+		panic(eris.Errorf("system %T Run method must use a pointer receiver", system))
+	}
+
+	baseField, ok := stateType.FieldByName("BaseSystemState")
+	if !ok || len(baseField.Index) != 1 || !baseField.Anonymous ||
+		baseField.Type != reflect.TypeFor[BaseSystemState]() {
+		panic(eris.Errorf("system %T must embed cardinal.BaseSystemState", system))
+	}
+
+	if err := initSystemV2Fields(state, world); err != nil {
+		panic(eris.Wrapf(err, "error initializing system fields"))
+	}
+
+	registerSystem(world, fmt.Sprintf("%T", system), cfg.hook, system.Run)
+}
+
+func registerSystem(world *World, name string, hook SystemHook, run func()) {
+	fn := run
+
+	// If debug is enabled, wrap the system with performance instrumentation.
 	if world.debug != nil {
 		fn = func() {
 			ts := world.currentTick.timestamp
 			startTime := ts.Add(time.Since(ts))
-			system(state)
+			run()
 			endTime := ts.Add(time.Since(ts))
 			world.debug.recordSpan(performance.TickSpan{
 				TickHeight: world.currentTick.height,
 				SystemName: name,
-				SystemHook: uint8(cfg.hook),
+				SystemHook: uint8(hook),
 				StartTime:  startTime,
 				EndTime:    endTime,
 			})
 		}
 	}
 
-	err := ecs.RegisterSystem(world.world, name, cfg.hook, fn)
+	err := ecs.RegisterSystem(world.world, name, hook, fn)
 	if err != nil {
 		panic(eris.Wrapf(err, "error registering system"))
 	}
 }
 
 func initSystemFields[T any](state *T, world *World) error {
+	return initSystemFieldValues(reflect.ValueOf(state).Elem(), world, false)
+}
+
+func initSystemV2Fields(state reflect.Value, world *World) error {
+	return initSystemFieldValues(state, world, true)
+}
+
+func initSystemFieldValues(state reflect.Value, world *World, allowPrivateState bool) error {
 	meta := systemInitMetadata{
 		world:        world,
 		commands:     make(map[string]struct{}),
@@ -75,18 +126,26 @@ func initSystemFields[T any](state *T, world *World) error {
 	}
 
 	// For each field in the system state, initialize the field and collect its dependencies.
-	value := reflect.ValueOf(state).Elem()
-	for i := range value.NumField() {
-		field := value.Field(i)
-		fieldType := value.Type().Field(i)
+	for i := range state.NumField() {
+		field := state.Field(i)
+		fieldType := state.Type().Field(i)
 
-		// Ignore private implementation state, but keep private Cardinal dependencies
-		// as fail-fast configuration errors.
-		if !fieldType.IsExported() {
-			if field.Addr().Type().Implements(reflect.TypeFor[systemField]()) {
+		if allowPrivateState && !fieldType.IsExported() {
+			systemFieldType := reflect.TypeFor[systemField]()
+			if field.Type().Implements(systemFieldType) ||
+				field.Addr().Type().Implements(systemFieldType) {
 				return eris.Errorf("field %s must be exported", fieldType.Name)
 			}
 			continue
+		}
+
+		if allowPrivateState && field.Type().Implements(reflect.TypeFor[systemField]()) {
+			return eris.Errorf("field %s must be declared as a value", fieldType.Name)
+		}
+
+		// If the field is not exported, return an error.
+		if !field.CanAddr() {
+			return eris.Errorf("field %s must be exported", fieldType.Name)
 		}
 
 		fieldInstance := field.Addr().Interface()
@@ -176,6 +235,8 @@ func WithHook(hook SystemHook) SystemOption {
 type BaseSystemState struct {
 	world *World
 }
+
+func (*BaseSystemState) cardinalSystem() {}
 
 func (b *BaseSystemState) init(meta *systemInitMetadata) error {
 	b.world = meta.world

--- a/pkg/cardinal/system.go
+++ b/pkg/cardinal/system.go
@@ -53,7 +53,7 @@ func RegisterSystem[T any](world *World, system func(*T), opts ...SystemOption) 
 
 // RegisterSystemV2 registers a caller-owned system instance. The instance must
 // be a non-nil pointer to a struct that embeds BaseSystemState.
-func RegisterSystemV2(world *World, s System, opts ...SystemOption) {
+func RegisterSystemV2[S System](world *World, s S, opts ...SystemOption) {
 	cfg := newSystemConfig()
 	for _, opt := range opts {
 		opt(&cfg)

--- a/pkg/cardinal/system.go
+++ b/pkg/cardinal/system.go
@@ -53,34 +53,34 @@ func RegisterSystem[T any](world *World, system func(*T), opts ...SystemOption) 
 
 // RegisterSystemV2 registers a caller-owned system instance. The instance must
 // be a non-nil pointer to a struct that embeds BaseSystemState.
-func RegisterSystemV2(world *World, system System, opts ...SystemOption) {
+func RegisterSystemV2(world *World, s System, opts ...SystemOption) {
 	cfg := newSystemConfig()
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
-	value := reflect.ValueOf(system)
+	value := reflect.ValueOf(s)
 	if value.Kind() != reflect.Pointer || value.IsNil() || value.Elem().Kind() != reflect.Struct {
-		panic(eris.Errorf("system %T must be a non-nil pointer to a struct", system))
+		panic(eris.Errorf("system %T must be a non-nil pointer to a struct", s))
 	}
 
 	state := value.Elem()
 	stateType := state.Type()
 	if _, ok := stateType.MethodByName("Run"); ok {
-		panic(eris.Errorf("system %T Run method must use a pointer receiver", system))
+		panic(eris.Errorf("system %T Run method must use a pointer receiver", s))
 	}
 
 	baseField, ok := stateType.FieldByName("BaseSystemState")
 	if !ok || len(baseField.Index) != 1 || !baseField.Anonymous ||
 		baseField.Type != reflect.TypeFor[BaseSystemState]() {
-		panic(eris.Errorf("system %T must embed cardinal.BaseSystemState", system))
+		panic(eris.Errorf("system %T must embed cardinal.BaseSystemState", s))
 	}
 
 	if err := initSystemV2Fields(state, world); err != nil {
 		panic(eris.Wrapf(err, "error initializing system fields"))
 	}
 
-	registerSystem(world, fmt.Sprintf("%T", system), cfg.hook, system.Run)
+	registerSystem(world, fmt.Sprintf("%T", s), cfg.hook, s.Run)
 }
 
 func registerSystem(world *World, name string, hook SystemHook, run func()) {

--- a/pkg/cardinal/system.go
+++ b/pkg/cardinal/system.go
@@ -80,9 +80,13 @@ func initSystemFields[T any](state *T, world *World) error {
 		field := value.Field(i)
 		fieldType := value.Type().Field(i)
 
-		// If the field is not exported, return an error.
-		if !field.CanAddr() {
-			return eris.Errorf("field %s must be exported", fieldType.Name)
+		// Ignore private implementation state, but keep private Cardinal dependencies
+		// as fail-fast configuration errors.
+		if !fieldType.IsExported() {
+			if field.Addr().Type().Implements(reflect.TypeFor[systemField]()) {
+				return eris.Errorf("field %s must be exported", fieldType.Name)
+			}
+			continue
 		}
 
 		fieldInstance := field.Addr().Interface()

--- a/pkg/cardinal/system.go
+++ b/pkg/cardinal/system.go
@@ -20,11 +20,10 @@ import (
 
 type EntityID = ecs.EntityID
 
-// System is a stateful Cardinal system. Implement it with a Run method on a
-// pointer to a struct that embeds BaseSystemState.
+// System is a stateful Cardinal system. Implement it with a Run method on a pointer to a struct
+// that embeds BaseSystemState.
 type System interface {
 	Run()
-	cardinalSystem()
 }
 
 func RegisterSystem[T any](world *World, system func(*T), opts ...SystemOption) {
@@ -43,7 +42,7 @@ func RegisterSystem[T any](world *World, system func(*T), opts ...SystemOption) 
 	// Initialize the fields in the system state.
 	state := new(T)
 
-	if err := initSystemFields(state, world); err != nil {
+	if err := initSystemFields(reflect.ValueOf(state).Elem(), world); err != nil {
 		panic(eris.Wrapf(err, "error initializing system fields"))
 	}
 
@@ -51,8 +50,8 @@ func RegisterSystem[T any](world *World, system func(*T), opts ...SystemOption) 
 	registerSystem(world, name, cfg.hook, func() { system(state) })
 }
 
-// RegisterSystemV2 registers a caller-owned system instance. The instance must
-// be a non-nil pointer to a struct that embeds BaseSystemState.
+// RegisterSystemV2 registers a caller-owned system instance. The instance must be a non-nil pointer
+// to a struct that embeds BaseSystemState.
 func RegisterSystemV2[S System](world *World, s S, opts ...SystemOption) {
 	cfg := newSystemConfig()
 	for _, opt := range opts {
@@ -76,7 +75,7 @@ func RegisterSystemV2[S System](world *World, s S, opts ...SystemOption) {
 		panic(eris.Errorf("system %T must embed cardinal.BaseSystemState", s))
 	}
 
-	if err := initSystemV2Fields(state, world); err != nil {
+	if err := initSystemFields(state, world); err != nil {
 		panic(eris.Wrapf(err, "error initializing system fields"))
 	}
 
@@ -109,15 +108,7 @@ func registerSystem(world *World, name string, hook SystemHook, run func()) {
 	}
 }
 
-func initSystemFields[T any](state *T, world *World) error {
-	return initSystemFieldValues(reflect.ValueOf(state).Elem(), world, false)
-}
-
-func initSystemV2Fields(state reflect.Value, world *World) error {
-	return initSystemFieldValues(state, world, true)
-}
-
-func initSystemFieldValues(state reflect.Value, world *World, allowPrivateState bool) error {
+func initSystemFields(state reflect.Value, world *World) error {
 	meta := systemInitMetadata{
 		world:        world,
 		commands:     make(map[string]struct{}),
@@ -130,7 +121,7 @@ func initSystemFieldValues(state reflect.Value, world *World, allowPrivateState 
 		field := state.Field(i)
 		fieldType := state.Type().Field(i)
 
-		if allowPrivateState && !fieldType.IsExported() {
+		if !fieldType.IsExported() {
 			systemFieldType := reflect.TypeFor[systemField]()
 			if field.Type().Implements(systemFieldType) ||
 				field.Addr().Type().Implements(systemFieldType) {
@@ -139,13 +130,8 @@ func initSystemFieldValues(state reflect.Value, world *World, allowPrivateState 
 			continue
 		}
 
-		if allowPrivateState && field.Type().Implements(reflect.TypeFor[systemField]()) {
+		if field.Type().Implements(reflect.TypeFor[systemField]()) {
 			return eris.Errorf("field %s must be declared as a value", fieldType.Name)
-		}
-
-		// If the field is not exported, return an error.
-		if !field.CanAddr() {
-			return eris.Errorf("field %s must be exported", fieldType.Name)
 		}
 
 		fieldInstance := field.Addr().Interface()
@@ -235,8 +221,6 @@ func WithHook(hook SystemHook) SystemOption {
 type BaseSystemState struct {
 	world *World
 }
-
-func (*BaseSystemState) cardinalSystem() {}
 
 func (b *BaseSystemState) init(meta *systemInitMetadata) error {
 	b.world = meta.world

--- a/pkg/cardinal/system.go
+++ b/pkg/cardinal/system.go
@@ -52,34 +52,34 @@ func RegisterSystem[T any](world *World, system func(*T), opts ...SystemOption) 
 
 // RegisterSystemV2 registers a caller-owned system instance. The instance must
 // be a non-nil pointer to a struct that embeds BaseSystemState.
-func RegisterSystemV2(world *World, system System, opts ...SystemOption) {
+func RegisterSystemV2(world *World, s System, opts ...SystemOption) {
 	cfg := newSystemConfig()
 	for _, opt := range opts {
 		opt(&cfg)
 	}
 
-	value := reflect.ValueOf(system)
+	value := reflect.ValueOf(s)
 	if value.Kind() != reflect.Pointer || value.IsNil() || value.Elem().Kind() != reflect.Struct {
-		panic(eris.Errorf("system %T must be a non-nil pointer to a struct", system))
+		panic(eris.Errorf("system %T must be a non-nil pointer to a struct", s))
 	}
 
 	state := value.Elem()
 	stateType := state.Type()
 	if _, ok := stateType.MethodByName("Run"); ok {
-		panic(eris.Errorf("system %T Run method must use a pointer receiver", system))
+		panic(eris.Errorf("system %T Run method must use a pointer receiver", s))
 	}
 
 	baseField, ok := stateType.FieldByName("BaseSystemState")
 	if !ok || len(baseField.Index) != 1 || !baseField.Anonymous ||
 		baseField.Type != reflect.TypeFor[BaseSystemState]() {
-		panic(eris.Errorf("system %T must embed cardinal.BaseSystemState", system))
+		panic(eris.Errorf("system %T must embed cardinal.BaseSystemState", s))
 	}
 
 	if err := initSystemV2Fields(state, world); err != nil {
 		panic(eris.Wrapf(err, "error initializing system fields"))
 	}
 
-	registerSystem(world, fmt.Sprintf("%T", system), cfg.hook, system.Run)
+	registerSystem(world, fmt.Sprintf("%T", s), cfg.hook, s.Run)
 }
 
 func registerSystem(world *World, name string, hook SystemHook, run func()) {

--- a/pkg/cardinal/system_internal_test.go
+++ b/pkg/cardinal/system_internal_test.go
@@ -22,9 +22,9 @@ type privateStateSystem struct {
 	scratch    []int
 }
 
-func (system *privateStateSystem) Run() {
-	(*system.dependency)++
-	system.scratch = append(system.scratch, *system.dependency)
+func (s *privateStateSystem) Run() {
+	(*s.dependency)++
+	s.scratch = append(s.scratch, *s.dependency)
 }
 
 type privateDependencySystem struct {
@@ -33,8 +33,8 @@ type privateDependencySystem struct {
 	events WithEvent[testutils.SimpleEvent]
 }
 
-func (system *privateDependencySystem) Run() {
-	_ = system.events
+func (s *privateDependencySystem) Run() {
+	_ = s.events
 }
 
 type privatePointerDependencySystem struct {
@@ -43,8 +43,8 @@ type privatePointerDependencySystem struct {
 	events *WithEvent[testutils.SimpleEvent]
 }
 
-func (system *privatePointerDependencySystem) Run() {
-	_ = system.events
+func (s *privatePointerDependencySystem) Run() {
+	_ = s.events
 }
 
 type exportedPointerDependencySystem struct {
@@ -53,8 +53,8 @@ type exportedPointerDependencySystem struct {
 	Events *WithEvent[testutils.SimpleEvent]
 }
 
-func (system *exportedPointerDependencySystem) Run() {
-	_ = system.Events
+func (s *exportedPointerDependencySystem) Run() {
+	_ = s.Events
 }
 
 type valueSystem struct {
@@ -78,16 +78,16 @@ func TestRegisterSystemV2_UsesCallerOwnedInstance(t *testing.T) {
 
 	dependency := 40
 	world := &World{world: ecs.NewWorld()}
-	system := &privateStateSystem{dependency: &dependency}
+	s := &privateStateSystem{dependency: &dependency}
 
-	RegisterSystemV2(world, system)
+	RegisterSystemV2(world, s)
 	world.world.Init()
 	world.world.Tick()
 	world.world.Tick()
 
-	assert.Same(t, world, system.world)
+	assert.Same(t, world, s.world)
 	assert.Equal(t, 42, dependency)
-	assert.Equal(t, []int{41, 42}, system.scratch)
+	assert.Equal(t, []int{41, 42}, s.scratch)
 }
 
 func TestRegisterSystemV2_HonorsHook(t *testing.T) {
@@ -95,9 +95,9 @@ func TestRegisterSystemV2_HonorsHook(t *testing.T) {
 
 	dependency := 40
 	world := &World{world: ecs.NewWorld()}
-	system := &privateStateSystem{dependency: &dependency}
+	s := &privateStateSystem{dependency: &dependency}
 
-	RegisterSystemV2(world, system, WithHook(Init))
+	RegisterSystemV2(world, s, WithHook(Init))
 	assert.Equal(t, 40, dependency)
 
 	world.world.Init()
@@ -107,7 +107,7 @@ func TestRegisterSystemV2_HonorsHook(t *testing.T) {
 	world.world.Tick()
 
 	assert.Equal(t, 41, dependency)
-	assert.Equal(t, []int{41}, system.scratch)
+	assert.Equal(t, []int{41}, s.scratch)
 }
 
 func TestRegisterSystemV2_RejectsPrivateCardinalDependency(t *testing.T) {
@@ -161,11 +161,11 @@ func TestRegisterSystemV2_RejectsInvalidInstances(t *testing.T) {
 	t.Run("typed nil", func(t *testing.T) {
 		t.Parallel()
 
-		var system *privateStateSystem
+		var s *privateStateSystem
 		require.PanicsWithError(
 			t,
 			"system *cardinal.privateStateSystem must be a non-nil pointer to a struct",
-			func() { RegisterSystemV2(world, system) },
+			func() { RegisterSystemV2(world, s) },
 		)
 	})
 

--- a/pkg/cardinal/system_internal_test.go
+++ b/pkg/cardinal/system_internal_test.go
@@ -23,9 +23,9 @@ type privateStateSystem struct {
 	scratch    []int
 }
 
-func (system *privateStateSystem) Run() {
-	(*system.dependency)++
-	system.scratch = append(system.scratch, *system.dependency)
+func (s *privateStateSystem) Run() {
+	(*s.dependency)++
+	s.scratch = append(s.scratch, *s.dependency)
 }
 
 type privateDependencySystem struct {
@@ -34,8 +34,8 @@ type privateDependencySystem struct {
 	events WithEvent[testutils.SimpleEvent]
 }
 
-func (system *privateDependencySystem) Run() {
-	_ = system.events
+func (s *privateDependencySystem) Run() {
+	_ = s.events
 }
 
 type privatePointerDependencySystem struct {
@@ -44,8 +44,8 @@ type privatePointerDependencySystem struct {
 	events *WithEvent[testutils.SimpleEvent]
 }
 
-func (system *privatePointerDependencySystem) Run() {
-	_ = system.events
+func (s *privatePointerDependencySystem) Run() {
+	_ = s.events
 }
 
 type exportedPointerDependencySystem struct {
@@ -54,8 +54,8 @@ type exportedPointerDependencySystem struct {
 	Events *WithEvent[testutils.SimpleEvent]
 }
 
-func (system *exportedPointerDependencySystem) Run() {
-	_ = system.Events
+func (s *exportedPointerDependencySystem) Run() {
+	_ = s.Events
 }
 
 type valueSystem struct {
@@ -79,16 +79,16 @@ func TestRegisterSystemV2_UsesCallerOwnedInstance(t *testing.T) {
 
 	dependency := 40
 	world := &World{world: ecs.NewWorld()}
-	system := &privateStateSystem{dependency: &dependency}
+	s := &privateStateSystem{dependency: &dependency}
 
-	RegisterSystemV2(world, system)
+	RegisterSystemV2(world, s)
 	world.world.Init()
 	world.world.Tick()
 	world.world.Tick()
 
-	assert.Same(t, world, system.world)
+	assert.Same(t, world, s.world)
 	assert.Equal(t, 42, dependency)
-	assert.Equal(t, []int{41, 42}, system.scratch)
+	assert.Equal(t, []int{41, 42}, s.scratch)
 }
 
 func TestRegisterSystemV2_HonorsHook(t *testing.T) {
@@ -96,9 +96,9 @@ func TestRegisterSystemV2_HonorsHook(t *testing.T) {
 
 	dependency := 40
 	world := &World{world: ecs.NewWorld()}
-	system := &privateStateSystem{dependency: &dependency}
+	s := &privateStateSystem{dependency: &dependency}
 
-	RegisterSystemV2(world, system, WithHook(Init))
+	RegisterSystemV2(world, s, WithHook(Init))
 	assert.Equal(t, 40, dependency)
 
 	world.world.Init()
@@ -108,7 +108,7 @@ func TestRegisterSystemV2_HonorsHook(t *testing.T) {
 	world.world.Tick()
 
 	assert.Equal(t, 41, dependency)
-	assert.Equal(t, []int{41}, system.scratch)
+	assert.Equal(t, []int{41}, s.scratch)
 }
 
 func TestRegisterSystemV2_RejectsPrivateCardinalDependency(t *testing.T) {
@@ -162,11 +162,11 @@ func TestRegisterSystemV2_RejectsInvalidInstances(t *testing.T) {
 	t.Run("typed nil", func(t *testing.T) {
 		t.Parallel()
 
-		var system *privateStateSystem
+		var s *privateStateSystem
 		require.PanicsWithError(
 			t,
 			"system *cardinal.privateStateSystem must be a non-nil pointer to a struct",
-			func() { RegisterSystemV2(world, system) },
+			func() { RegisterSystemV2(world, s) },
 		)
 	})
 

--- a/pkg/cardinal/system_internal_test.go
+++ b/pkg/cardinal/system_internal_test.go
@@ -23,55 +23,172 @@ type privateStateSystem struct {
 	scratch    []int
 }
 
+func (system *privateStateSystem) Run() {
+	(*system.dependency)++
+	system.scratch = append(system.scratch, *system.dependency)
+}
+
 type privateDependencySystem struct {
 	BaseSystemState
 
 	events WithEvent[testutils.SimpleEvent]
 }
 
-func TestRegisterSystem_AllowsPersistentPrivateState(t *testing.T) {
+func (system *privateDependencySystem) Run() {
+	_ = system.events
+}
+
+type privatePointerDependencySystem struct {
+	BaseSystemState
+
+	events *WithEvent[testutils.SimpleEvent]
+}
+
+func (system *privatePointerDependencySystem) Run() {
+	_ = system.events
+}
+
+type exportedPointerDependencySystem struct {
+	BaseSystemState
+
+	Events *WithEvent[testutils.SimpleEvent]
+}
+
+func (system *exportedPointerDependencySystem) Run() {
+	_ = system.Events
+}
+
+type valueSystem struct {
+	BaseSystemState
+}
+
+func (valueSystem) Run() {}
+
+type indirectBaseState struct {
+	BaseSystemState
+}
+
+type indirectBaseSystem struct {
+	indirectBaseState
+}
+
+func (*indirectBaseSystem) Run() {}
+
+func TestRegisterSystemV2_UsesCallerOwnedInstance(t *testing.T) {
 	t.Parallel()
 
 	dependency := 40
 	world := &World{world: ecs.NewWorld()}
-	var firstState *privateStateSystem
+	system := &privateStateSystem{dependency: &dependency}
 
-	RegisterSystem(world, func(state *privateStateSystem) {
-		if state.dependency == nil {
-			state.dependency = &dependency
-		}
-		if firstState == nil {
-			firstState = state
-		}
-
-		assert.Same(t, firstState, state)
-		(*state.dependency)++
-		state.scratch = append(state.scratch, *state.dependency)
-	})
+	RegisterSystemV2(world, system)
 	world.world.Init()
 	world.world.Tick()
 	world.world.Tick()
 
-	require.NotNil(t, firstState)
-	assert.Same(t, world, firstState.world)
+	assert.Same(t, world, system.world)
 	assert.Equal(t, 42, dependency)
-	assert.Equal(t, []int{41, 42}, firstState.scratch)
+	assert.Equal(t, []int{41, 42}, system.scratch)
 }
 
-func TestRegisterSystem_RejectsPrivateCardinalDependency(t *testing.T) {
+func TestRegisterSystemV2_HonorsHook(t *testing.T) {
+	t.Parallel()
+
+	dependency := 40
+	world := &World{world: ecs.NewWorld()}
+	system := &privateStateSystem{dependency: &dependency}
+
+	RegisterSystemV2(world, system, WithHook(Init))
+	assert.Equal(t, 40, dependency)
+
+	world.world.Init()
+	assert.Equal(t, 41, dependency)
+
+	world.world.Tick()
+	world.world.Tick()
+
+	assert.Equal(t, 41, dependency)
+	assert.Equal(t, []int{41}, system.scratch)
+}
+
+func TestRegisterSystemV2_RejectsPrivateCardinalDependency(t *testing.T) {
+	t.Parallel()
+
+	t.Run("value", func(t *testing.T) {
+		t.Parallel()
+
+		world := &World{world: ecs.NewWorld()}
+		require.PanicsWithError(
+			t,
+			"error initializing system fields: field events must be exported",
+			func() {
+				RegisterSystemV2(world, &privateDependencySystem{})
+			},
+		)
+	})
+
+	t.Run("pointer", func(t *testing.T) {
+		t.Parallel()
+
+		world := &World{world: ecs.NewWorld()}
+		require.PanicsWithError(
+			t,
+			"error initializing system fields: field events must be exported",
+			func() {
+				RegisterSystemV2(world, &privatePointerDependencySystem{})
+			},
+		)
+	})
+}
+
+func TestRegisterSystemV2_RejectsPointerCardinalDependency(t *testing.T) {
+	t.Parallel()
+
+	world := &World{world: ecs.NewWorld()}
+	require.PanicsWithError(
+		t,
+		"error initializing system fields: field Events must be declared as a value",
+		func() {
+			RegisterSystemV2(world, &exportedPointerDependencySystem{})
+		},
+	)
+}
+
+func TestRegisterSystemV2_RejectsInvalidInstances(t *testing.T) {
 	t.Parallel()
 
 	world := &World{world: ecs.NewWorld()}
 
-	require.PanicsWithError(
-		t,
-		"error initializing system fields: field events must be exported",
-		func() {
-			RegisterSystem(world, func(state *privateDependencySystem) {
-				_ = state.events
-			})
-		},
-	)
+	t.Run("typed nil", func(t *testing.T) {
+		t.Parallel()
+
+		var system *privateStateSystem
+		require.PanicsWithError(
+			t,
+			"system *cardinal.privateStateSystem must be a non-nil pointer to a struct",
+			func() { RegisterSystemV2(world, system) },
+		)
+	})
+
+	t.Run("value receiver", func(t *testing.T) {
+		t.Parallel()
+
+		require.PanicsWithError(
+			t,
+			"system *cardinal.valueSystem Run method must use a pointer receiver",
+			func() { RegisterSystemV2(world, &valueSystem{}) },
+		)
+	})
+
+	t.Run("indirect base state", func(t *testing.T) {
+		t.Parallel()
+
+		require.PanicsWithError(
+			t,
+			"system *cardinal.indirectBaseSystem must embed cardinal.BaseSystemState",
+			func() { RegisterSystemV2(world, &indirectBaseSystem{}) },
+		)
+	})
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/pkg/cardinal/system_internal_test.go
+++ b/pkg/cardinal/system_internal_test.go
@@ -22,55 +22,172 @@ type privateStateSystem struct {
 	scratch    []int
 }
 
+func (system *privateStateSystem) Run() {
+	(*system.dependency)++
+	system.scratch = append(system.scratch, *system.dependency)
+}
+
 type privateDependencySystem struct {
 	BaseSystemState
 
 	events WithEvent[testutils.SimpleEvent]
 }
 
-func TestRegisterSystem_AllowsPersistentPrivateState(t *testing.T) {
+func (system *privateDependencySystem) Run() {
+	_ = system.events
+}
+
+type privatePointerDependencySystem struct {
+	BaseSystemState
+
+	events *WithEvent[testutils.SimpleEvent]
+}
+
+func (system *privatePointerDependencySystem) Run() {
+	_ = system.events
+}
+
+type exportedPointerDependencySystem struct {
+	BaseSystemState
+
+	Events *WithEvent[testutils.SimpleEvent]
+}
+
+func (system *exportedPointerDependencySystem) Run() {
+	_ = system.Events
+}
+
+type valueSystem struct {
+	BaseSystemState
+}
+
+func (valueSystem) Run() {}
+
+type indirectBaseState struct {
+	BaseSystemState
+}
+
+type indirectBaseSystem struct {
+	indirectBaseState
+}
+
+func (*indirectBaseSystem) Run() {}
+
+func TestRegisterSystemV2_UsesCallerOwnedInstance(t *testing.T) {
 	t.Parallel()
 
 	dependency := 40
 	world := &World{world: ecs.NewWorld()}
-	var firstState *privateStateSystem
+	system := &privateStateSystem{dependency: &dependency}
 
-	RegisterSystem(world, func(state *privateStateSystem) {
-		if state.dependency == nil {
-			state.dependency = &dependency
-		}
-		if firstState == nil {
-			firstState = state
-		}
-
-		assert.Same(t, firstState, state)
-		(*state.dependency)++
-		state.scratch = append(state.scratch, *state.dependency)
-	})
+	RegisterSystemV2(world, system)
 	world.world.Init()
 	world.world.Tick()
 	world.world.Tick()
 
-	require.NotNil(t, firstState)
-	assert.Same(t, world, firstState.world)
+	assert.Same(t, world, system.world)
 	assert.Equal(t, 42, dependency)
-	assert.Equal(t, []int{41, 42}, firstState.scratch)
+	assert.Equal(t, []int{41, 42}, system.scratch)
 }
 
-func TestRegisterSystem_RejectsPrivateCardinalDependency(t *testing.T) {
+func TestRegisterSystemV2_HonorsHook(t *testing.T) {
+	t.Parallel()
+
+	dependency := 40
+	world := &World{world: ecs.NewWorld()}
+	system := &privateStateSystem{dependency: &dependency}
+
+	RegisterSystemV2(world, system, WithHook(Init))
+	assert.Equal(t, 40, dependency)
+
+	world.world.Init()
+	assert.Equal(t, 41, dependency)
+
+	world.world.Tick()
+	world.world.Tick()
+
+	assert.Equal(t, 41, dependency)
+	assert.Equal(t, []int{41}, system.scratch)
+}
+
+func TestRegisterSystemV2_RejectsPrivateCardinalDependency(t *testing.T) {
+	t.Parallel()
+
+	t.Run("value", func(t *testing.T) {
+		t.Parallel()
+
+		world := &World{world: ecs.NewWorld()}
+		require.PanicsWithError(
+			t,
+			"error initializing system fields: field events must be exported",
+			func() {
+				RegisterSystemV2(world, &privateDependencySystem{})
+			},
+		)
+	})
+
+	t.Run("pointer", func(t *testing.T) {
+		t.Parallel()
+
+		world := &World{world: ecs.NewWorld()}
+		require.PanicsWithError(
+			t,
+			"error initializing system fields: field events must be exported",
+			func() {
+				RegisterSystemV2(world, &privatePointerDependencySystem{})
+			},
+		)
+	})
+}
+
+func TestRegisterSystemV2_RejectsPointerCardinalDependency(t *testing.T) {
+	t.Parallel()
+
+	world := &World{world: ecs.NewWorld()}
+	require.PanicsWithError(
+		t,
+		"error initializing system fields: field Events must be declared as a value",
+		func() {
+			RegisterSystemV2(world, &exportedPointerDependencySystem{})
+		},
+	)
+}
+
+func TestRegisterSystemV2_RejectsInvalidInstances(t *testing.T) {
 	t.Parallel()
 
 	world := &World{world: ecs.NewWorld()}
 
-	require.PanicsWithError(
-		t,
-		"error initializing system fields: field events must be exported",
-		func() {
-			RegisterSystem(world, func(state *privateDependencySystem) {
-				_ = state.events
-			})
-		},
-	)
+	t.Run("typed nil", func(t *testing.T) {
+		t.Parallel()
+
+		var system *privateStateSystem
+		require.PanicsWithError(
+			t,
+			"system *cardinal.privateStateSystem must be a non-nil pointer to a struct",
+			func() { RegisterSystemV2(world, system) },
+		)
+	})
+
+	t.Run("value receiver", func(t *testing.T) {
+		t.Parallel()
+
+		require.PanicsWithError(
+			t,
+			"system *cardinal.valueSystem Run method must use a pointer receiver",
+			func() { RegisterSystemV2(world, &valueSystem{}) },
+		)
+	})
+
+	t.Run("indirect base state", func(t *testing.T) {
+		t.Parallel()
+
+		require.PanicsWithError(
+			t,
+			"system *cardinal.indirectBaseSystem must embed cardinal.BaseSystemState",
+			func() { RegisterSystemV2(world, &indirectBaseSystem{}) },
+		)
+	})
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/pkg/cardinal/system_internal_test.go
+++ b/pkg/cardinal/system_internal_test.go
@@ -15,6 +15,64 @@ import (
 
 // TODO: test system registration, e.g. duplicate field detection, etc.
 
+type privateStateSystem struct {
+	BaseSystemState
+
+	dependency *int
+	scratch    []int
+}
+
+type privateDependencySystem struct {
+	BaseSystemState
+
+	events WithEvent[testutils.SimpleEvent]
+}
+
+func TestRegisterSystem_AllowsPersistentPrivateState(t *testing.T) {
+	t.Parallel()
+
+	dependency := 40
+	world := &World{world: ecs.NewWorld()}
+	var firstState *privateStateSystem
+
+	RegisterSystem(world, func(state *privateStateSystem) {
+		if state.dependency == nil {
+			state.dependency = &dependency
+		}
+		if firstState == nil {
+			firstState = state
+		}
+
+		assert.Same(t, firstState, state)
+		(*state.dependency)++
+		state.scratch = append(state.scratch, *state.dependency)
+	})
+	world.world.Init()
+	world.world.Tick()
+	world.world.Tick()
+
+	require.NotNil(t, firstState)
+	assert.Same(t, world, firstState.world)
+	assert.Equal(t, 42, dependency)
+	assert.Equal(t, []int{41, 42}, firstState.scratch)
+}
+
+func TestRegisterSystem_RejectsPrivateCardinalDependency(t *testing.T) {
+	t.Parallel()
+
+	world := &World{world: ecs.NewWorld()}
+
+	require.PanicsWithError(
+		t,
+		"error initializing system fields: field events must be exported",
+		func() {
+			RegisterSystem(world, func(state *privateDependencySystem) {
+				_ = state.events
+			})
+		},
+	)
+}
+
 // -------------------------------------------------------------------------------------------------
 // WithCommand smoke tests
 // -------------------------------------------------------------------------------------------------

--- a/pkg/cardinal/system_internal_test.go
+++ b/pkg/cardinal/system_internal_test.go
@@ -1,6 +1,7 @@
 package cardinal
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/argus-labs/world-engine/pkg/cardinal/internal/command"
@@ -13,7 +14,105 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TODO: test system registration, e.g. duplicate field detection, etc.
+// -------------------------------------------------------------------------------------------------
+// System registration tests
+// -------------------------------------------------------------------------------------------------
+
+func TestRegisterSystems_IgnorePrivateFields(t *testing.T) {
+	t.Parallel()
+
+	t.Run("v1", func(t *testing.T) {
+		t.Parallel()
+
+		world := &World{world: ecs.NewWorld()}
+		require.NotPanics(t, func() {
+			RegisterSystem(world, func(*privateStateSystem) {})
+		})
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		t.Parallel()
+
+		world := &World{world: ecs.NewWorld()}
+		require.NotPanics(t, func() {
+			RegisterSystemV2(world, &privateStateSystem{})
+		})
+	})
+}
+
+func TestRegisterSystems_RejectPrivateCardinalDependency(t *testing.T) {
+	t.Parallel()
+
+	assertRejected := func(t *testing.T, register func(*World)) {
+		t.Helper()
+		world := &World{world: ecs.NewWorld()}
+		require.PanicsWithError(
+			t,
+			"error initializing system fields: field events must be exported",
+			func() { register(world) },
+		)
+	}
+
+	t.Run("v1", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("value field", func(t *testing.T) {
+			assertRejected(t, func(world *World) {
+				RegisterSystem(world, func(*privateDependencySystem) {})
+			})
+		})
+		t.Run("pointer field", func(t *testing.T) {
+			assertRejected(t, func(world *World) {
+				RegisterSystem(world, func(*privatePointerDependencySystem) {})
+			})
+		})
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		t.Parallel()
+
+		t.Run("value field", func(t *testing.T) {
+			assertRejected(t, func(world *World) {
+				RegisterSystemV2(world, &privateDependencySystem{})
+			})
+		})
+		t.Run("pointer field", func(t *testing.T) {
+			assertRejected(t, func(world *World) {
+				RegisterSystemV2(world, &privatePointerDependencySystem{})
+			})
+		})
+	})
+}
+
+func TestRegisterSystems_RejectPointerCardinalDependency(t *testing.T) {
+	t.Parallel()
+
+	assertRejected := func(t *testing.T, register func(*World)) {
+		t.Helper()
+		world := &World{world: ecs.NewWorld()}
+		require.PanicsWithError(
+			t,
+			"error initializing system fields: field Events must be declared as a value",
+			func() { register(world) },
+		)
+	}
+
+	t.Run("v1", func(t *testing.T) {
+		t.Parallel()
+
+		assertRejected(t, func(world *World) {
+			RegisterSystem(world, func(*exportedPointerDependencySystem) {})
+		})
+	})
+
+	t.Run("v2", func(t *testing.T) {
+		t.Parallel()
+
+		assertRejected(t, func(world *World) {
+			RegisterSystemV2(world, &exportedPointerDependencySystem{})
+		})
+	})
+}
 
 type privateStateSystem struct {
 	BaseSystemState
@@ -55,139 +154,6 @@ type exportedPointerDependencySystem struct {
 
 func (s *exportedPointerDependencySystem) Run() {
 	_ = s.Events
-}
-
-type valueSystem struct {
-	BaseSystemState
-}
-
-func (valueSystem) Run() {}
-
-type indirectBaseState struct {
-	BaseSystemState
-}
-
-type indirectBaseSystem struct {
-	indirectBaseState
-}
-
-func (*indirectBaseSystem) Run() {}
-
-func TestRegisterSystemV2_UsesCallerOwnedInstance(t *testing.T) {
-	t.Parallel()
-
-	dependency := 40
-	world := &World{world: ecs.NewWorld()}
-	s := &privateStateSystem{dependency: &dependency}
-
-	RegisterSystemV2(world, s)
-	world.world.Init()
-	world.world.Tick()
-	world.world.Tick()
-
-	assert.Same(t, world, s.world)
-	assert.Equal(t, 42, dependency)
-	assert.Equal(t, []int{41, 42}, s.scratch)
-}
-
-func TestRegisterSystemV2_HonorsHook(t *testing.T) {
-	t.Parallel()
-
-	dependency := 40
-	world := &World{world: ecs.NewWorld()}
-	s := &privateStateSystem{dependency: &dependency}
-
-	RegisterSystemV2(world, s, WithHook(Init))
-	assert.Equal(t, 40, dependency)
-
-	world.world.Init()
-	assert.Equal(t, 41, dependency)
-
-	world.world.Tick()
-	world.world.Tick()
-
-	assert.Equal(t, 41, dependency)
-	assert.Equal(t, []int{41}, s.scratch)
-}
-
-func TestRegisterSystemV2_RejectsPrivateCardinalDependency(t *testing.T) {
-	t.Parallel()
-
-	t.Run("value", func(t *testing.T) {
-		t.Parallel()
-
-		world := &World{world: ecs.NewWorld()}
-		require.PanicsWithError(
-			t,
-			"error initializing system fields: field events must be exported",
-			func() {
-				RegisterSystemV2(world, &privateDependencySystem{})
-			},
-		)
-	})
-
-	t.Run("pointer", func(t *testing.T) {
-		t.Parallel()
-
-		world := &World{world: ecs.NewWorld()}
-		require.PanicsWithError(
-			t,
-			"error initializing system fields: field events must be exported",
-			func() {
-				RegisterSystemV2(world, &privatePointerDependencySystem{})
-			},
-		)
-	})
-}
-
-func TestRegisterSystemV2_RejectsPointerCardinalDependency(t *testing.T) {
-	t.Parallel()
-
-	world := &World{world: ecs.NewWorld()}
-	require.PanicsWithError(
-		t,
-		"error initializing system fields: field Events must be declared as a value",
-		func() {
-			RegisterSystemV2(world, &exportedPointerDependencySystem{})
-		},
-	)
-}
-
-func TestRegisterSystemV2_RejectsInvalidInstances(t *testing.T) {
-	t.Parallel()
-
-	world := &World{world: ecs.NewWorld()}
-
-	t.Run("typed nil", func(t *testing.T) {
-		t.Parallel()
-
-		var s *privateStateSystem
-		require.PanicsWithError(
-			t,
-			"system *cardinal.privateStateSystem must be a non-nil pointer to a struct",
-			func() { RegisterSystemV2(world, s) },
-		)
-	})
-
-	t.Run("value receiver", func(t *testing.T) {
-		t.Parallel()
-
-		require.PanicsWithError(
-			t,
-			"system *cardinal.valueSystem Run method must use a pointer receiver",
-			func() { RegisterSystemV2(world, &valueSystem{}) },
-		)
-	})
-
-	t.Run("indirect base state", func(t *testing.T) {
-		t.Parallel()
-
-		require.PanicsWithError(
-			t,
-			"system *cardinal.indirectBaseSystem must embed cardinal.BaseSystemState",
-			func() { RegisterSystemV2(world, &indirectBaseSystem{}) },
-		)
-	})
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -710,7 +676,7 @@ func newSearchFixture(t *testing.T) *searchFixture {
 
 	fixture := &searchFixture{}
 
-	err := initSystemFields(fixture, world)
+	err := initSystemFields(reflect.ValueOf(fixture).Elem(), world)
 	require.NoError(t, err)
 
 	return fixture

--- a/pkg/cardinal/system_internal_test.go
+++ b/pkg/cardinal/system_internal_test.go
@@ -16,6 +16,64 @@ import (
 
 // TODO: test system registration, e.g. duplicate field detection, etc.
 
+type privateStateSystem struct {
+	BaseSystemState
+
+	dependency *int
+	scratch    []int
+}
+
+type privateDependencySystem struct {
+	BaseSystemState
+
+	events WithEvent[testutils.SimpleEvent]
+}
+
+func TestRegisterSystem_AllowsPersistentPrivateState(t *testing.T) {
+	t.Parallel()
+
+	dependency := 40
+	world := &World{world: ecs.NewWorld()}
+	var firstState *privateStateSystem
+
+	RegisterSystem(world, func(state *privateStateSystem) {
+		if state.dependency == nil {
+			state.dependency = &dependency
+		}
+		if firstState == nil {
+			firstState = state
+		}
+
+		assert.Same(t, firstState, state)
+		(*state.dependency)++
+		state.scratch = append(state.scratch, *state.dependency)
+	})
+	world.world.Init()
+	world.world.Tick()
+	world.world.Tick()
+
+	require.NotNil(t, firstState)
+	assert.Same(t, world, firstState.world)
+	assert.Equal(t, 42, dependency)
+	assert.Equal(t, []int{41, 42}, firstState.scratch)
+}
+
+func TestRegisterSystem_RejectsPrivateCardinalDependency(t *testing.T) {
+	t.Parallel()
+
+	world := &World{world: ecs.NewWorld()}
+
+	require.PanicsWithError(
+		t,
+		"error initializing system fields: field events must be exported",
+		func() {
+			RegisterSystem(world, func(state *privateDependencySystem) {
+				_ = state.events
+			})
+		},
+	)
+}
+
 // -------------------------------------------------------------------------------------------------
 // WithCommand smoke tests
 // -------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- add `cardinal.System` and `cardinal.RegisterSystemV2` for caller-owned system instances
- require a non-nil pointer to a struct with `BaseSystemState` and a pointer-receiver `Run()` method
- initialize exported Cardinal dependencies while preserving constructor-owned private dependencies and scratch memory
- keep the existing `RegisterSystem` API and behavior unchanged
- fail early for private or pointer-form Cardinal dependency fields

## Developer experience

```go
type MovementSystem struct {
    cardinal.BaseSystemState
    Positions PositionSearch

    runtime *Runtime
    scratch []Input
}

func (s *MovementSystem) Run() {
    // Use initialized Cardinal fields and persistent private state.
}

cardinal.RegisterSystemV2(world, NewMovementSystem(runtime))
```

The constructor owns external dependencies. Cardinal initializes the same instance and calls `Run()` on it for every configured hook.

## Validation

- `go test ./pkg/cardinal -count=1`
- scoped `golangci-lint`: `0 issues`
- pointer/value validation, persistent state, private dependency, and hook tests

## Stack

This is the base PR for NativeAOT runtime PR #919.