### PR TITLE
fix: unblock CI by restoring the wire contract #916 left behind

### DIFF
--- a/pkg/plugin/physics2d/test/cardinal_integration_test.go
+++ b/pkg/plugin/physics2d/test/cardinal_integration_test.go
@@ -24,7 +24,7 @@ type harnessTag struct {
 func (harnessTag) Name() string { return "physics2d_e2e_harness_tag" }
 
 func (c harnessTag) MarshalWire() ([]byte, error) { return json.Marshal(c) }
-func (harnessTag) UnmarshalWire(b []byte) (harnessTag, error) {
+func (harnessTag) UnmarshalWire(b []byte) (any, error) {
 	var v harnessTag
 	err := json.Unmarshal(b, &v)
 	return v, err

--- a/pkg/template/basic/shards/game/component/wire.gen.go
+++ b/pkg/template/basic/shards/game/component/wire.gen.go
@@ -25,10 +25,10 @@ func (c Gravestone) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (c Gravestone) UnmarshalWire(data []byte) (Gravestone, error) {
+func (c Gravestone) UnmarshalWire(data []byte) (any, error) {
 	var p component.Gravestone
 	if err := proto.Unmarshal(data, &p); err != nil {
-		return Gravestone{}, err
+		return nil, err
 	}
 	return c.FromProto(&p), nil
 }
@@ -51,10 +51,10 @@ func (c Health) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (c Health) UnmarshalWire(data []byte) (Health, error) {
+func (c Health) UnmarshalWire(data []byte) (any, error) {
 	var p component.Health
 	if err := proto.Unmarshal(data, &p); err != nil {
-		return Health{}, err
+		return nil, err
 	}
 	return c.FromProto(&p), nil
 }
@@ -77,10 +77,10 @@ func (c PlayerTag) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (c PlayerTag) UnmarshalWire(data []byte) (PlayerTag, error) {
+func (c PlayerTag) UnmarshalWire(data []byte) (any, error) {
 	var p component.PlayerTag
 	if err := proto.Unmarshal(data, &p); err != nil {
-		return PlayerTag{}, err
+		return nil, err
 	}
 	return c.FromProto(&p), nil
 }

--- a/pkg/template/basic/shards/game/event/wire.gen.go
+++ b/pkg/template/basic/shards/game/event/wire.gen.go
@@ -25,6 +25,14 @@ func (c NewPlayer) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
+func (c NewPlayer) UnmarshalWire(data []byte) (any, error) {
+	var p event.NewPlayer
+	if err := proto.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	return c.FromProto(&p), nil
+}
+
 func (c PlayerDeath) ToProto() *event.PlayerDeath {
 	p := &event.PlayerDeath{}
 	p.Nickname = string(c.Nickname)
@@ -41,4 +49,12 @@ func (c PlayerDeath) FromProto(p *event.PlayerDeath) PlayerDeath {
 
 func (c PlayerDeath) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
+}
+
+func (c PlayerDeath) UnmarshalWire(data []byte) (any, error) {
+	var p event.PlayerDeath
+	if err := proto.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	return c.FromProto(&p), nil
 }

--- a/pkg/template/basic/shards/game/system/wire.gen.go
+++ b/pkg/template/basic/shards/game/system/wire.gen.go
@@ -3,9 +3,6 @@
 package system
 
 import (
-	"fmt"
-
-	"github.com/argus-labs/world-engine/pkg/cardinal"
 	system "github.com/argus-labs/world-engine/pkg/template/basic/shards/game/gen/pkg/template/basic/shards/game/system"
 	"google.golang.org/protobuf/proto"
 )
@@ -26,24 +23,16 @@ func (c AttackPlayerCommand) FromProto(p *system.AttackPlayerCommand) AttackPlay
 	return c
 }
 
-type attackPlayerCommandCodec struct{}
-
-func (attackPlayerCommandCodec) Marshal(p cardinal.Command) ([]byte, error) {
-	c, ok := p.(AttackPlayerCommand)
-	if !ok {
-		return nil, fmt.Errorf("expected AttackPlayerCommand, got %T", p)
-	}
+func (c AttackPlayerCommand) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (attackPlayerCommandCodec) Unmarshal(data []byte) (cardinal.Command, error) {
+func (c AttackPlayerCommand) UnmarshalWire(data []byte) (any, error) {
 	var p system.AttackPlayerCommand
 	if err := proto.Unmarshal(data, &p); err != nil {
 		return nil, err
 	}
-	var c AttackPlayerCommand
-	c = c.FromProto(&p)
-	return c, nil
+	return c.FromProto(&p), nil
 }
 
 func (c CallExternalCommand) ToProto() *system.CallExternalCommand {
@@ -60,24 +49,16 @@ func (c CallExternalCommand) FromProto(p *system.CallExternalCommand) CallExtern
 	return c
 }
 
-type callExternalCommandCodec struct{}
-
-func (callExternalCommandCodec) Marshal(p cardinal.Command) ([]byte, error) {
-	c, ok := p.(CallExternalCommand)
-	if !ok {
-		return nil, fmt.Errorf("expected CallExternalCommand, got %T", p)
-	}
+func (c CallExternalCommand) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (callExternalCommandCodec) Unmarshal(data []byte) (cardinal.Command, error) {
+func (c CallExternalCommand) UnmarshalWire(data []byte) (any, error) {
 	var p system.CallExternalCommand
 	if err := proto.Unmarshal(data, &p); err != nil {
 		return nil, err
 	}
-	var c CallExternalCommand
-	c = c.FromProto(&p)
-	return c, nil
+	return c.FromProto(&p), nil
 }
 
 func (c CreatePlayerCommand) ToProto() *system.CreatePlayerCommand {
@@ -94,28 +75,14 @@ func (c CreatePlayerCommand) FromProto(p *system.CreatePlayerCommand) CreatePlay
 	return c
 }
 
-type createPlayerCommandCodec struct{}
-
-func (createPlayerCommandCodec) Marshal(p cardinal.Command) ([]byte, error) {
-	c, ok := p.(CreatePlayerCommand)
-	if !ok {
-		return nil, fmt.Errorf("expected CreatePlayerCommand, got %T", p)
-	}
+func (c CreatePlayerCommand) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (createPlayerCommandCodec) Unmarshal(data []byte) (cardinal.Command, error) {
+func (c CreatePlayerCommand) UnmarshalWire(data []byte) (any, error) {
 	var p system.CreatePlayerCommand
 	if err := proto.Unmarshal(data, &p); err != nil {
 		return nil, err
 	}
-	var c CreatePlayerCommand
-	c = c.FromProto(&p)
-	return c, nil
-}
-
-func init() {
-	cardinal.RegisterCommandCodec("attack-player", attackPlayerCommandCodec{})
-	cardinal.RegisterCommandCodec("call-external", callExternalCommandCodec{})
-	cardinal.RegisterCommandCodec("create-player", createPlayerCommandCodec{})
+	return c.FromProto(&p), nil
 }

--- a/pkg/template/basic/shards/game/system_event/wire.go
+++ b/pkg/template/basic/shards/game/system_event/wire.go
@@ -1,0 +1,40 @@
+package systemevent
+
+import (
+	event "github.com/argus-labs/world-engine/pkg/template/basic/shards/game/gen/pkg/template/basic/shards/game/event"
+	"google.golang.org/protobuf/proto"
+)
+
+// Hand-written, unlike its siblings: `world sdk generate` emits no proto message for system events, so
+// there is no system_event/wire.gen.go for it to live in. PlayerDeath still has to satisfy
+// schema.Serializable to be usable with WithSystemEventEmitter/Receiver, so it borrows the generated
+// event.PlayerDeath message, which is structurally identical (one string field, Nickname).
+//
+// The borrowing is the wart: change event.PlayerDeath's shape and you silently change this system
+// event's encoding. Delete this file once the generator emits system-event protos of its own.
+
+func (c PlayerDeath) ToProto() *event.PlayerDeath {
+	p := &event.PlayerDeath{}
+	p.Nickname = c.Nickname
+	return p
+}
+
+func (c PlayerDeath) FromProto(p *event.PlayerDeath) PlayerDeath {
+	if p == nil {
+		return c
+	}
+	c.Nickname = p.GetNickname()
+	return c
+}
+
+func (c PlayerDeath) MarshalWire() ([]byte, error) {
+	return proto.Marshal(c.ToProto())
+}
+
+func (c PlayerDeath) UnmarshalWire(data []byte) (any, error) {
+	var p event.PlayerDeath
+	if err := proto.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	return c.FromProto(&p), nil
+}

--- a/pkg/template/multi-shard/shards/chat/command/wire.gen.go
+++ b/pkg/template/multi-shard/shards/chat/command/wire.gen.go
@@ -3,9 +3,6 @@
 package command
 
 import (
-	"fmt"
-
-	"github.com/argus-labs/world-engine/pkg/cardinal"
 	command "github.com/argus-labs/world-engine/pkg/template/multi-shard/shards/chat/gen/pkg/template/multi-shard/shards/chat/command"
 	"google.golang.org/protobuf/proto"
 )
@@ -28,26 +25,14 @@ func (c UserChat) FromProto(p *command.UserChat) UserChat {
 	return c
 }
 
-type userChatCodec struct{}
-
-func (userChatCodec) Marshal(p cardinal.Command) ([]byte, error) {
-	c, ok := p.(UserChat)
-	if !ok {
-		return nil, fmt.Errorf("expected UserChat, got %T", p)
-	}
+func (c UserChat) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (userChatCodec) Unmarshal(data []byte) (cardinal.Command, error) {
+func (c UserChat) UnmarshalWire(data []byte) (any, error) {
 	var p command.UserChat
 	if err := proto.Unmarshal(data, &p); err != nil {
 		return nil, err
 	}
-	var c UserChat
-	c = c.FromProto(&p)
-	return c, nil
-}
-
-func init() {
-	cardinal.RegisterCommandCodec("user-chat", userChatCodec{})
+	return c.FromProto(&p), nil
 }

--- a/pkg/template/multi-shard/shards/chat/component/wire.gen.go
+++ b/pkg/template/multi-shard/shards/chat/component/wire.gen.go
@@ -30,10 +30,10 @@ func (c Chat) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (c Chat) UnmarshalWire(data []byte) (Chat, error) {
+func (c Chat) UnmarshalWire(data []byte) (any, error) {
 	var p component.Chat
 	if err := proto.Unmarshal(data, &p); err != nil {
-		return Chat{}, err
+		return nil, err
 	}
 	return c.FromProto(&p), nil
 }
@@ -58,10 +58,10 @@ func (c UserTag) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (c UserTag) UnmarshalWire(data []byte) (UserTag, error) {
+func (c UserTag) UnmarshalWire(data []byte) (any, error) {
 	var p component.UserTag
 	if err := proto.Unmarshal(data, &p); err != nil {
-		return UserTag{}, err
+		return nil, err
 	}
 	return c.FromProto(&p), nil
 }

--- a/pkg/template/multi-shard/shards/chat/event/wire.gen.go
+++ b/pkg/template/multi-shard/shards/chat/event/wire.gen.go
@@ -33,3 +33,11 @@ func (c UserChat) FromProto(p *event.UserChat) UserChat {
 func (c UserChat) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
+
+func (c UserChat) UnmarshalWire(data []byte) (any, error) {
+	var p event.UserChat
+	if err := proto.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	return c.FromProto(&p), nil
+}

--- a/pkg/template/multi-shard/shards/game/command/wire.gen.go
+++ b/pkg/template/multi-shard/shards/game/command/wire.gen.go
@@ -3,9 +3,6 @@
 package command
 
 import (
-	"fmt"
-
-	"github.com/argus-labs/world-engine/pkg/cardinal"
 	command "github.com/argus-labs/world-engine/pkg/template/multi-shard/shards/game/gen/pkg/template/multi-shard/shards/game/command"
 	"google.golang.org/protobuf/proto"
 )
@@ -28,24 +25,16 @@ func (c MovePlayer) FromProto(p *command.MovePlayer) MovePlayer {
 	return c
 }
 
-type movePlayerCodec struct{}
-
-func (movePlayerCodec) Marshal(p cardinal.Command) ([]byte, error) {
-	c, ok := p.(MovePlayer)
-	if !ok {
-		return nil, fmt.Errorf("expected MovePlayer, got %T", p)
-	}
+func (c MovePlayer) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (movePlayerCodec) Unmarshal(data []byte) (cardinal.Command, error) {
+func (c MovePlayer) UnmarshalWire(data []byte) (any, error) {
 	var p command.MovePlayer
 	if err := proto.Unmarshal(data, &p); err != nil {
 		return nil, err
 	}
-	var c MovePlayer
-	c = c.FromProto(&p)
-	return c, nil
+	return c.FromProto(&p), nil
 }
 
 func (c PlayerLeave) ToProto() *command.PlayerLeave {
@@ -62,24 +51,16 @@ func (c PlayerLeave) FromProto(p *command.PlayerLeave) PlayerLeave {
 	return c
 }
 
-type playerLeaveCodec struct{}
-
-func (playerLeaveCodec) Marshal(p cardinal.Command) ([]byte, error) {
-	c, ok := p.(PlayerLeave)
-	if !ok {
-		return nil, fmt.Errorf("expected PlayerLeave, got %T", p)
-	}
+func (c PlayerLeave) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (playerLeaveCodec) Unmarshal(data []byte) (cardinal.Command, error) {
+func (c PlayerLeave) UnmarshalWire(data []byte) (any, error) {
 	var p command.PlayerLeave
 	if err := proto.Unmarshal(data, &p); err != nil {
 		return nil, err
 	}
-	var c PlayerLeave
-	c = c.FromProto(&p)
-	return c, nil
+	return c.FromProto(&p), nil
 }
 
 func (c PlayerSpawn) ToProto() *command.PlayerSpawn {
@@ -102,28 +83,14 @@ func (c PlayerSpawn) FromProto(p *command.PlayerSpawn) PlayerSpawn {
 	return c
 }
 
-type playerSpawnCodec struct{}
-
-func (playerSpawnCodec) Marshal(p cardinal.Command) ([]byte, error) {
-	c, ok := p.(PlayerSpawn)
-	if !ok {
-		return nil, fmt.Errorf("expected PlayerSpawn, got %T", p)
-	}
+func (c PlayerSpawn) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (playerSpawnCodec) Unmarshal(data []byte) (cardinal.Command, error) {
+func (c PlayerSpawn) UnmarshalWire(data []byte) (any, error) {
 	var p command.PlayerSpawn
 	if err := proto.Unmarshal(data, &p); err != nil {
 		return nil, err
 	}
-	var c PlayerSpawn
-	c = c.FromProto(&p)
-	return c, nil
-}
-
-func init() {
-	cardinal.RegisterCommandCodec("move-player", movePlayerCodec{})
-	cardinal.RegisterCommandCodec("player-leave", playerLeaveCodec{})
-	cardinal.RegisterCommandCodec("player-spawn", playerSpawnCodec{})
+	return c.FromProto(&p), nil
 }

--- a/pkg/template/multi-shard/shards/game/component/wire.gen.go
+++ b/pkg/template/multi-shard/shards/game/component/wire.gen.go
@@ -30,10 +30,10 @@ func (c OnlineStatus) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (c OnlineStatus) UnmarshalWire(data []byte) (OnlineStatus, error) {
+func (c OnlineStatus) UnmarshalWire(data []byte) (any, error) {
 	var p component.OnlineStatus
 	if err := proto.Unmarshal(data, &p); err != nil {
-		return OnlineStatus{}, err
+		return nil, err
 	}
 	return c.FromProto(&p), nil
 }
@@ -58,10 +58,10 @@ func (c PlayerTag) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (c PlayerTag) UnmarshalWire(data []byte) (PlayerTag, error) {
+func (c PlayerTag) UnmarshalWire(data []byte) (any, error) {
 	var p component.PlayerTag
 	if err := proto.Unmarshal(data, &p); err != nil {
-		return PlayerTag{}, err
+		return nil, err
 	}
 	return c.FromProto(&p), nil
 }
@@ -86,10 +86,10 @@ func (c Position) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
-func (c Position) UnmarshalWire(data []byte) (Position, error) {
+func (c Position) UnmarshalWire(data []byte) (any, error) {
 	var p component.Position
 	if err := proto.Unmarshal(data, &p); err != nil {
-		return Position{}, err
+		return nil, err
 	}
 	return c.FromProto(&p), nil
 }

--- a/pkg/template/multi-shard/shards/game/event/wire.gen.go
+++ b/pkg/template/multi-shard/shards/game/event/wire.gen.go
@@ -25,6 +25,14 @@ func (c PlayerDeparture) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
+func (c PlayerDeparture) UnmarshalWire(data []byte) (any, error) {
+	var p event.PlayerDeparture
+	if err := proto.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	return c.FromProto(&p), nil
+}
+
 func (c PlayerMovement) ToProto() *event.PlayerMovement {
 	p := &event.PlayerMovement{}
 	p.ArgusAuthID = string(c.ArgusAuthID)
@@ -49,6 +57,14 @@ func (c PlayerMovement) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
 }
 
+func (c PlayerMovement) UnmarshalWire(data []byte) (any, error) {
+	var p event.PlayerMovement
+	if err := proto.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	return c.FromProto(&p), nil
+}
+
 func (c PlayerSpawn) ToProto() *event.PlayerSpawn {
 	p := &event.PlayerSpawn{}
 	p.ArgusAuthID = string(c.ArgusAuthID)
@@ -71,4 +87,12 @@ func (c PlayerSpawn) FromProto(p *event.PlayerSpawn) PlayerSpawn {
 
 func (c PlayerSpawn) MarshalWire() ([]byte, error) {
 	return proto.Marshal(c.ToProto())
+}
+
+func (c PlayerSpawn) UnmarshalWire(data []byte) (any, error) {
+	var p event.PlayerSpawn
+	if err := proto.Unmarshal(data, &p); err != nil {
+		return nil, err
+	}
+	return c.FromProto(&p), nil
 }

--- a/pkg/testutils/ecs.go
+++ b/pkg/testutils/ecs.go
@@ -56,13 +56,13 @@ func (SimpleComponent) UnmarshalWire(b []byte) (any, error) {
 	return gobUnmarshal[SimpleComponent](b)
 }
 
-func (c ComponentA) MarshalWire() ([]byte, error)             { return gobMarshal(c) }
+func (c ComponentA) MarshalWire() ([]byte, error)      { return gobMarshal(c) }
 func (ComponentA) UnmarshalWire(b []byte) (any, error) { return gobUnmarshal[ComponentA](b) }
 
-func (c ComponentB) MarshalWire() ([]byte, error)             { return gobMarshal(c) }
+func (c ComponentB) MarshalWire() ([]byte, error)      { return gobMarshal(c) }
 func (ComponentB) UnmarshalWire(b []byte) (any, error) { return gobUnmarshal[ComponentB](b) }
 
-func (c ComponentC) MarshalWire() ([]byte, error)             { return gobMarshal(c) }
+func (c ComponentC) MarshalWire() ([]byte, error)      { return gobMarshal(c) }
 func (ComponentC) UnmarshalWire(b []byte) (any, error) { return gobUnmarshal[ComponentC](b) }
 
 func gobMarshal(v any) ([]byte, error) {


### PR DESCRIPTION
## Summary

**CI (Go) has been red on `main` since 2026-07-31.** #916 changed the wire contract but did not regenerate the code that implements it, so eleven packages fail to build and take `task lint` and `task test` down with them. This PR is the unblock, and nothing else — no behaviour change, no wire-format change.

#916 collapsed components, commands, events, and system events onto a single interface, `schema.Serializable`:

```go
Name() string
MarshalWire() ([]byte, error)
UnmarshalWire([]byte) (any, error)   // was (T, error)
```

and deleted `cardinal.RegisterCommandCodec`. Two places were left behind.

### 1. `pkg/template` — nine packages (`fix(template)`)

Three mechanical changes across nine `wire.gen.go` files:

1. `UnmarshalWire` returns `(any, error)` instead of `(T, error)`, and `nil` on the error path.
2. The six event types that had only `MarshalWire` gain the decode half.
3. Seven codec structs and their `init()` registrations become plain methods on the command types, which drops the now-unused `fmt` and `cardinal` imports.

### 2. `pkg/plugin/physics2d/test` — one line (`fix(physics2d)`)

`harnessTag.UnmarshalWire` still returned the concrete type. The package has not compiled since #916, so **none of its 12 test files have been running** — silently, because a package that fails to build reports no failures.

## The wire format does not move

Checked against the diff rather than asserted:

- nothing under `gen/` or any `.pb.go` is touched;
- zero field-mapping lines added or removed in any `ToProto`/`FromProto` body;
- all seven command `Name()` strings still match the keys the old `init()` registered (`attack-player`, `call-external`, `create-player`, `user-chat`, `move-player`, `player-leave`, `player-spawn`).

## Two things to push back on

- **These are hand-edited `DO NOT EDIT` files.** `world sdk generate` lives in another repo, so the next regeneration re-emits the old non-compiling shape unless the generator is updated in tandem. Updating the generator is the real fix; this is the unblock, and it should not be mistaken for the former.
- **`systemevent.PlayerDeath` is a gap the generator cannot fill.** System events get no proto message of their own, so it borrows the structurally identical `event.PlayerDeath`. That coupling is a wart — change one and you silently change the other's encoding — so it lives in a hand-written `wire.go`, not a `wire.gen.go`: a file no generator emits should not claim it did. The comment says to delete it once the generator emits system-event protos.

Also here: `pkg/testutils/ecs.go` gofmt alignment (`git diff -w` on it is empty). It was already unformatted on `main` — golangci-lint suppresses every other finding once any package fails to typecheck, so the build breakage was hiding it.

## Pre-existing, deliberately not fixed

Both are product calls rather than lint fixes, and neither blocks CI:

- `ExternalCommand` in `basic/shards/game/system/external.go` is advertised in its doc comment as receivable from another shard, but has no proto message and is registered nowhere — so the compiler never checks it against `cardinal.Command`, and it would fail to satisfy `schema.Serializable` the moment anyone wired it up.
- System events have no protos at all, hence the borrow above.

## Test plan

- [x] `go build ./pkg/...` and `go vet ./pkg/...` — clean
- [x] `go test ./pkg/...` — 17 packages, 0 FAIL (none of which ran to completion on `main`)
- [x] `golangci-lint run --fix=false ./pkg/...` — **0 issues at CI's pinned v2.6.2**, not the newer version mise installs locally. The two disagree on gosec (v2.6.2 fires G115; 2.10.1 fires G704/G117 instead), so a clean run on the local build proves nothing about CI
- [x] `--fix=false` matters: `.golangci.yaml` sets `issues.fix: true`, so a bare `golangci-lint run` rewrites source and `nolintlint` deletes `//nolint` directives CI still needs
- [x] Verified standalone on top of `origin/main`, not merely inside the branch it was split from

Split out of #931 so that PR stays scoped to the snapshot work. #931 will be rebased once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
