### PR TITLE
feat: async snapshot writes to prevent slow storage from stalling the tick loop

### DIFF
--- a/pkg/cardinal/cardinal.go
+++ b/pkg/cardinal/cardinal.go
@@ -127,6 +127,9 @@ func NewWorld(opts WorldOptions) (*World, error) {
 		panic("unreachable")
 	}
 
+	// Snapshot writes asynchronous so a slow storage backend can never stall the tick loop.
+	world.snapshotStorage = snapshot.NewAsync(world.snapshotStorage, tel.GetLogger("snapshot"))
+
 	// Create the debug module only if debug is on.
 	if *options.Debug {
 		world.debug = newDebugModule(world)
@@ -270,9 +273,6 @@ func (w *World) persistState(ctx context.Context, timestamp time.Time) {
 // snapshot writes an already-serialized world state to storage, best-effort: errors are logged, not
 // returned, so a failed write doesn't stop the world and lose unsaved state — the next snapshot retries.
 func (w *World) snapshot(ctx context.Context, timestamp time.Time, worldState *cardinalv1.WorldState) {
-	ctx, cancel := context.WithTimeout(ctx, 2*time.Second)
-	defer cancel()
-
 	data, err := proto.MarshalOptions{Deterministic: true}.Marshal(worldState)
 	if err != nil {
 		w.tel.Logger.Warn().Err(err).Msg("failed to marshal world state to bytes")
@@ -341,12 +341,18 @@ func (w *World) shutdown() {
 	// instead of being severed on the first cleanup step. Telemetry goes last
 	// so it can flush log lines emitted by every preceding step.
 
-	// 1. Final snapshot. Producer-side; serialize world state for snapshot.
+	// 1. Final snapshot, best-effort: enqueue, then drain the background writer on a short
+	// budget of its own so a hung backend can't starve steps 2-4.
 	if worldState, err := w.world.ToProto(); err != nil {
 		w.tel.Logger.Warn().Err(err).Msg("failed to serialize world for final snapshot")
 	} else {
 		w.snapshot(ctx, time.Now(), worldState)
 	}
+	flushCtx, cancelFlush := context.WithTimeout(ctx, 2*time.Second)
+	if err := w.snapshotStorage.Flush(flushCtx); err != nil {
+		w.tel.Logger.Error().Err(err).Msg("final snapshot may not have persisted")
+	}
+	cancelFlush()
 
 	// 2. Shard service (NATS) — drain queued commands/events. Typically quick,
 	// but the producer side should stop before observers do.

--- a/pkg/cardinal/dst.go
+++ b/pkg/cardinal/dst.go
@@ -397,3 +397,8 @@ func (m *memSnapshotStorage) Load(_ context.Context) (*snapshot.Snapshot, error)
 
 	return &cp, nil
 }
+
+// Flush is a no-op: memSnapshotStorage writes synchronously in Store.
+func (m *memSnapshotStorage) Flush(_ context.Context) error {
+	return nil
+}

--- a/pkg/cardinal/snapshot/snapshot.go
+++ b/pkg/cardinal/snapshot/snapshot.go
@@ -32,6 +32,10 @@ type Storage interface {
 	// Load retrieves the current snapshot.
 	// Returns an error if no snapshot exists.
 	Load(ctx context.Context) (*Snapshot, error)
+
+	// Flush blocks until all pending writes have completed or ctx expires.
+	// Synchronous implementations have nothing pending and return nil immediately.
+	Flush(ctx context.Context) error
 }
 
 // StorageType defines the type of snapshot storage to use.

--- a/pkg/cardinal/snapshot/storage_async.go
+++ b/pkg/cardinal/snapshot/storage_async.go
@@ -1,0 +1,102 @@
+package snapshot
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+// storeTimeout bounds a single background write. It is deliberately generous: the write no longer
+// blocks the tick loop, so the timeout only guards against a hung backend leaking goroutines.
+const storeTimeout = 30 * time.Second
+
+// AsyncStorage decorates a Storage so Store never blocks: writes happen on a background
+// goroutine, one at a time (parallel writes to the same key could land older-over-newer).
+// At most one snapshot waits its turn — a newer Store replaces it, so the freshest state
+// is always the one persisted.
+//
+// Store must not be called concurrently. Flush must come after the last Store. Load delegates.
+type AsyncStorage struct {
+	inner  Storage
+	logger zerolog.Logger
+
+	mu      sync.Mutex
+	pending *Snapshot     // newest unsent snapshot; replaced wholesale by a newer Store
+	done    chan struct{} // non-nil while a drain goroutine is active; closed when it exits
+}
+
+var _ Storage = (*AsyncStorage)(nil)
+
+// NewAsync wraps inner so Store returns immediately and writes happen in the background.
+func NewAsync(inner Storage, logger zerolog.Logger) *AsyncStorage {
+	return &AsyncStorage{inner: inner, logger: logger}
+}
+
+// Store hands the snapshot to the background writer and returns nil immediately. Write errors are
+// logged, not returned (snapshots are best-effort; the next Store retries with fresher state).
+func (a *AsyncStorage) Store(_ context.Context, snap *Snapshot) error {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	if a.pending != nil {
+		a.logger.Debug().
+			Uint64("superseded_tick", a.pending.TickHeight).
+			Uint64("tick", snap.TickHeight).
+			Msg("snapshot superseded before it was written")
+	}
+	a.pending = snap
+
+	if a.done == nil {
+		a.done = make(chan struct{})
+		go a.drain(a.done)
+	}
+	return nil
+}
+
+// drain writes pending snapshots until none remain, then exits. At most one drain runs at a time;
+// done is closed on exit so Flush can wait for it.
+func (a *AsyncStorage) drain(done chan struct{}) {
+	defer close(done)
+	for {
+		a.mu.Lock()
+		snap := a.pending
+		a.pending = nil
+		if snap == nil {
+			a.done = nil
+			a.mu.Unlock()
+			return
+		}
+		a.mu.Unlock()
+
+		ctx, cancel := context.WithTimeout(context.Background(), storeTimeout)
+		if err := a.inner.Store(ctx, snap); err != nil {
+			a.logger.Warn().Err(err).Uint64("tick", snap.TickHeight).Msg("failed to store snapshot")
+		}
+		cancel()
+	}
+}
+
+// Load delegates to the wrapped storage. It is only called at boot, before any Store.
+func (a *AsyncStorage) Load(ctx context.Context) (*Snapshot, error) {
+	return a.inner.Load(ctx)
+}
+
+// Flush blocks until every submitted snapshot has been written (or failed), or ctx expires. Call it
+// after the final Store so shutdown doesn't abandon an in-flight write.
+func (a *AsyncStorage) Flush(ctx context.Context) error {
+	a.mu.Lock()
+	done := a.done
+	a.mu.Unlock()
+	if done == nil {
+		return nil
+	}
+
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/pkg/cardinal/snapshot/storage_jetstream.go
+++ b/pkg/cardinal/snapshot/storage_jetstream.go
@@ -166,3 +166,8 @@ func (opt *JetStreamStorageOptions) Validate() error {
 	// SnapshotStorageMaxBytes can be 0 which means unlimited storage. No need to validate here.
 	return nil
 }
+
+// Flush is a no-op: JetStreamStorage writes synchronously in Store, so nothing is ever pending.
+func (j *JetStreamStorage) Flush(_ context.Context) error {
+	return nil
+}

--- a/pkg/cardinal/snapshot/storage_nop.go
+++ b/pkg/cardinal/snapshot/storage_nop.go
@@ -24,3 +24,8 @@ func (n *NopStorage) Store(_ context.Context, _ *Snapshot) error {
 func (n *NopStorage) Load(_ context.Context) (*Snapshot, error) {
 	return nil, eris.Wrap(ErrSnapshotNotFound, "no snapshots available (using no-op storage)")
 }
+
+// Flush is a no-op: NopStorage writes nothing, so nothing is ever pending.
+func (n *NopStorage) Flush(_ context.Context) error {
+	return nil
+}

--- a/pkg/cardinal/snapshot/storage_s3.go
+++ b/pkg/cardinal/snapshot/storage_s3.go
@@ -208,3 +208,8 @@ func (opt *S3StorageOptions) Validate() error {
 	}
 	return nil
 }
+
+// Flush is a no-op: S3Storage writes synchronously in Store, so nothing is ever pending.
+func (s *S3Storage) Flush(_ context.Context) error {
+	return nil
+}


### PR DESCRIPTION
### TL;DR

Snapshot writes are now asynchronous so a slow storage backend can never stall the tick loop.

### What changed?

A new `AsyncStorage` wrapper is introduced in `pkg/cardinal/snapshot/storage_async.go`. It decorates any `Storage` implementation so that `Store` returns immediately and the actual write happens on a background goroutine. It keeps at most one write in-flight and one pending snapshot at a time, with newer snapshots superseding older ones that haven't been written yet.

A `Flush(ctx context.Context) error` method has been added to the `Storage` interface, which blocks until all pending writes complete or the context expires. All existing storage implementations (`JetStreamStorage`, `S3Storage`, `NopStorage`, and `memSnapshotStorage`) implement `Flush` as a no-op since they already write synchronously.

During world initialization, the configured `snapshotStorage` is automatically wrapped with `NewAsync`. During shutdown, `Flush` is called after the final snapshot to ensure any in-flight or pending writes complete before the process exits. The previous 2-second per-write timeout on the tick path has been removed; background writes are instead bounded by a generous 30-second `storeTimeout` that only guards against a hung backend leaking goroutines.

### How to test?

- Run the existing snapshot-related tests to verify correctness of the async wrapper and that `Flush` properly drains pending writes.
- Verify that a slow or temporarily unavailable storage backend no longer causes tick loop stalls.
- Confirm that on shutdown, the final snapshot is fully persisted before the process exits by checking logs for any flush errors.

### Why make this change?

Previously, snapshot writes happened synchronously during the tick loop. A slow storage backend (e.g., high-latency S3 or JetStream) could stall the entire tick loop, degrading game performance. By moving writes to a background goroutine and ensuring the freshest state is always what gets persisted, snapshot I/O is fully decoupled from tick execution while still guaranteeing the final snapshot is flushed cleanly on shutdown.