### PR TITLE
ci: add claude code github actions workflows

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,83 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  GO_VERSION: 1.26.5
+
+jobs:
+  claude-review:
+    name: Review
+    # Fork PRs receive no secrets, so CLAUDE_CODE_OAUTH_TOKEN would be empty and
+    # the action would fail on every external contribution.
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: namespace-profile-claude
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+      actions: read
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: namespacelabs/nscloud-checkout-action@v9
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git for private repos
+        run: git config --global url."https://x-token-auth:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false # Namespace cache volume below handles this
+
+      - uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: go
+          path: |
+            ~/go/pkg
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
+
+      # NOTE: common-go-ci.yaml's `Setup envtest` / KUBEBUILDER_ASSETS steps are
+      # deliberately not mirrored here. Nothing outside .github references
+      # envtest or KUBEBUILDER_ASSETS, and controller-runtime is not even a
+      # dependency -- the step is vestigial and downloads ~150 MB per run.
+
+      - name: Run Claude Code Review
+        id: claude-review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          track_progress: true
+          use_sticky_comment: true
+          allowed_bots: "*"
+          # Without this the `actions: read` permission above is inert and
+          # Claude cannot read the CI run it is reviewing.
+          additional_permissions: |-
+            actions: read
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
+          claude_args: |
+            --allowedTools "Read,Edit,Bash(git:*),Bash(task lint),Bash(task lint:fix),Bash(task test),Bash(task test:unit),Bash(task test:ci),Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(golangci-lint:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),mcp__github_inline_comment__create_inline_comment,mcp__github_inline_comment__list_inline_comments,mcp__github_inline_comment__delete_inline_comment"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,77 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+concurrency:
+  # Queue mentions rather than cancelling: Claude may be mid-implementation.
+  group: claude-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+env:
+  GO_VERSION: 1.26.5
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    name: Code
+    runs-on: namespace-profile-claude
+    permissions:
+      contents: read
+      pull-requests: read
+      issues: read
+      id-token: write
+      actions: read # Required for Claude to read CI results on PRs
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: namespacelabs/nscloud-checkout-action@v9
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git for private repos
+        run: git config --global url."https://x-token-auth:${{ github.token }}@github.com/".insteadOf "https://github.com/"
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: false # Namespace cache volume below handles this
+
+      - uses: namespacelabs/nscloud-cache-action@v1
+        with:
+          cache: go
+          path: |
+            ~/go/pkg
+            ~/.cache/go-build
+            ~/.cache/golangci-lint
+
+      # NOTE: common-go-ci.yaml's `Setup envtest` / KUBEBUILDER_ASSETS steps are
+      # deliberately not mirrored here. Nothing outside .github references
+      # envtest or KUBEBUILDER_ASSETS, and controller-runtime is not even a
+      # dependency -- the step is vestigial and downloads ~150 MB per run.
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          allowed_bots: "*"
+          additional_permissions: |-
+            actions: read


### PR DESCRIPTION
Adds the mention-triggered (`claude.yml`) and PR-review (`claude-code-review.yml`) Claude workflows. This repo had none.

Both files follow the stock `/install-github-app` template skeleton, adapted for this repo.

## Repo-specific CI setup
Mirrors `common-go-ci.yaml`'s Go lane so Claude can run `task lint` / `task test:ci`:
- `arduino/setup-task@v2`, `actions/setup-go@v5` pinned to `GO_VERSION: 1.26.5`
- `namespacelabs/nscloud-cache-action@v1` with the same Go cache paths

## Deliberately omits setup-envtest
`common-go-ci.yaml` installs `setup-envtest` and threads `KUBEBUILDER_ASSETS` into `task test:ci`. That is vestigial:

```
rg "KUBEBUILDER_ASSETS" --glob '!.github/**'  -> no matches
rg "envtest"            --glob '!.github/**'  -> no matches
```

`controller-runtime` is not even a dependency in `go.mod`. The step costs a `go install ...@latest` plus a ~150 MB download of k8s control-plane binaries on every run, for assets nothing reads.

Worth a separate follow-up: delete those steps from `common-go-ci.yaml` itself, and fix `slug: Argus-Labs/monorepo` → `Argus-Labs/world-engine` in its codecov step.

Also omits `bufbuild/buf-action` — proto lint has its own workflow and no Taskfile target needs `buf`.

## Namespace runner
`runs-on: namespace-profile-claude`, with `namespacelabs/nscloud-checkout-action@v9` at `fetch-depth: 0` (the review needs a merge base to diff against).

## Hardening beyond the template
- **Least privilege:** review job is `contents: read` + `pull-requests: write`. It only writes comments; it never pushes.
- **`additional_permissions: actions: read`** — without it the `actions: read` permission is inert and Claude cannot read the CI run it is reviewing.
- **Fork and draft guards** — fork PRs get no secrets, so `CLAUDE_CODE_OAUTH_TOKEN` would be empty and the action would fail on every external contribution. This repo is the most exposed of the four.
- **Explicit tool allowlist** rather than `Bash(task:*)`.
- **Concurrency groups** — review cancels superseded runs; mentions queue instead of cancelling.

## Note
This repo has no `CLAUDE.md` or `AGENTS.md`, so Claude reviews start with no project context — expect a higher rate of low-value findings on generated (`proto/gen/`) and vendored code. Worth a follow-up.

## Verification
`actionlint` clean (only the expected unknown-custom-runner-label note). The review job on this PR is itself the live test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)