### PR TITLE
ci: add Claude PR review and @claude mention workflows

### DIFF
--- a/.github/workflows/claude-code.yaml
+++ b/.github/workflows/claude-code.yaml
@@ -1,0 +1,62 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+env:
+  GO_VERSION: 1.26.5
+
+jobs:
+  code:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    name: Code
+    runs-on: namespace-profile-linux-8vcpu-16gb-cached
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure Git for private repos
+        run: git config --global url."https://x-token-auth:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: go
+          path: |
+            ~/go/pkg
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |-
+            actions: read

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -1,0 +1,61 @@
+name: Claude
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+env:
+  GO_VERSION: 1.26.5
+
+jobs:
+  review:
+    name: Review
+    # Fork PRs do not receive secrets, so skip them instead of failing.
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: namespace-profile-linux-8vcpu-16gb-cached
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Configure Git for private repos
+        run: git config --global url."https://x-token-auth:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false
+
+      - uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: go
+          path: |
+            ~/go/pkg
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
+
+      - name: Run Claude Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          use_sticky_comment: true
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+          claude_args: |
+            --allowedTools "Read,Edit,Bash(git:*),Bash(task:*),Bash(go:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),mcp__github_inline_comment__create_inline_comment,mcp__github_inline_comment__list_inline_comments,mcp__github_inline_comment__delete_inline_comment"


### PR DESCRIPTION
## Context

`world-engine` had no Claude automation. This ports the pair already running in `Argus-Labs/monorepo` onto `anthropics/claude-code-action@v1`.

- **`claude-review.yaml`** — runs the `/code-review` plugin on PR open/synchronize/reopen/ready_for_review, with `track_progress` and a sticky comment.
- **`claude-code.yaml`** — responds to `@claude` in issues, PR comments, and reviews.

## Adapted for this repo

| Change | Reason |
|---|---|
| moon setup → `arduino/setup-task@v2` + `setup-go@v5` (1.26.5) + `nscloud-cache-action@v1` | this repo uses Taskfile, not moon — steps mirror `common-go-ci.yaml` |
| `nscloud-checkout-action@v8` → `actions/checkout@v4` | consistent with the other workflows here |
| `Bash(moon:*)` → `Bash(task:*)` in `allowedTools` | Taskfile |

## Public-repo hardening

`monorepo` is private; this repo is public with 53 forks. Two differences follow:

1. The review job is gated to non-fork PRs (`head.repo.full_name == github.repository`). Fork PRs receive no secrets, so without the gate every external contributor PR would show a failed job. They now show **skipped**.
2. `allowed_bots: "*"` is omitted. The action already requires the commenter to have write access, so outside users cannot trigger `@claude`.

`pull_request_target` was deliberately not used — it runs with secrets against untrusted fork code.

## Before this works

The `CLAUDE_CODE_OAUTH_TOKEN` secret does not yet exist on this repo (it is repo-scoped in `monorepo`, not org-wide). Both jobs fail until an admin adds it:

```
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo Argus-Labs/world-engine
```

## Verification

`actionlint` v1.7.12 passes. Its only output is `label "namespace-profile-linux-8vcpu-16gb-cached" is unknown` on both files — a custom Namespace runner label actionlint cannot resolve, already used by the existing Go CI.

Remaining checks are runtime and need the secret: confirm a sticky review comment on a same-repo PR, confirm `@claude` replies, and confirm the review job reports skipped on a fork PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)