### PR TITLE
ci: drop allowed_bots wildcard, grant build tools to @claude

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -67,7 +67,10 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           track_progress: true
           use_sticky_comment: true
-          allowed_bots: "*"
+          # No allowed_bots: this repo is public, and allowed bots bypass the
+          # repository write-permission check. See claude-code-action
+          # docs/security.md. Add a single bot name here if one ever needs to
+          # trigger Claude -- never "*".
           # Without this the `actions: read` permission above is inert and
           # Claude cannot read the CI run it is reviewing.
           additional_permissions: |-
@@ -80,4 +83,5 @@ jobs:
 
             /code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
           claude_args: |
+            --model claude-opus-5
             --allowedTools "Read,Edit,Bash(git:*),Bash(task lint),Bash(task lint:fix),Bash(task test),Bash(task test:unit),Bash(task test:ci),Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(golangci-lint:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh run view:*),mcp__github_inline_comment__create_inline_comment,mcp__github_inline_comment__list_inline_comments,mcp__github_inline_comment__delete_inline_comment"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -72,6 +72,12 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          allowed_bots: "*"
+          # No allowed_bots: this repo is public, and allowed bots bypass the
+          # repository write-permission check. See claude-code-action
+          # docs/security.md. Add a single bot name here if one ever needs to
+          # trigger Claude -- never "*".
           additional_permissions: |-
             actions: read
+          claude_args: |
+            --model claude-opus-5
+            --allowedTools "Bash(task lint),Bash(task lint:fix),Bash(task test),Bash(task test:unit),Bash(task test:ci),Bash(go build:*),Bash(go vet:*),Bash(go test:*),Bash(go doc:*),Bash(gofmt:*),Bash(golangci-lint:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh run view:*),Bash(gh issue view:*)"


### PR DESCRIPTION
Pass over the two Claude workflows against the upstream [claude-code-action docs](https://github.com/anthropics/claude-code-action/tree/main/docs) (`security.md`, `configuration.md`, `usage.md`, `solutions.md`). Two problems found, both fixed here.

## 1. `allowed_bots: "*"` on a public repo

`docs/security.md` calls this out directly: **allowed bots are not checked for repository permissions.** A matching bot needs neither an installation on this repo nor write access. world-engine is public, so with `"*"` any GitHub App that anyone creates can open an issue or post a comment and invoke the action with a prompt it controls.

`claude.yml` is the exposed one. The action authenticates through the Claude GitHub App, whose token carries `contents: write` independently of the workflow `permissions:` block — so an injected prompt can reach a commit even though the job declares `contents: read`.

Removed from both workflows. Empty is the default and allows no bots. Each removal site keeps a comment so it does not get silently restored.

**Accepted trade-off:** a `@claude` mention posted by `dependabot[bot]`, `devin-ai-integration[bot]`, or `linear[bot]` no longer starts a run. Human mentions are unaffected, and bot-authored PRs still get reviewed — `allowed_bots` gates the trigger *actor*, and review runs on the `pull_request` event. If one specific bot ever needs to trigger Claude, add that single name — not `"*"`.

## 2. `claude.yml` granted no `--allowedTools`

The job installs Task, Go 1.26.5, and a Namespace build cache, then never allows a single build or test command. The action permits **no arbitrary Bash** by default, so all of that setup was dead weight and `@claude fix this` could not verify its own change.

Added a tool list mirroring the Bash entries already proven in `claude-code-review.yml`.

Notes for review:
- `task` targets are **exact-match**, not `task:*`, so a mention cannot run an arbitrary Task target.
- `Read`/`Edit` omitted on purpose — per `docs/configuration.md` base file operations and read-only git are always included; only Bash and MCP tools need a grant.
- No `git`, `gh pr comment`, or inline-comment tools — tag mode commits and replies inside its own tracking comment, and PR review commenting stays owned by `claude-code-review.yml`.

## 3. Model pinned

Neither workflow pinned a model. Both now pass `--model claude-opus-5` via `claude_args` (the `model` input is deprecated per `docs/usage.md`).

## Verification

| Check | Result |
|---|---|
| YAML parses | ok, both files |
| `allowed_bots:` key present | no (comments only) |
| Parsed action inputs | `--model` + `--allowedTools` correct in both |
| Task targets `lint` / `lint:fix` / `test` / `test:ci` / `test:unit` | exist in `Taskfile.yaml` |

`actionlint`, `yq`, and `task` are not installed on the authoring machine, so target names were confirmed by reading `Taskfile.yaml` rather than by running `task --list`.

**The real end-to-end test is this PR.** Two things to watch:
1. `claude-code-review.yml` should post its review here (proves the review path still works without `allowed_bots`).
2. Comment `@claude run task lint and report the result` — the run should start and the tracking comment should show linter output, not a permission-denied message. That is the direct proof of change 2.
3. An unknown model id fails the run at startup, so a green run also confirms `claude-opus-5` resolves. If it is rejected, fall back to the `opus` alias.

## Considered, not included

Root `CLAUDE.md` (none exists anywhere in the repo today), `--max-turns` and `paths-ignore` cost controls, `exclude_comments_by_actor` for Dependabot comment noise, and the upstream `agent-approval-check` workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)