### PR TITLE
refactor: extract world-free runtime services

### DIFF
--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -1,0 +1,217 @@
+// Package auth authenticates client requests to a shard's ConnectRPC service.
+//
+// Two modes ship: ARGUS validates a bearer JWT against the Argus Auth service's JWKS, and DEV
+// trusts an X-Email header. Both resolve a request to a *User, which downstream handlers read
+// with UserFromContext — a command's persona comes from there, never from the request body.
+//
+// Callers wire it in one step:
+//
+//	middleware, err := auth.NewMiddleware(auth.ModeDev, "")
+//	if err != nil {
+//	    return err
+//	}
+//	mux.Handle(path, middleware.Wrap(handler))
+//
+// The package holds no world or tick state, so any runtime serving the client-facing protocol can
+// use it, whether or not it has a simulation loop.
+package auth
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"connectrpc.com/authn"
+	"github.com/MicahParks/keyfunc/v3"
+	"github.com/argus-labs/world-engine/pkg/assert"
+	"github.com/goccy/go-json"
+	"github.com/golang-jwt/jwt/v5"
+	"github.com/rotisserie/eris"
+)
+
+// jwksFetchTimeout bounds the JWKS fetch at startup. Failing fast beats hanging a boot.
+const jwksFetchTimeout = 3 * time.Second
+
+// User is the authenticated caller behind a request.
+type User struct {
+	jwt.RegisteredClaims
+
+	ID    string `json:"id"`
+	Name  string `json:"name"`
+	Email string `json:"email"`
+}
+
+// UserFromContext returns the authenticated user for the request being served, or nil if the
+// request did not pass through NewMiddleware's wrapper.
+func UserFromContext(ctx context.Context) *User {
+	info := authn.GetInfo(ctx)
+	if info == nil {
+		return nil
+	}
+	user, ok := info.(*User)
+	if !ok {
+		return nil
+	}
+	return user
+}
+
+// -------------------------------------------------------------------------------------------------
+// Mode
+// -------------------------------------------------------------------------------------------------
+
+// Mode selects the authentication mode for the client-facing ConnectRPC service.
+type Mode uint8
+
+const (
+	ModeUndefined Mode = iota
+	ModeArgus
+	ModeDev
+)
+
+const (
+	argusModeString     = "ARGUS"
+	devModeString       = "DEV"
+	undefinedModeString = "UNDEFINED"
+)
+
+func (m Mode) String() string {
+	switch m {
+	case ModeUndefined:
+		return undefinedModeString
+	case ModeArgus:
+		return argusModeString
+	case ModeDev:
+		return devModeString
+	default:
+		return undefinedModeString
+	}
+}
+
+// IsValid reports whether m names a usable mode. ModeUndefined is not usable.
+func (m Mode) IsValid() bool {
+	return m == ModeArgus || m == ModeDev
+}
+
+// ParseMode converts a mode name (case-insensitive) to a Mode.
+func ParseMode(s string) (Mode, error) {
+	switch strings.ToUpper(s) {
+	case argusModeString:
+		return ModeArgus, nil
+	case devModeString:
+		return ModeDev, nil
+	default:
+		return ModeUndefined, eris.Errorf("invalid auth mode: %s", s)
+	}
+}
+
+// -------------------------------------------------------------------------------------------------
+// Middleware
+// -------------------------------------------------------------------------------------------------
+
+// NewMiddleware builds the authentication middleware for mode. argusAuthURL is required when mode
+// is ModeArgus and ignored otherwise; in that mode this fetches the JWKS, so it performs network
+// I/O and should be called once at startup, not per request.
+func NewMiddleware(mode Mode, argusAuthURL string) (*authn.Middleware, error) {
+	var authenticate func(context.Context, *http.Request) (any, error)
+
+	switch mode {
+	case ModeArgus:
+		authenticator, err := newAuthenticatorArgus(argusAuthURL)
+		if err != nil {
+			return nil, eris.Wrap(err, "failed to create argus authenticator")
+		}
+		authenticate = authenticator.authenticate
+	case ModeDev:
+		authenticate = authenticatorDev{}.authenticate
+	case ModeUndefined:
+		fallthrough
+	default:
+		return nil, eris.Errorf("invalid service auth mode: %s", mode)
+	}
+
+	return authn.NewMiddleware(authenticate), nil
+}
+
+// -------------------------------------------------------------------------------------------------
+// Argus Auth
+// -------------------------------------------------------------------------------------------------
+
+type authenticatorArgus struct {
+	keyfunc keyfunc.Keyfunc
+}
+
+func newAuthenticatorArgus(argusAuthURL string) (*authenticatorArgus, error) {
+	assert.That(argusAuthURL != "", "Should've validated the URL")
+
+	jwksURL := argusAuthURL + "/auth/jwks"
+	client := &http.Client{
+		Timeout: jwksFetchTimeout,
+	}
+
+	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, jwksURL, nil)
+	if err != nil {
+		return nil, eris.Wrap(err, "failed to create JWKS request")
+	}
+
+	response, err := client.Do(request)
+	if err != nil {
+		return nil, eris.Wrap(err, "failed to fetch JWKS")
+	}
+	defer func() { _ = response.Body.Close() }()
+
+	if response.StatusCode != http.StatusOK {
+		return nil, eris.Errorf("HTTP error: %d - %s", response.StatusCode, response.Status)
+	}
+
+	body, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, eris.Wrap(err, "failed to read response body")
+	}
+
+	keyfn, err := keyfunc.NewJWKSetJSON(json.RawMessage(body))
+	if err != nil {
+		return nil, eris.Wrap(err, "failed to create keyfunc")
+	}
+
+	return &authenticatorArgus{keyfunc: keyfn}, nil
+}
+
+func (a *authenticatorArgus) authenticate(_ context.Context, req *http.Request) (any, error) {
+	jwtString, ok := authn.BearerToken(req)
+	if !ok {
+		return nil, authn.Errorf("Authorization header must be in format: 'Bearer <JWT>'")
+	}
+
+	user := &User{}
+	token, err := jwt.ParseWithClaims(jwtString, user, a.keyfunc.Keyfunc)
+	if err != nil {
+		return nil, eris.Wrap(err, "JWT parse error")
+	}
+	if !token.Valid {
+		return nil, eris.New("JWT token is invalid")
+	}
+
+	// TODO: Remove this comment once persona ID is removed from the JWT.
+	// if u.PersonaID == "" {
+	// 	return nil, authn.Errorf("JWT token is missing persona ID")
+	// }
+
+	return user, nil
+}
+
+// -------------------------------------------------------------------------------------------------
+// Dev Auth
+// -------------------------------------------------------------------------------------------------
+
+type authenticatorDev struct{}
+
+func (a authenticatorDev) authenticate(_ context.Context, req *http.Request) (any, error) {
+	email := strings.TrimSpace(req.Header.Get("X-Email"))
+	if email == "" {
+		return nil, authn.Errorf("X-Email header is required")
+	}
+
+	return &User{ID: email, Email: email}, nil
+}

--- a/pkg/auth/auth_internal_test.go
+++ b/pkg/auth/auth_internal_test.go
@@ -1,0 +1,140 @@
+package auth
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseMode(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		in      string
+		want    Mode
+		wantErr bool
+	}{
+		{in: "ARGUS", want: ModeArgus},
+		{in: "argus", want: ModeArgus},
+		{in: "DEV", want: ModeDev},
+		{in: "dev", want: ModeDev},
+		{in: "UNDEFINED", wantErr: true},
+		{in: "", wantErr: true},
+		{in: "nope", wantErr: true},
+	} {
+		got, err := ParseMode(tc.in)
+		if tc.wantErr {
+			require.Error(t, err, "ParseMode(%q) should reject", tc.in)
+			require.Equal(t, ModeUndefined, got, "rejected mode should be ModeUndefined")
+			continue
+		}
+		require.NoError(t, err, "ParseMode(%q)", tc.in)
+		require.Equal(t, tc.want, got, "ParseMode(%q)", tc.in)
+	}
+}
+
+func TestMode_StringRoundTrips(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []Mode{ModeArgus, ModeDev} {
+		got, err := ParseMode(mode.String())
+		require.NoError(t, err, "String() of a valid mode must parse back")
+		require.Equal(t, mode, got)
+	}
+
+	require.Equal(t, undefinedModeString, ModeUndefined.String())
+	require.Equal(t, undefinedModeString, Mode(99).String(), "unknown values must not claim a real mode")
+}
+
+func TestMode_IsValid(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, ModeArgus.IsValid())
+	require.True(t, ModeDev.IsValid())
+	require.False(t, ModeUndefined.IsValid(), "undefined must never authenticate anything")
+	require.False(t, Mode(99).IsValid())
+}
+
+// TestNewMiddleware_RejectsUnusableMode verifies an unset or unknown mode is a startup error rather
+// than a service that silently accepts every request.
+func TestNewMiddleware_RejectsUnusableMode(t *testing.T) {
+	t.Parallel()
+
+	for _, mode := range []Mode{ModeUndefined, Mode(99)} {
+		mw, err := NewMiddleware(mode, "")
+		require.Error(t, err, "mode %s must not produce middleware", mode)
+		require.Nil(t, mw)
+	}
+}
+
+// TestDevMiddleware_PopulatesUser is the contract handlers depend on: after a request passes the
+// middleware, UserFromContext resolves the caller. A command's persona is read from there, so a
+// regression here is an authentication bypass, not a cosmetic bug.
+func TestDevMiddleware_PopulatesUser(t *testing.T) {
+	t.Parallel()
+
+	middleware, err := NewMiddleware(ModeDev, "")
+	require.NoError(t, err)
+
+	var got *User
+	handler := middleware.Wrap(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		got = UserFromContext(r.Context())
+	}))
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+	require.NoError(t, err)
+	request.Header.Set("X-Email", "  player@example.com  ")
+
+	response, err := server.Client().Do(request)
+	require.NoError(t, err)
+	require.NoError(t, response.Body.Close())
+	require.Equal(t, http.StatusOK, response.StatusCode)
+
+	require.NotNil(t, got, "handler must see an authenticated user")
+	require.Equal(t, "player@example.com", got.Email, "surrounding whitespace must be trimmed")
+	require.Equal(t, "player@example.com", got.ID)
+}
+
+// TestDevMiddleware_RejectsMissingEmail verifies the handler never runs without an identity.
+func TestDevMiddleware_RejectsMissingEmail(t *testing.T) {
+	t.Parallel()
+
+	middleware, err := NewMiddleware(ModeDev, "")
+	require.NoError(t, err)
+
+	reached := false
+	handler := middleware.Wrap(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		reached = true
+	}))
+
+	server := httptest.NewServer(handler)
+	t.Cleanup(server.Close)
+
+	for _, email := range []string{"", "   "} {
+		request, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL, nil)
+		require.NoError(t, err)
+		if email != "" {
+			request.Header.Set("X-Email", email)
+		}
+
+		response, err := server.Client().Do(request)
+		require.NoError(t, err)
+		require.NoError(t, response.Body.Close())
+
+		require.Equal(t, http.StatusUnauthorized, response.StatusCode, "X-Email %q must be rejected", email)
+		require.False(t, reached, "handler must not run for an unauthenticated request")
+	}
+}
+
+// TestUserFromContext_NilWithoutMiddleware verifies an unauthenticated context yields nil rather
+// than a zero-valued User that would read as a caller with an empty ID.
+func TestUserFromContext_NilWithoutMiddleware(t *testing.T) {
+	t.Parallel()
+
+	require.Nil(t, UserFromContext(t.Context()))
+}

--- a/pkg/cardinal/auth.go
+++ b/pkg/cardinal/auth.go
@@ -1,0 +1,37 @@
+package cardinal
+
+import (
+	"context"
+
+	"github.com/argus-labs/world-engine/pkg/auth"
+)
+
+// Authentication lives in pkg/auth so runtimes without a world can serve the same client-facing
+// protocol. These aliases keep the long-standing cardinal.* spelling working for game code; new
+// callers should prefer the auth package directly.
+
+type (
+	// User is the authenticated caller behind a request. See auth.User.
+	User = auth.User
+
+	// AuthMode selects the authentication mode for the client-facing ConnectRPC service.
+	// See auth.Mode.
+	AuthMode = auth.Mode
+)
+
+const (
+	AuthModeUndefined = auth.ModeUndefined
+	AuthModeArgus     = auth.ModeArgus
+	AuthModeDev       = auth.ModeDev
+)
+
+// ParseAuthMode converts a mode name (case-insensitive) to an AuthMode. See auth.ParseMode.
+func ParseAuthMode(s string) (AuthMode, error) {
+	return auth.ParseMode(s)
+}
+
+// UserFromContext returns the authenticated user for the request being served, or nil if the
+// request did not pass through the authentication middleware. See auth.UserFromContext.
+func UserFromContext(ctx context.Context) *User {
+	return auth.UserFromContext(ctx)
+}

--- a/pkg/cardinal/cardinal.go
+++ b/pkg/cardinal/cardinal.go
@@ -93,7 +93,10 @@ func NewWorld(opts WorldOptions) (*World, error) {
 	})
 
 	// Create the ConnectRPC client-facing service.
-	world.service = newService(world, options.AuthMode, options.ArgusAuthURL)
+	world.service, err = newService(world, options.AuthMode, options.ArgusAuthURL)
+	if err != nil {
+		return nil, eris.Wrap(err, "failed to create client-facing service")
+	}
 
 	// Register event handlers with the ConnectRPC service publishers.
 	world.events.RegisterHandler(event.KindDefault, world.service.publishDefaultEvent)

--- a/pkg/cardinal/e2e.go
+++ b/pkg/cardinal/e2e.go
@@ -196,7 +196,9 @@ func newE2EFixture(t *testing.T, setup E2ESetupFunc) *e2eFixture {
 		w.options.NATSConfig.URL = natsURL
 	}
 	w.options.AuthMode = AuthModeDev
-	w.service = newService(w, w.options.AuthMode, w.options.ArgusAuthURL)
+	svc, err := newService(w, w.options.AuthMode, w.options.ArgusAuthURL)
+	require.NoError(t, err, "e2e failed to create service")
+	w.service = svc
 	w.events.RegisterHandler(event.KindDefault, w.service.publishDefaultEvent)
 
 	connectAddr := "127.0.0.1:5000"

--- a/pkg/cardinal/service.go
+++ b/pkg/cardinal/service.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net"
 	"net/http"
-	"strings"
-	"sync"
 	"time"
 
 	"connectrpc.com/connect"
@@ -16,7 +14,7 @@ import (
 	"github.com/argus-labs/world-engine/pkg/cardinal/internal/command"
 	"github.com/argus-labs/world-engine/pkg/cardinal/internal/event"
 	"github.com/argus-labs/world-engine/pkg/micro"
-	cardinalv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1"
+	"github.com/argus-labs/world-engine/pkg/shard"
 	"github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1/cardinalv1connect"
 	iscv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/isc/v1"
 	"github.com/rotisserie/eris"
@@ -27,9 +25,12 @@ import (
 // this blocking is worth revisiting.
 const interShardSendTimeout = 10 * time.Second
 
-// service hosts the direct client-facing Cardinal service.
+// service wires a world to the network: the shared client-facing server on one side, and NATS
+// inter-shard commands on the other. The client-facing protocol itself lives in pkg/shard, so this
+// world and any other runtime serving the same protocol cannot drift apart.
 type service struct {
 	world        *World
+	shardServer  *shard.Server
 	server       *http.Server
 	log          zerolog.Logger
 	authMode     AuthMode
@@ -37,24 +38,38 @@ type service struct {
 	client       *micro.Client
 	microService *micro.Service
 	commands     map[string]struct{}
-	subscribers  map[string]*streamSubscriber
-	replyWaiters map[string][]chan *iscv1.Event
-	mu           sync.RWMutex
 }
 
-var _ cardinalv1connect.CardinalServiceHandler = (*service)(nil)
+var _ shard.CommandSink = (*service)(nil)
 
 // newService creates a new direct client-facing Cardinal service.
-func newService(world *World, authMode AuthMode, argusAuthURL string) *service {
-	return &service{
+func newService(world *World, authMode AuthMode, argusAuthURL string) (*service, error) {
+	s := &service{
 		world:        world,
 		log:          world.tel.GetLogger("service"),
 		authMode:     authMode,
 		argusAuthURL: argusAuthURL,
 		commands:     make(map[string]struct{}),
-		subscribers:  make(map[string]*streamSubscriber),
-		replyWaiters: make(map[string][]chan *iscv1.Event),
 	}
+
+	shardServer, err := shard.NewServer(shard.Config{
+		Address:  world.address,
+		Commands: s,
+		Logger:   s.log,
+	})
+	if err != nil {
+		return nil, eris.Wrap(err, "failed to create shard server")
+	}
+	s.shardServer = shardServer
+
+	return s, nil
+}
+
+// Submit implements shard.CommandSink and micro's inter-shard command handler: both the
+// client-facing server and the ISC transport have already validated the command and proven it
+// belongs to this shard, so the world's only remaining job is to queue it for the next tick.
+func (s *service) Submit(_ context.Context, cmd *iscv1.Command) error {
+	return s.world.commands.Enqueue(cmd)
 }
 
 // h2cProtocols enables HTTP/1.1 and unencrypted HTTP/2 (h2c), matching the
@@ -89,15 +104,9 @@ func (s *service) init(address string) error {
 	for cmd := range s.commands {
 		commandNames = append(commandNames, cmd)
 	}
-	if err := s.microService.ServeCommands(commandNames, s.enqueueInterShardCommand); err != nil {
+	if err := s.microService.ServeCommands(commandNames, s.Submit); err != nil {
 		return eris.Wrap(err, "failed to register inter-shard command handlers")
 	}
-
-	otelInterceptor, err := otelconnect.NewInterceptor()
-	if err != nil {
-		return eris.Wrap(err, "failed to create otel interceptor")
-	}
-	validateInterceptor := validate.NewInterceptor()
 
 	mux := http.NewServeMux()
 
@@ -106,16 +115,13 @@ func (s *service) init(address string) error {
 		return err
 	}
 
-	cardinalPath, cardinalHandler := cardinalv1connect.NewCardinalServiceHandler(
-		s,
-		connect.WithInterceptors(
-			otelInterceptor,
-			validateInterceptor,
-		),
-	)
+	cardinalPath, cardinalHandler, err := s.shardServer.Handler()
+	if err != nil {
+		return eris.Wrap(err, "failed to create cardinal service handler")
+	}
 	mux.Handle(cardinalPath, authMiddleware.Wrap(cardinalHandler))
 
-	if err := s.mountDebugService(mux, otelInterceptor, validateInterceptor); err != nil {
+	if err := s.mountDebugService(mux); err != nil {
 		return err
 	}
 
@@ -140,16 +146,20 @@ func (s *service) init(address string) error {
 	return nil
 }
 
-func (s *service) mountDebugService(mux *http.ServeMux, interceptors ...connect.Interceptor) error {
+func (s *service) mountDebugService(mux *http.ServeMux) error {
 	if s.world.debug == nil {
 		return nil
 	}
 	if err := s.world.debug.finalizeCatalog(); err != nil {
 		return eris.Wrap(err, "failed to finalize introspection catalog")
 	}
+	otelInterceptor, err := otelconnect.NewInterceptor()
+	if err != nil {
+		return eris.Wrap(err, "failed to create otel interceptor")
+	}
 	debugPath, debugHandler := cardinalv1connect.NewDebugServiceHandler(
 		s.world.debug,
-		connect.WithInterceptors(interceptors...),
+		connect.WithInterceptors(otelInterceptor, validate.NewInterceptor()),
 	)
 	mux.Handle(debugPath, debugHandler)
 	s.log.Info().Msg("DebugService mounted on client-facing port (dev)")
@@ -179,276 +189,11 @@ func (s *service) registerCommandHandler(name string) {
 }
 
 // -------------------------------------------------------------------------------------------------
-// Command handlers
-// -------------------------------------------------------------------------------------------------
-
-// TODO: eventually, we'll probably have more user fields in the command metadata, possibly a User
-// struct field instead of a single persona ID.
-
-type streamSubscriber struct {
-	ctx    context.Context
-	stream *connect.ServerStream[cardinalv1.StartEventStreamResponse]
-	events map[string]struct{}
-	mu     sync.Mutex
-}
-
-func (s *streamSubscriber) send(response *cardinalv1.StartEventStreamResponse) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	return s.stream.Send(response)
-}
-
-func (s *service) SendCommand(
-	ctx context.Context,
-	req *connect.Request[cardinalv1.SendCommandRequest],
-) (*connect.Response[cardinalv1.SendCommandResponse], error) {
-	select {
-	case <-ctx.Done():
-		return nil, connect.NewError(connect.CodeCanceled, eris.Wrap(ctx.Err(), "context cancelled"))
-	default:
-	}
-
-	user := UserFromContext(ctx)
-	assert.That(user != nil, "user should exist in authenticated request context")
-
-	cmd := req.Msg.GetCommand()
-	assert.That(cmd != nil, "command should have been validated")
-	assert.That(cmd.GetPersona() != nil, "command persona should have been validated")
-
-	cmd.Persona.Id = user.ID
-
-	if micro.String(s.world.address) != micro.String(cmd.GetAddress()) {
-		return nil, connect.NewError(connect.CodeInvalidArgument, eris.New("address doesn't match shard address"))
-	}
-
-	if err := s.world.commands.Enqueue(cmd); err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, eris.Wrap(err, "failed to enqueue command"))
-	}
-
-	return connect.NewResponse(&cardinalv1.SendCommandResponse{}), nil
-}
-
-func (s *service) SendCommandWithReply(
-	ctx context.Context,
-	req *connect.Request[cardinalv1.SendCommandWithReplyRequest],
-) (*connect.Response[cardinalv1.SendCommandWithReplyResponse], error) {
-	user := UserFromContext(ctx)
-	assert.That(user != nil, "user should exist in authenticated request context")
-
-	cmd := req.Msg.GetCommand()
-	assert.That(cmd != nil, "command should have been validated")
-	assert.That(cmd.GetPersona() != nil, "command persona should have been validated")
-
-	cmd.Persona.Id = user.ID
-
-	if micro.String(s.world.address) != micro.String(cmd.GetAddress()) {
-		return nil, connect.NewError(connect.CodeInvalidArgument, eris.New("address doesn't match shard address"))
-	}
-
-	if err := s.world.commands.Enqueue(cmd); err != nil {
-		return nil, connect.NewError(connect.CodeInvalidArgument, eris.Wrap(err, "failed to enqueue command"))
-	}
-
-	waiter := s.addReplyWaiter(req.Msg.GetEventName())
-	defer s.removeReplyWaiter(req.Msg.GetEventName(), waiter)
-
-	select {
-	case <-ctx.Done():
-		return nil, connect.NewError(connect.CodeCanceled, eris.Wrap(ctx.Err(), "waiting for reply event"))
-	case event := <-waiter:
-		return connect.NewResponse(&cardinalv1.SendCommandWithReplyResponse{Event: event}), nil
-	}
-}
-
-func (s *service) addReplyWaiter(eventName string) chan *iscv1.Event {
-	waiter := make(chan *iscv1.Event, 1)
-
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	s.replyWaiters[eventName] = append(s.replyWaiters[eventName], waiter)
-	return waiter
-}
-
-func (s *service) removeReplyWaiter(eventName string, waiter chan *iscv1.Event) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	waiters := s.replyWaiters[eventName]
-	for i, current := range waiters {
-		if current == waiter {
-			s.replyWaiters[eventName] = append(waiters[:i], waiters[i+1:]...)
-			break
-		}
-	}
-	if len(s.replyWaiters[eventName]) == 0 {
-		delete(s.replyWaiters, eventName)
-	}
-}
-
-// -------------------------------------------------------------------------------------------------
-// Event streams
-// -------------------------------------------------------------------------------------------------
-
-func (s *service) StartEventStream(
-	ctx context.Context,
-	req *connect.Request[cardinalv1.StartEventStreamRequest],
-	stream *connect.ServerStream[cardinalv1.StartEventStreamResponse],
-) error {
-	user := UserFromContext(ctx)
-	assert.That(user != nil, "user should exist in authenticated stream context")
-
-	subscriber, err := s.addSubscriber(ctx, user, stream)
-	if err != nil {
-		return connect.NewError(connect.CodeFailedPrecondition, err)
-	}
-	defer s.removeSubscriber(user)
-
-	for _, subscription := range req.Msg.GetSubscriptions() {
-		if micro.String(s.world.address) != micro.String(subscription.GetAddress()) {
-			return connect.NewError(connect.CodeInvalidArgument, eris.New("address doesn't match shard address"))
-		}
-	}
-	s.subscribeEvents(user, req.Msg.GetSubscriptions())
-
-	if err := subscriber.send(&cardinalv1.StartEventStreamResponse{}); err != nil {
-		return connect.NewError(connect.CodeInternal, eris.Wrap(err, "failed to send initial empty event to client"))
-	}
-
-	// Send periodic keepalive messages to prevent ALB idle timeouts.
-	// Empty responses are safely ignored by the client SDK (ShardEvent.Name is null → HandleEvent skips it).
-	ticker := time.NewTicker(30 * time.Second)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			if err := ctx.Err(); !eris.Is(err, context.Canceled) {
-				return connect.NewError(connect.CodeCanceled, eris.Wrap(err, "stream cancelled"))
-			}
-			return nil
-		case <-ticker.C:
-			if err := subscriber.send(&cardinalv1.StartEventStreamResponse{}); err != nil {
-				return err
-			}
-		}
-	}
-}
-
-func (s *service) SubscribeEvents(
-	ctx context.Context,
-	req *connect.Request[cardinalv1.SubscribeEventsRequest],
-) (*connect.Response[cardinalv1.SubscribeEventsResponse], error) {
-	user := UserFromContext(ctx)
-	assert.That(user != nil, "user should exist in authenticated request context")
-
-	if !s.hasSubscriber(user) {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, eris.New("client has no established stream"))
-	}
-
-	for _, subscription := range req.Msg.GetSubscriptions() {
-		if micro.String(s.world.address) != micro.String(subscription.GetAddress()) {
-			return nil, connect.NewError(connect.CodeInvalidArgument, eris.New("address doesn't match shard address"))
-		}
-	}
-	s.subscribeEvents(user, req.Msg.GetSubscriptions())
-
-	return connect.NewResponse(&cardinalv1.SubscribeEventsResponse{}), nil
-}
-
-func (s *service) UnsubscribeEvents(
-	ctx context.Context,
-	req *connect.Request[cardinalv1.UnsubscribeEventsRequest],
-) (*connect.Response[cardinalv1.UnsubscribeEventsResponse], error) {
-	user := UserFromContext(ctx)
-	assert.That(user != nil, "user should exist in authenticated request context")
-
-	if !s.hasSubscriber(user) {
-		return nil, connect.NewError(connect.CodeFailedPrecondition, eris.New("client has no established stream"))
-	}
-
-	for _, subscription := range req.Msg.GetSubscriptions() {
-		if micro.String(s.world.address) != micro.String(subscription.GetAddress()) {
-			return nil, connect.NewError(connect.CodeInvalidArgument, eris.New("address doesn't match shard address"))
-		}
-	}
-	s.unsubscribeEvents(user, req.Msg.GetSubscriptions())
-
-	return connect.NewResponse(&cardinalv1.UnsubscribeEventsResponse{}), nil
-}
-
-func (s *service) addSubscriber(
-	ctx context.Context,
-	user *User,
-	stream *connect.ServerStream[cardinalv1.StartEventStreamResponse],
-) (*streamSubscriber, error) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	if _, exists := s.subscribers[user.ID]; exists {
-		return nil, eris.Errorf("user %s already has an open stream", user.ID)
-	}
-
-	subscriber := &streamSubscriber{
-		ctx:    ctx,
-		stream: stream,
-		events: make(map[string]struct{}),
-	}
-	s.subscribers[user.ID] = subscriber
-	return subscriber, nil
-}
-
-func (s *service) removeSubscriber(user *User) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	delete(s.subscribers, user.ID)
-}
-
-func (s *service) subscribeEvents(user *User, subscriptions []*cardinalv1.EventSubscription) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	subscriber := s.subscribers[user.ID]
-	assert.That(subscriber != nil, "subscriber should exist for authenticated stream")
-
-	for _, subscription := range subscriptions {
-		for _, eventName := range subscription.GetEvents() {
-			subscriber.events[eventName] = struct{}{}
-		}
-	}
-}
-
-func (s *service) unsubscribeEvents(user *User, subscriptions []*cardinalv1.EventSubscription) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	subscriber := s.subscribers[user.ID]
-	assert.That(subscriber != nil, "subscriber should exist for authenticated stream")
-
-	for _, subscription := range subscriptions {
-		for _, eventName := range subscription.GetEvents() {
-			delete(subscriber.events, eventName)
-		}
-	}
-}
-
-func (s *service) hasSubscriber(user *User) bool {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-
-	_, ok := s.subscribers[user.ID]
-	return ok
-}
-
-// -------------------------------------------------------------------------------------------------
 // Event publishers
 // -------------------------------------------------------------------------------------------------
 
-// TODO: move away from this centralized approach to a actor model for easier(?) synchronization.
-
-//nolint:gocognit // Put everything here so you can understand the logic in one place.
+// publishDefaultEvent marshals a world event and hands it to the shared server, which decides who
+// receives it. Called from the event manager's dispatch at the end of a tick.
 func (s *service) publishDefaultEvent(evt event.Event) error {
 	payload, ok := evt.Payload.(event.Payload)
 	if !ok {
@@ -462,84 +207,16 @@ func (s *service) publishDefaultEvent(evt event.Event) error {
 		return eris.Wrap(err, "failed to marshal event payload")
 	}
 
-	eventPb := &iscv1.Event{
-		Name:    payload.Name(),
-		Payload: payloadPb,
-	}
-
-	s.mu.RLock()
-	var subscribers []*streamSubscriber
-	//nolint:nestif // It's fine
-	if evt.Recipient != "" {
-		if subscriber, exists := s.subscribers[evt.Recipient]; exists {
-			for subscription := range subscriber.events {
-				if matchesEvent(subscription, eventPb.GetName()) {
-					subscribers = []*streamSubscriber{subscriber}
-					break
-				}
-			}
-		} else {
-			s.log.Debug().Str("recipient", evt.Recipient).Str("event", eventPb.GetName()).Msg("recipient has no open stream")
-		}
-	} else {
-		subscribers = make([]*streamSubscriber, 0, len(s.subscribers))
-		for _, subscriber := range s.subscribers {
-			for subscription := range subscriber.events {
-				if matchesEvent(subscription, eventPb.GetName()) {
-					subscribers = append(subscribers, subscriber)
-					break
-				}
-			}
-		}
-	}
-	waiters := append([]chan *iscv1.Event(nil), s.replyWaiters[eventPb.GetName()]...)
-	s.mu.RUnlock()
-
-	// Send events for SendCommandWithReply channels.
-	for _, waiter := range waiters {
-		select {
-		case waiter <- eventPb:
-		default:
-		}
-	}
-
-	// Send events to stream subscribers.
-	for _, subscriber := range subscribers {
-		select {
-		case <-subscriber.ctx.Done():
-			continue
-		default:
-		}
-
-		err := subscriber.send(&cardinalv1.StartEventStreamResponse{
-			Address: s.world.address,
-			Event:   eventPb,
-		})
-		if err != nil {
-			s.log.Error().Err(err).Str("event", eventPb.GetName()).Msg("failed to send event to subscriber")
-			continue
-		}
-	}
-
-	return nil
-}
-
-func matchesEvent(subscription string, eventName string) bool {
-	return subscription == eventName ||
-		subscription == "*" ||
-		subscription == ">" ||
-		(strings.HasSuffix(subscription, ".>") && strings.HasPrefix(eventName, strings.TrimSuffix(subscription, ">")))
+	return s.shardServer.PublishEvent(shard.Event{
+		Name:      payload.Name(),
+		Payload:   payloadPb,
+		Recipient: evt.Recipient,
+	})
 }
 
 // -------------------------------------------------------------------------------------------------
 // ISC
 // -------------------------------------------------------------------------------------------------
-
-// enqueueInterShardCommand is the runtime half of inter-shard command handling: micro validates the
-// command and proves it belongs to this shard, and the world queues it for the next tick.
-func (s *service) enqueueInterShardCommand(_ context.Context, cmd *iscv1.Command) error {
-	return s.world.commands.Enqueue(cmd)
-}
 
 func (s *service) publishInterShardCommand(evt event.Event) error {
 	isc, ok := evt.Payload.(command.Command)

--- a/pkg/cardinal/service.go
+++ b/pkg/cardinal/service.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"time"
 
-	"buf.build/go/protovalidate"
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
 	"connectrpc.com/validate"
@@ -22,8 +21,11 @@ import (
 	iscv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/isc/v1"
 	"github.com/rotisserie/eris"
 	"github.com/rs/zerolog"
-	"google.golang.org/grpc/codes"
 )
+
+// interShardSendTimeout bounds a single shard-to-shard send. See publishInterShardCommand for why
+// this blocking is worth revisiting.
+const interShardSendTimeout = 10 * time.Second
 
 // service hosts the direct client-facing Cardinal service.
 type service struct {
@@ -83,13 +85,12 @@ func (s *service) init(address string) error {
 
 	// Keep these for now cuz ISC requires a bit more work than client connections. Will need another
 	// refactor after the current clients are migrated to connect directly to the shards.
-	if err = s.microService.AddEndpoint("ping", s.handlePing); err != nil {
-		return eris.Wrap(err, "failed to register ping handler")
-	}
+	commandNames := make([]string, 0, len(s.commands))
 	for cmd := range s.commands {
-		if err := s.microService.AddGroup("command").AddEndpoint(cmd, s.handleInterShardCommand); err != nil {
-			return eris.Wrapf(err, "failed to register %s command handler", cmd)
-		}
+		commandNames = append(commandNames, cmd)
+	}
+	if err := s.microService.ServeCommands(commandNames, s.enqueueInterShardCommand); err != nil {
+		return eris.Wrap(err, "failed to register inter-shard command handlers")
 	}
 
 	otelInterceptor, err := otelconnect.NewInterceptor()
@@ -534,38 +535,10 @@ func matchesEvent(subscription string, eventName string) bool {
 // ISC
 // -------------------------------------------------------------------------------------------------
 
-func (s *service) handlePing(_ context.Context, req *micro.Request) *micro.Response {
-	return micro.NewSuccessResponse(req, nil)
-}
-
-func (s *service) handleInterShardCommand(ctx context.Context, req *micro.Request) *micro.Response {
-	select {
-	case <-ctx.Done():
-		return micro.NewErrorResponse(req, eris.Wrap(ctx.Err(), "context cancelled"), codes.Canceled)
-	default:
-	}
-
-	cmd := &iscv1.Command{}
-	if err := req.Payload.UnmarshalTo(cmd); err != nil {
-		return micro.NewErrorResponse(req, eris.Wrap(err, "failed to parse request payload"), codes.InvalidArgument)
-	}
-
-	if err := protovalidate.Validate(cmd); err != nil {
-		return micro.NewErrorResponse(req, eris.Wrap(err, "failed to validate command"), codes.InvalidArgument)
-	}
-	if _, err := micro.ParseAddress(cmd.GetPersona().GetId()); err != nil {
-		return micro.NewErrorResponse(req, eris.Wrap(err, "command persona is not a shard address"), codes.InvalidArgument)
-	}
-
-	if micro.String(s.world.address) != micro.String(cmd.GetAddress()) {
-		return micro.NewErrorResponse(req, eris.New("command address doesn't match shard address"), codes.InvalidArgument)
-	}
-
-	if err := s.world.commands.Enqueue(cmd); err != nil {
-		return micro.NewErrorResponse(req, eris.Wrap(err, "failed to enqueue command"), codes.InvalidArgument)
-	}
-
-	return micro.NewSuccessResponse(req, nil)
+// enqueueInterShardCommand is the runtime half of inter-shard command handling: micro validates the
+// command and proves it belongs to this shard, and the world queues it for the next tick.
+func (s *service) enqueueInterShardCommand(_ context.Context, cmd *iscv1.Command) error {
+	return s.world.commands.Enqueue(cmd)
 }
 
 func (s *service) publishInterShardCommand(evt event.Event) error {
@@ -583,21 +556,13 @@ func (s *service) publishInterShardCommand(evt event.Event) error {
 		return nil
 	}
 
-	commandPb := &iscv1.Command{
-		Name:    isc.Payload.Name(),
-		Address: isc.Address,
-		Persona: &iscv1.Persona{Id: isc.Persona},
-		Payload: payload,
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), interShardSendTimeout)
 	defer cancel()
 
 	// TODO: revisit shard-to-shard blocking. Dispatch runs synchronously in the tick loop, so this
 	// request-reply blocks the whole world up to 10s per send — and we discard the reply anyway. If
 	// shard-to-shard isn't meant to block the tick, make this async (worker) or fire-and-forget Publish.
-	_, err = s.client.Request(ctx, isc.Address, "command."+isc.Payload.Name(), commandPb)
-	if err != nil {
+	if err := s.client.SendCommand(ctx, isc.Address, isc.Payload.Name(), isc.Persona, payload); err != nil {
 		s.log.Error().Err(err).Str("command", isc.Payload.Name()).Msg("inter-shard command dropped: send failed")
 		return nil
 	}

--- a/pkg/cardinal/service.go
+++ b/pkg/cardinal/service.go
@@ -2,7 +2,6 @@ package cardinal
 
 import (
 	"context"
-	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -10,20 +9,17 @@ import (
 	"time"
 
 	"buf.build/go/protovalidate"
-	"connectrpc.com/authn"
 	"connectrpc.com/connect"
 	"connectrpc.com/otelconnect"
 	"connectrpc.com/validate"
-	"github.com/MicahParks/keyfunc/v3"
 	"github.com/argus-labs/world-engine/pkg/assert"
+	"github.com/argus-labs/world-engine/pkg/auth"
 	"github.com/argus-labs/world-engine/pkg/cardinal/internal/command"
 	"github.com/argus-labs/world-engine/pkg/cardinal/internal/event"
 	"github.com/argus-labs/world-engine/pkg/micro"
 	cardinalv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1"
 	"github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1/cardinalv1connect"
 	iscv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/isc/v1"
-	"github.com/goccy/go-json"
-	"github.com/golang-jwt/jwt/v5"
 	"github.com/rotisserie/eris"
 	"github.com/rs/zerolog"
 	"google.golang.org/grpc/codes"
@@ -104,22 +100,10 @@ func (s *service) init(address string) error {
 
 	mux := http.NewServeMux()
 
-	var authenticate func(context.Context, *http.Request) (any, error)
-	switch s.authMode {
-	case AuthModeArgus:
-		authenticator, err := newAuthenticatorArgus(s.argusAuthURL)
-		if err != nil {
-			return eris.Wrap(err, "failed to create argus authenticator")
-		}
-		authenticate = authenticator.authenticate
-	case AuthModeDev:
-		authenticate = authenticatorDev{}.authenticate
-	case AuthModeUndefined:
-		fallthrough
-	default:
-		return eris.Errorf("invalid service auth mode: %s", s.authMode)
+	authMiddleware, err := auth.NewMiddleware(s.authMode, s.argusAuthURL)
+	if err != nil {
+		return err
 	}
-	authMiddleware := authn.NewMiddleware(authenticate)
 
 	cardinalPath, cardinalHandler := cardinalv1connect.NewCardinalServiceHandler(
 		s,
@@ -619,153 +603,4 @@ func (s *service) publishInterShardCommand(evt event.Event) error {
 	}
 
 	return nil
-}
-
-// -------------------------------------------------------------------------------------------------
-// Authentication
-// -------------------------------------------------------------------------------------------------
-
-type User struct {
-	jwt.RegisteredClaims
-
-	ID    string `json:"id"`
-	Name  string `json:"name"`
-	Email string `json:"email"`
-}
-
-// AuthMode selects the authentication mode for the client-facing ConnectRPC service.
-type AuthMode uint8
-
-const (
-	AuthModeUndefined AuthMode = iota
-	AuthModeArgus
-	AuthModeDev
-)
-
-const (
-	argusAuthModeString     = "ARGUS"
-	devAuthModeString       = "DEV"
-	undefinedAuthModeString = "UNDEFINED"
-)
-
-func (a AuthMode) String() string {
-	switch a {
-	case AuthModeUndefined:
-		return undefinedAuthModeString
-	case AuthModeArgus:
-		return argusAuthModeString
-	case AuthModeDev:
-		return devAuthModeString
-	default:
-		return undefinedAuthModeString
-	}
-}
-
-func (a AuthMode) IsValid() bool {
-	return a == AuthModeArgus || a == AuthModeDev
-}
-
-func ParseAuthMode(s string) (AuthMode, error) {
-	switch strings.ToUpper(s) {
-	case argusAuthModeString:
-		return AuthModeArgus, nil
-	case devAuthModeString:
-		return AuthModeDev, nil
-	default:
-		return AuthModeUndefined, eris.Errorf("invalid auth mode: %s", s)
-	}
-}
-
-func UserFromContext(ctx context.Context) *User {
-	info := authn.GetInfo(ctx)
-	if info == nil {
-		return nil
-	}
-	user, ok := info.(*User)
-	if !ok {
-		return nil
-	}
-	return user
-}
-
-// -------------------------------------------------------------------------------------------------
-// Argus Auth
-// -------------------------------------------------------------------------------------------------
-
-type authenticatorArgus struct {
-	keyfunc keyfunc.Keyfunc
-}
-
-func newAuthenticatorArgus(argusAuthURL string) (*authenticatorArgus, error) {
-	assert.That(argusAuthURL != "", "Should've validated the URL")
-
-	jwksURL := argusAuthURL + "/auth/jwks"
-	client := &http.Client{
-		Timeout: 3 * time.Second,
-	}
-
-	request, err := http.NewRequestWithContext(context.Background(), http.MethodGet, jwksURL, nil)
-	if err != nil {
-		return nil, eris.Wrap(err, "failed to create JWKS request")
-	}
-
-	response, err := client.Do(request)
-	if err != nil {
-		return nil, eris.Wrap(err, "failed to fetch JWKS")
-	}
-	defer func() { _ = response.Body.Close() }()
-
-	if response.StatusCode != http.StatusOK {
-		return nil, eris.Errorf("HTTP error: %d - %s", response.StatusCode, response.Status)
-	}
-
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		return nil, eris.Wrap(err, "failed to read response body")
-	}
-
-	keyfn, err := keyfunc.NewJWKSetJSON(json.RawMessage(body))
-	if err != nil {
-		return nil, eris.Wrap(err, "failed to create keyfunc")
-	}
-
-	return &authenticatorArgus{keyfunc: keyfn}, nil
-}
-
-func (a *authenticatorArgus) authenticate(_ context.Context, req *http.Request) (any, error) {
-	jwtString, ok := authn.BearerToken(req)
-	if !ok {
-		return nil, authn.Errorf("Authorization header must be in format: 'Bearer <JWT>'")
-	}
-
-	user := &User{}
-	token, err := jwt.ParseWithClaims(jwtString, user, a.keyfunc.Keyfunc)
-	if err != nil {
-		return nil, eris.Wrap(err, "JWT parse error")
-	}
-	if !token.Valid {
-		return nil, eris.New("JWT token is invalid")
-	}
-
-	// TODO: Remove this comment once persona ID is removed from the JWT.
-	// if u.PersonaID == "" {
-	// 	return nil, authn.Errorf("JWT token is missing persona ID")
-	// }
-
-	return user, nil
-}
-
-// -------------------------------------------------------------------------------------------------
-// Dev Auth
-// -------------------------------------------------------------------------------------------------
-
-type authenticatorDev struct{}
-
-func (a authenticatorDev) authenticate(_ context.Context, req *http.Request) (any, error) {
-	email := strings.TrimSpace(req.Header.Get("X-Email"))
-	if email == "" {
-		return nil, authn.Errorf("X-Email header is required")
-	}
-
-	return &User{ID: email, Email: email}, nil
 }

--- a/pkg/cardinal/service_internal_test.go
+++ b/pkg/cardinal/service_internal_test.go
@@ -259,10 +259,9 @@ func newServiceFixture(t *testing.T, prng *rand.Rand, registerNATSEndpoints bool
 		t.Cleanup(func() { _ = microService.Close() })
 		svc.microService = microService
 
-		require.NoError(t, microService.AddEndpoint("ping", svc.handlePing))
-		require.NoError(t, microService.AddGroup("command").AddEndpoint(
-			testutils.SimpleCommand{}.Name(),
-			svc.handleInterShardCommand,
+		require.NoError(t, microService.ServeCommands(
+			[]string{testutils.SimpleCommand{}.Name()},
+			svc.enqueueInterShardCommand,
 		))
 		require.NoError(t, client.Flush())
 	}

--- a/pkg/cardinal/service_internal_test.go
+++ b/pkg/cardinal/service_internal_test.go
@@ -55,7 +55,7 @@ func TestService_SendCommand(t *testing.T) {
 			Payload: payloadBytes,
 		}
 
-		_, err = fixture.svc.SendCommand(
+		_, err = fixture.svc.shardServer.SendCommand(
 			serviceTestContext(userID),
 			connect.NewRequest(&cardinalv1.SendCommandRequest{Command: cmdPb}),
 		)
@@ -84,7 +84,7 @@ func TestService_SendCommand(t *testing.T) {
 			Payload: payloadBytes,
 		}
 
-		_, err = fixture.svc.SendCommand(
+		_, err = fixture.svc.shardServer.SendCommand(
 			serviceTestContext(testutils.RandString(prng, 8)),
 			connect.NewRequest(&cardinalv1.SendCommandRequest{Command: cmdPb}),
 		)
@@ -97,33 +97,36 @@ func TestService_SendCommand(t *testing.T) {
 // -------------------------------------------------------------------------------------------------
 // publishDefaultEvent smoke tests
 // -------------------------------------------------------------------------------------------------
-// Verifies that publishing a default event serializes the payload and delivers it to registered
-// ConnectRPC reply waiters with round-trip integrity.
+// Verifies the world's half of event publishing: marshaling a world event and handing it to the
+// shared server. Who receives a published event, and with what payload, is the server's contract
+// and is covered by the conformance suite in pkg/shard.
 // -------------------------------------------------------------------------------------------------
 
 func TestService_PublishDefaultEvent(t *testing.T) {
 	t.Parallel()
 
-	t.Run("reply waiter", func(t *testing.T) {
+	t.Run("marshals and publishes", func(t *testing.T) {
 		t.Parallel()
 		prng := testutils.NewRand(t)
 		fixture := newServiceFixture(t, prng, false)
 
-		payload := testutils.SimpleEvent{Value: prng.Int()}
-		waiter := fixture.svc.addReplyWaiter(payload.Name())
-		defer fixture.svc.removeReplyWaiter(payload.Name(), waiter)
+		require.NoError(t, fixture.svc.publishDefaultEvent(event.Event{
+			Kind:    event.KindDefault,
+			Payload: testutils.SimpleEvent{Value: prng.Int()},
+		}))
+	})
+
+	t.Run("rejects a payload that is not an event", func(t *testing.T) {
+		t.Parallel()
+		prng := testutils.NewRand(t)
+		fixture := newServiceFixture(t, prng, false)
 
 		err := fixture.svc.publishDefaultEvent(event.Event{
 			Kind:    event.KindDefault,
-			Payload: payload,
+			Payload: nil,
 		})
-		require.NoError(t, err)
-
-		eventPb := <-waiter
-		assert.Equal(t, payload.Name(), eventPb.GetName())
-		decoded, err := testutils.SimpleEvent{}.UnmarshalWire(eventPb.GetPayload())
-		require.NoError(t, err)
-		assert.Equal(t, payload, decoded)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid event payload type")
 	})
 }
 
@@ -239,7 +242,8 @@ func newServiceFixture(t *testing.T, prng *rand.Rand, registerNATSEndpoints bool
 	cmdID, err := w.commands.Register(testutils.SimpleCommand{}.Name(), queue)
 	require.NoError(t, err)
 
-	svc := newService(w, AuthModeDev, "")
+	svc, err := newService(w, AuthModeDev, "")
+	require.NoError(t, err)
 	svc.registerCommandHandler(testutils.SimpleCommand{}.Name())
 	w.service = svc
 
@@ -261,7 +265,7 @@ func newServiceFixture(t *testing.T, prng *rand.Rand, registerNATSEndpoints bool
 
 		require.NoError(t, microService.ServeCommands(
 			[]string{testutils.SimpleCommand{}.Name()},
-			svc.enqueueInterShardCommand,
+			svc.Submit,
 		))
 		require.NoError(t, client.Flush())
 	}

--- a/pkg/cardinal/system_internal_test.go
+++ b/pkg/cardinal/system_internal_test.go
@@ -97,14 +97,16 @@ func newCommandFixture(t *testing.T) *commandFixture {
 
 	world := &World{
 		commands: command.NewManager(),
+		address:  RandServiceAddress(testutils.NewRand(t)),
 	}
-	world.service = newService(world, AuthModeDev, "")
+	svc, err := newService(world, AuthModeDev, "")
+	require.NoError(t, err)
+	world.service = svc
 
 	fixture := &commandFixture{world: world}
 
 	meta := &systemInitMetadata{world: world, commands: make(map[string]struct{}), events: make(map[string]struct{})}
-	err := fixture.Command.init(meta)
-	require.NoError(t, err)
+	require.NoError(t, fixture.Command.init(meta))
 
 	return fixture
 }

--- a/pkg/micro/isc.go
+++ b/pkg/micro/isc.go
@@ -1,0 +1,125 @@
+package micro
+
+import (
+	"context"
+
+	"buf.build/go/protovalidate"
+	iscv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/isc/v1"
+	"github.com/rotisserie/eris"
+	"google.golang.org/grpc/codes"
+)
+
+// commandGroup is the endpoint group inter-shard commands are served under and sent to. Both
+// directions read it from here so a shard can never listen on one subject and be sent another.
+const commandGroup = "command"
+
+// pingEndpoint answers liveness checks from other shards.
+const pingEndpoint = "ping"
+
+// CommandHandler receives an inbound inter-shard command that has already passed transport
+// validation: the payload parsed, the proto validated, the sender proven to be a shard, and the
+// destination proven to be this shard.
+//
+// What happens next belongs to the runtime — enqueue the command for a later tick, run it now
+// inside a transaction, whatever the runtime does. Returning an error fails the request back to the
+// sending shard with codes.Internal.
+type CommandHandler func(ctx context.Context, cmd *iscv1.Command) error
+
+// ServeCommands registers this service's inter-shard endpoints: a liveness ping, plus one endpoint
+// per entry in names, and routes every inbound command to handler.
+//
+// The validation applied before handler runs is the security boundary between shards, and it lives
+// here so that every runtime serving inter-shard commands enforces the same rules:
+//
+//   - the payload must parse as a Command and satisfy its proto constraints;
+//   - the sender's persona must be a shard address, so a player cannot reach these endpoints by
+//     impersonating one;
+//   - the command's destination address must be this service's own address.
+//
+// Nothing is sent as a side effect of handling. Outbound commands go out only when the caller calls
+// Client.SendCommand, so a runtime that must not emit before a transaction commits stays in
+// control of when that happens.
+func (s *Service) ServeCommands(names []string, handler CommandHandler) error {
+	if handler == nil {
+		return eris.New("command handler must not be nil")
+	}
+
+	if err := s.AddEndpoint(pingEndpoint, func(_ context.Context, req *Request) *Response {
+		return NewSuccessResponse(req, nil)
+	}); err != nil {
+		return eris.Wrap(err, "failed to register ping handler")
+	}
+
+	group := s.AddGroup(commandGroup)
+	for _, name := range names {
+		if err := group.AddEndpoint(name, s.commandEndpoint(handler)); err != nil {
+			return eris.Wrapf(err, "failed to register %s command handler", name)
+		}
+	}
+
+	return nil
+}
+
+// commandEndpoint builds the Handler that validates an inbound command and passes it to handler.
+func (s *Service) commandEndpoint(handler CommandHandler) Handler {
+	return func(ctx context.Context, req *Request) *Response {
+		select {
+		case <-ctx.Done():
+			return NewErrorResponse(req, eris.Wrap(ctx.Err(), "context cancelled"), codes.Canceled)
+		default:
+		}
+
+		cmd := &iscv1.Command{}
+		if err := req.Payload.UnmarshalTo(cmd); err != nil {
+			return NewErrorResponse(req, eris.Wrap(err, "failed to parse request payload"), codes.InvalidArgument)
+		}
+
+		if err := protovalidate.Validate(cmd); err != nil {
+			return NewErrorResponse(req, eris.Wrap(err, "failed to validate command"), codes.InvalidArgument)
+		}
+
+		// A shard-to-shard command carries a shard address as its persona. Anything else is a client
+		// reaching for an endpoint it must not have.
+		if _, err := ParseAddress(cmd.GetPersona().GetId()); err != nil {
+			return NewErrorResponse(req, eris.Wrap(err, "command persona is not a shard address"), codes.InvalidArgument)
+		}
+
+		if String(s.Address) != String(cmd.GetAddress()) {
+			return NewErrorResponse(req, eris.New("command address doesn't match shard address"), codes.InvalidArgument)
+		}
+
+		if err := handler(ctx, cmd); err != nil {
+			return NewErrorResponse(req, eris.Wrap(err, "failed to handle command"), codes.Internal)
+		}
+
+		return NewSuccessResponse(req, nil)
+	}
+}
+
+// SendCommand sends an inter-shard command to another shard and waits for its acknowledgement.
+// persona identifies the sending shard and must be its address, since the receiver rejects a
+// persona that is not one.
+//
+// The caller decides when this runs. A runtime that must not emit before its state is durable
+// should buffer outbound commands and call this only after the commit succeeds — nothing here
+// sends on its own.
+func (c *Client) SendCommand(
+	ctx context.Context,
+	to *ServiceAddress,
+	name string,
+	persona string,
+	payload []byte,
+) error {
+	cmd := &iscv1.Command{
+		Name:    name,
+		Address: to,
+		Persona: &iscv1.Persona{Id: persona},
+		Payload: payload,
+	}
+
+	if _, err := c.Request(ctx, to, commandGroup+"."+name, cmd); err != nil {
+		return eris.Wrapf(err, "failed to send %s command", name)
+	}
+
+	return nil
+}

--- a/pkg/micro/isc_internal_test.go
+++ b/pkg/micro/isc_internal_test.go
@@ -1,0 +1,161 @@
+package micro
+
+import (
+	"context"
+	"math/rand/v2"
+	"testing"
+	"time"
+
+	iscv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/isc/v1"
+	"github.com/rotisserie/eris"
+	"github.com/stretchr/testify/require"
+)
+
+const testCommandName = "test_command"
+
+// iscFixture is a service serving one inter-shard command, plus a record of what its handler saw.
+type iscFixture struct {
+	service  *Service
+	client   *Client
+	sender   *ServiceAddress
+	received chan *iscv1.Command
+	handlErr error
+}
+
+func newISCFixture(t *testing.T, prng *rand.Rand) *iscFixture {
+	t.Helper()
+
+	service, client := newTestService(t, prng)
+	fixture := &iscFixture{
+		service:  service,
+		client:   client,
+		sender:   RandServiceAddress(t, prng),
+		received: make(chan *iscv1.Command, 1),
+	}
+
+	require.NoError(t, service.ServeCommands([]string{testCommandName},
+		func(_ context.Context, cmd *iscv1.Command) error {
+			fixture.received <- cmd
+			return fixture.handlErr
+		}))
+	require.NoError(t, client.Flush())
+
+	return fixture
+}
+
+// handled returns the command the handler received, or fails if none arrived.
+func (f *iscFixture) handled(t *testing.T) *iscv1.Command {
+	t.Helper()
+
+	select {
+	case cmd := <-f.received:
+		return cmd
+	case <-time.After(2 * time.Second):
+		t.Fatal("handler was never called")
+		return nil
+	}
+}
+
+// refused fails if the handler ran. Callers use it to prove a rejected command never reached the
+// runtime behind the transport.
+func (f *iscFixture) refused(t *testing.T) {
+	t.Helper()
+
+	select {
+	case cmd := <-f.received:
+		t.Fatalf("handler ran for a command it should have rejected: %v", cmd)
+	case <-time.After(200 * time.Millisecond):
+	}
+}
+
+func iscTestContext(t *testing.T) context.Context {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 5*time.Second)
+	t.Cleanup(cancel)
+	return ctx
+}
+
+// TestServeCommands_DeliversValidCommand covers the happy path end to end: a command sent with
+// Client.SendCommand reaches the handler intact, which also pins the subject convention — if the
+// send and serve sides ever disagree on it, this never arrives.
+func TestServeCommands_DeliversValidCommand(t *testing.T) {
+	prng := rand.New(rand.NewPCG(1, 2))
+	fixture := newISCFixture(t, prng)
+
+	payload := []byte("payload-bytes")
+	require.NoError(t, fixture.client.SendCommand(
+		iscTestContext(t), fixture.service.Address, testCommandName, String(fixture.sender), payload))
+
+	got := fixture.handled(t)
+	require.Equal(t, testCommandName, got.GetName())
+	require.Equal(t, String(fixture.sender), got.GetPersona().GetId())
+	require.Equal(t, String(fixture.service.Address), String(got.GetAddress()))
+	require.Equal(t, payload, got.GetPayload())
+}
+
+// TestServeCommands_RejectsNonShardPersona is the security boundary: inter-shard endpoints must be
+// reachable only by shards. A caller presenting a player identity is refused before the handler
+// runs, so a runtime behind this transport cannot mistake a player for a peer shard.
+func TestServeCommands_RejectsNonShardPersona(t *testing.T) {
+	prng := rand.New(rand.NewPCG(3, 4))
+	fixture := newISCFixture(t, prng)
+
+	for _, persona := range []string{"player@example.com", "not-a-shard", "1234"} {
+		err := fixture.client.SendCommand(
+			iscTestContext(t), fixture.service.Address, testCommandName, persona, nil)
+		require.Error(t, err, "persona %q must be refused", persona)
+		fixture.refused(t)
+	}
+}
+
+// TestServeCommands_RejectsMismatchedAddress verifies a command addressed to a different shard is
+// refused even when it is delivered to this one's subject.
+func TestServeCommands_RejectsMismatchedAddress(t *testing.T) {
+	prng := rand.New(rand.NewPCG(5, 6))
+	fixture := newISCFixture(t, prng)
+	elsewhere := RandServiceAddress(t, prng)
+
+	cmd := &iscv1.Command{
+		Name:    testCommandName,
+		Address: elsewhere,
+		Persona: &iscv1.Persona{Id: String(fixture.sender)},
+	}
+
+	_, err := fixture.client.Request(
+		iscTestContext(t), fixture.service.Address, commandGroup+"."+testCommandName, cmd)
+	require.Error(t, err)
+	fixture.refused(t)
+}
+
+// TestServeCommands_HandlerErrorFailsSender verifies a runtime that cannot accept a command — a
+// rejected transaction, a full queue — reports that back to the sending shard rather than
+// acknowledging work it never did.
+func TestServeCommands_HandlerErrorFailsSender(t *testing.T) {
+	prng := rand.New(rand.NewPCG(7, 8))
+	fixture := newISCFixture(t, prng)
+	fixture.handlErr = eris.New("runtime refused the command")
+
+	err := fixture.client.SendCommand(
+		iscTestContext(t), fixture.service.Address, testCommandName, String(fixture.sender), nil)
+	require.Error(t, err)
+	fixture.handled(t) // the handler did run; it was its error that failed the send
+}
+
+// TestServeCommands_ServesPing verifies the liveness endpoint every shard is expected to answer.
+func TestServeCommands_ServesPing(t *testing.T) {
+	prng := rand.New(rand.NewPCG(9, 10))
+	fixture := newISCFixture(t, prng)
+
+	_, err := fixture.client.Request(iscTestContext(t), fixture.service.Address, pingEndpoint, nil)
+	require.NoError(t, err)
+}
+
+// TestServeCommands_NilHandlerRejected verifies a wiring mistake fails at startup rather than
+// producing a service that accepts commands and silently drops them.
+func TestServeCommands_NilHandlerRejected(t *testing.T) {
+	prng := rand.New(rand.NewPCG(11, 12))
+	service, _ := newTestService(t, prng)
+
+	require.Error(t, service.ServeCommands([]string{testCommandName}, nil))
+}

--- a/pkg/plugin/data/data_test.go
+++ b/pkg/plugin/data/data_test.go
@@ -174,6 +174,51 @@ func TestPlugin_LoadsRegisteredKind(t *testing.T) {
 }
 
 // -------------------------------------------------------------------------------------------------
+// Tests — world-free load
+// -------------------------------------------------------------------------------------------------
+
+// TestPlugin_LoadWithoutWorld verifies Plugin.Load populates the catalog and wires Get[T] with no
+// cardinal.World in the process at all. This is the load path for tickless, snapshot-free runtimes:
+// they never construct a world, so the only thing they may skip is the reconcile system.
+func TestPlugin_LoadWithoutWorld(t *testing.T) {
+	plugin := data.NewPlugin(data.Config{EmbeddedFS: testFS})
+	data.Register[Abilities](plugin)
+	plugin.Load()
+
+	got := data.Get[Abilities]()
+	require.Equal(t, []AbilityRecord{
+		{ID: "fireball", Cooldown: 2.5},
+		{ID: "frostbolt", Cooldown: 3.0},
+	}, got.Items)
+}
+
+// TestPlugin_LoadRunsResolverThroughEmbed verifies Load takes the same Resolver path as
+// Register(world): hooks fetch through the local embed, never the primary Source. The primary fake
+// errors on any file but the kind's own, so a resolver fetch through it would fail the test.
+func TestPlugin_LoadRunsResolverThroughEmbed(t *testing.T) {
+	primarySrc := &mainOnlyFake{
+		mainFile:  "resolver_main.json",
+		mainBytes: []byte(`{"include":"testdata/resolver_side.json"}`),
+	}
+
+	plugin := data.NewPlugin(data.Config{Source: primarySrc, EmbeddedFS: testFS})
+	data.Register[resolverKind](plugin)
+	plugin.Load()
+
+	got := data.Get[resolverKind]()
+	require.Equal(t, "testdata/resolver_side.json", got.Include)
+	require.JSONEq(t, "{\"extra\":\"hello\"}\n", got.Side)
+}
+
+// TestPlugin_LoadValidateErrorPanics verifies Load keeps the fail-loud discipline of
+// Register(world): a Validator returning an error panics rather than loading bad config.
+func TestPlugin_LoadValidateErrorPanics(t *testing.T) {
+	plugin := data.NewPlugin(data.Config{EmbeddedFS: testFS})
+	data.Register[rejectingAbilities](plugin)
+	require.Panics(t, func() { plugin.Load() })
+}
+
+// -------------------------------------------------------------------------------------------------
 // Tests — manifest component lifecycle
 // -------------------------------------------------------------------------------------------------
 

--- a/pkg/plugin/data/plugin.go
+++ b/pkg/plugin/data/plugin.go
@@ -32,6 +32,10 @@
 // kind into the catalog before the tick loop begins. Get[T] is valid immediately after
 // cardinal.RegisterPlugin returns.
 //
+// A runtime that has no world — no tick loop, no snapshots — calls Plugin.Load in place of
+// cardinal.RegisterPlugin. The catalog and Get[T] behave identically; only the snapshot-restore
+// reconcile system is skipped, having nothing to reconcile against.
+//
 // The plugin picks the underlying Source based on the runtime environment (embedded files for
 // local dev; operator/forge integration is a future addition that flips automatically when
 // OPERATOR_ADDR is set). Shards do not select a source themselves — they hand the plugin their
@@ -136,7 +140,7 @@ func Register[T Definition](p *Plugin) {
 var registered *Plugin
 
 // Get returns the loaded value for kind T from the registered plugin. Call this from any game
-// system after cardinal.RegisterPlugin(world, dataPlugin) has run:
+// system after cardinal.RegisterPlugin(world, dataPlugin) — or dataPlugin.Load() — has run:
 //
 //	mobs := data.Get[component.Mobs]()
 //
@@ -144,7 +148,7 @@ var registered *Plugin
 // both are wiring bugs and should be caught loudly the first time any system reads.
 func Get[T Definition]() T {
 	if registered == nil {
-		panic("data: no plugin registered — call cardinal.RegisterPlugin(world, dataPlugin) first")
+		panic("data: no plugin registered — call cardinal.RegisterPlugin(world, dataPlugin) or dataPlugin.Load() first")
 	}
 	var zero T
 	v, ok := registered.state.MustGet(zero.Name()).(T)
@@ -157,18 +161,35 @@ func Get[T Definition]() T {
 	return v
 }
 
+// Load fetches every registered kind into the catalog and stashes the plugin as the process-global
+// backing data.Get[T](), without a cardinal.World. Call it after every Register[T] and before the
+// first data.Get[T]().
+//
+// This is the load path for runtimes that have no tick loop and no snapshots. Such a runtime holds
+// its state elsewhere, so there is no ConfigManifest to restore and nothing for the reconcile
+// system to reconcile against — the one thing Register(world) does that this does not. Worlds
+// built with cardinal.NewWorld should go through cardinal.RegisterPlugin instead, which calls this
+// and then installs reconcile.
+func (p *Plugin) Load() {
+	// Resolver hooks always go through the local embed regardless of how the primary source is
+	// configured (operator, fake, etc.). Resolver-fetched files are heavy designer-bundled assets
+	// — tilemaps, prefab manifests — that ship with the binary and aren't operator-editable.
+	p.state.LoadAll(context.Background(), p.config.Source, p.resolverSource())
+	registered = p
+}
+
+// resolverSource is the Source used for Resolver hooks. See Load for why it is always the embed.
+func (p *Plugin) resolverSource() Source {
+	return system.EmbedSource{FS: p.config.EmbeddedFS}
+}
+
 // Register implements cardinal.Plugin. Called synchronously by cardinal.RegisterPlugin, before
 // StartGame. Loads every registered kind into the catalog, stashes the plugin as the
 // process-global for data.Get[T](), and registers the per-tick reconcile system that keeps the
 // catalog matched to whatever ConfigManifest the snapshot restored.
 func (p *Plugin) Register(world *cardinal.World) {
-	// Resolver hooks always go through the local embed regardless of how the primary source is
-	// configured (operator, fake, etc.). Resolver-fetched files are heavy designer-bundled assets
-	// — tilemaps, prefab manifests — that ship with the binary and aren't operator-editable.
-	resolverSource := system.EmbedSource{FS: p.config.EmbeddedFS}
-	p.state.LoadAll(context.Background(), p.config.Source, resolverSource)
-	registered = p
+	p.Load()
 	cardinal.RegisterSystem(world, func(rs *system.ReconcileState) {
-		p.state.Reconcile(rs, p.config.Source, resolverSource)
+		p.state.Reconcile(rs, p.config.Source, p.resolverSource())
 	}, cardinal.WithHook(cardinal.PreUpdate))
 }

--- a/pkg/shard/server.go
+++ b/pkg/shard/server.go
@@ -1,0 +1,487 @@
+// Package shard serves the client-facing CardinalService protocol.
+//
+// The server owns every wire detail a client can observe: where a command's persona comes from,
+// when a subscription takes effect, which events a subscription matches, and how a reply is
+// awaited. What it does not own is what happens to a command once accepted — that is the runtime's
+// job, reached through CommandSink. A runtime that queues commands for a simulation tick and one
+// that executes each command in a transaction both plug in here and are indistinguishable to a
+// client, because neither gets to reimplement the protocol.
+//
+// Wiring is two halves. Inbound, the runtime supplies a CommandSink and mounts the server's
+// handler:
+//
+//	server, err := shard.NewServer(shard.Config{Address: addr, Commands: sink, Logger: log})
+//	path, handler, err := server.Handler()
+//	mux.Handle(path, authMiddleware.Wrap(handler))
+//
+// Outbound, the runtime publishes events as they become visible to clients:
+//
+//	server.PublishEvent(shard.Event{Name: "player_died", Payload: bz})
+//
+// PublishEvent never runs on its own, so a runtime that must not reveal an outcome before its
+// state is durable decides when to call it.
+package shard
+
+import (
+	"context"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"connectrpc.com/connect"
+	"connectrpc.com/otelconnect"
+	"connectrpc.com/validate"
+	"github.com/argus-labs/world-engine/pkg/assert"
+	"github.com/argus-labs/world-engine/pkg/auth"
+	"github.com/argus-labs/world-engine/pkg/micro"
+	cardinalv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1"
+	"github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1/cardinalv1connect"
+	iscv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/isc/v1"
+	"github.com/rotisserie/eris"
+	"github.com/rs/zerolog"
+)
+
+// keepaliveInterval bounds how long an idle event stream stays silent. Load balancers drop idle
+// connections, so the server sends an empty response to hold the stream open. The client SDK
+// ignores a response with no event.
+const keepaliveInterval = 30 * time.Second
+
+// CommandSink accepts commands the server has accepted on a client's behalf. The server has
+// already authenticated the caller, stamped the command's persona from that identity, and proven
+// the command is addressed to this shard.
+//
+// Submit decides what "accepted" means for the runtime: queueing the command for a later tick, or
+// running it now inside a transaction. Returning an error rejects the client's request.
+type CommandSink interface {
+	Submit(ctx context.Context, cmd *iscv1.Command) error
+}
+
+// Event is a marshaled event on its way to clients. Recipient addresses it to a single user; empty
+// broadcasts it to every subscriber whose subscriptions match Name.
+type Event struct {
+	Name      string
+	Payload   []byte
+	Recipient string
+}
+
+// EventBus is the outbound half of the protocol, implemented by *Server. A runtime holds one of
+// these to publish without depending on the server's concrete type.
+type EventBus interface {
+	PublishEvent(evt Event) error
+}
+
+// Config configures a Server.
+type Config struct {
+	// Address is this shard's own address. Commands and subscriptions naming a different shard are
+	// rejected.
+	Address *micro.ServiceAddress
+
+	// Commands receives accepted commands. Required.
+	Commands CommandSink
+
+	// Logger records delivery failures that are not worth failing a request over.
+	Logger zerolog.Logger
+}
+
+// Server implements the client-facing CardinalService.
+type Server struct {
+	address      *micro.ServiceAddress
+	commands     CommandSink
+	log          zerolog.Logger
+	subscribers  map[string]*streamSubscriber
+	replyWaiters map[string][]chan *iscv1.Event
+	mu           sync.RWMutex
+}
+
+var (
+	_ cardinalv1connect.CardinalServiceHandler = (*Server)(nil)
+	_ EventBus                                 = (*Server)(nil)
+)
+
+// NewServer creates a client-facing server for the shard at cfg.Address.
+func NewServer(cfg Config) (*Server, error) {
+	if cfg.Address == nil {
+		return nil, eris.New("shard address is required")
+	}
+	if cfg.Commands == nil {
+		return nil, eris.New("command sink is required")
+	}
+
+	return &Server{
+		address:      cfg.Address,
+		commands:     cfg.Commands,
+		log:          cfg.Logger,
+		subscribers:  make(map[string]*streamSubscriber),
+		replyWaiters: make(map[string][]chan *iscv1.Event),
+	}, nil
+}
+
+// Handler returns the mount path and HTTP handler for the CardinalService, with the tracing and
+// proto-validation interceptors already applied. Callers mount it behind authentication:
+//
+//	path, handler, err := server.Handler()
+//	mux.Handle(path, authMiddleware.Wrap(handler))
+//
+// The interceptors are attached here rather than left to callers because proto validation is part
+// of the protocol: a runtime that mounted the handler bare would accept malformed commands the
+// other runtimes reject.
+func (s *Server) Handler() (string, http.Handler, error) {
+	otelInterceptor, err := otelconnect.NewInterceptor()
+	if err != nil {
+		return "", nil, eris.Wrap(err, "failed to create otel interceptor")
+	}
+
+	path, handler := cardinalv1connect.NewCardinalServiceHandler(
+		s,
+		connect.WithInterceptors(otelInterceptor, validate.NewInterceptor()),
+	)
+	return path, handler, nil
+}
+
+// -------------------------------------------------------------------------------------------------
+// Commands
+// -------------------------------------------------------------------------------------------------
+
+// accept authenticates the caller, stamps the command's persona from that identity, and checks the
+// command is addressed to this shard. The persona is taken from the authenticated user and never
+// read from the request body, so a client cannot act as another player by asking to.
+func (s *Server) accept(ctx context.Context, cmd *iscv1.Command) error {
+	user := auth.UserFromContext(ctx)
+	assert.That(user != nil, "user should exist in authenticated request context")
+
+	assert.That(cmd != nil, "command should have been validated")
+	assert.That(cmd.GetPersona() != nil, "command persona should have been validated")
+
+	cmd.Persona.Id = user.ID
+
+	if micro.String(s.address) != micro.String(cmd.GetAddress()) {
+		return connect.NewError(connect.CodeInvalidArgument, eris.New("address doesn't match shard address"))
+	}
+
+	if err := s.commands.Submit(ctx, cmd); err != nil {
+		return connect.NewError(connect.CodeInvalidArgument, eris.Wrap(err, "failed to enqueue command"))
+	}
+
+	return nil
+}
+
+func (s *Server) SendCommand(
+	ctx context.Context,
+	req *connect.Request[cardinalv1.SendCommandRequest],
+) (*connect.Response[cardinalv1.SendCommandResponse], error) {
+	select {
+	case <-ctx.Done():
+		return nil, connect.NewError(connect.CodeCanceled, eris.Wrap(ctx.Err(), "context cancelled"))
+	default:
+	}
+
+	if err := s.accept(ctx, req.Msg.GetCommand()); err != nil {
+		return nil, err
+	}
+
+	return connect.NewResponse(&cardinalv1.SendCommandResponse{}), nil
+}
+
+func (s *Server) SendCommandWithReply(
+	ctx context.Context,
+	req *connect.Request[cardinalv1.SendCommandWithReplyRequest],
+) (*connect.Response[cardinalv1.SendCommandWithReplyResponse], error) {
+	// The waiter must be registered before the command is submitted. A runtime that executes
+	// commands synchronously publishes the reply event during Submit, and a waiter registered
+	// afterwards would miss it and block until the client gives up.
+	waiter := s.addReplyWaiter(req.Msg.GetEventName())
+	defer s.removeReplyWaiter(req.Msg.GetEventName(), waiter)
+
+	if err := s.accept(ctx, req.Msg.GetCommand()); err != nil {
+		return nil, err
+	}
+
+	select {
+	case <-ctx.Done():
+		return nil, connect.NewError(connect.CodeCanceled, eris.Wrap(ctx.Err(), "waiting for reply event"))
+	case event := <-waiter:
+		return connect.NewResponse(&cardinalv1.SendCommandWithReplyResponse{Event: event}), nil
+	}
+}
+
+func (s *Server) addReplyWaiter(eventName string) chan *iscv1.Event {
+	waiter := make(chan *iscv1.Event, 1)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.replyWaiters[eventName] = append(s.replyWaiters[eventName], waiter)
+	return waiter
+}
+
+func (s *Server) removeReplyWaiter(eventName string, waiter chan *iscv1.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	waiters := s.replyWaiters[eventName]
+	for i, current := range waiters {
+		if current == waiter {
+			s.replyWaiters[eventName] = append(waiters[:i], waiters[i+1:]...)
+			break
+		}
+	}
+	if len(s.replyWaiters[eventName]) == 0 {
+		delete(s.replyWaiters, eventName)
+	}
+}
+
+// -------------------------------------------------------------------------------------------------
+// Event streams
+// -------------------------------------------------------------------------------------------------
+
+type streamSubscriber struct {
+	ctx    context.Context
+	stream *connect.ServerStream[cardinalv1.StartEventStreamResponse]
+	events map[string]struct{}
+	mu     sync.Mutex
+}
+
+func (s *streamSubscriber) send(response *cardinalv1.StartEventStreamResponse) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.stream.Send(response)
+}
+
+func (s *Server) StartEventStream(
+	ctx context.Context,
+	req *connect.Request[cardinalv1.StartEventStreamRequest],
+	stream *connect.ServerStream[cardinalv1.StartEventStreamResponse],
+) error {
+	user := auth.UserFromContext(ctx)
+	assert.That(user != nil, "user should exist in authenticated stream context")
+
+	subscriber, err := s.addSubscriber(ctx, user, stream)
+	if err != nil {
+		return connect.NewError(connect.CodeFailedPrecondition, err)
+	}
+	defer s.removeSubscriber(user)
+
+	if err := s.checkSubscriptionAddresses(req.Msg.GetSubscriptions()); err != nil {
+		return err
+	}
+	s.subscribeEvents(user, req.Msg.GetSubscriptions())
+
+	if err := subscriber.send(&cardinalv1.StartEventStreamResponse{}); err != nil {
+		return connect.NewError(connect.CodeInternal, eris.Wrap(err, "failed to send initial empty event to client"))
+	}
+
+	ticker := time.NewTicker(keepaliveInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			if err := ctx.Err(); !eris.Is(err, context.Canceled) {
+				return connect.NewError(connect.CodeCanceled, eris.Wrap(err, "stream cancelled"))
+			}
+			return nil
+		case <-ticker.C:
+			if err := subscriber.send(&cardinalv1.StartEventStreamResponse{}); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (s *Server) SubscribeEvents(
+	ctx context.Context,
+	req *connect.Request[cardinalv1.SubscribeEventsRequest],
+) (*connect.Response[cardinalv1.SubscribeEventsResponse], error) {
+	user := auth.UserFromContext(ctx)
+	assert.That(user != nil, "user should exist in authenticated request context")
+
+	if !s.hasSubscriber(user) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, eris.New("client has no established stream"))
+	}
+
+	if err := s.checkSubscriptionAddresses(req.Msg.GetSubscriptions()); err != nil {
+		return nil, err
+	}
+	s.subscribeEvents(user, req.Msg.GetSubscriptions())
+
+	return connect.NewResponse(&cardinalv1.SubscribeEventsResponse{}), nil
+}
+
+func (s *Server) UnsubscribeEvents(
+	ctx context.Context,
+	req *connect.Request[cardinalv1.UnsubscribeEventsRequest],
+) (*connect.Response[cardinalv1.UnsubscribeEventsResponse], error) {
+	user := auth.UserFromContext(ctx)
+	assert.That(user != nil, "user should exist in authenticated request context")
+
+	if !s.hasSubscriber(user) {
+		return nil, connect.NewError(connect.CodeFailedPrecondition, eris.New("client has no established stream"))
+	}
+
+	if err := s.checkSubscriptionAddresses(req.Msg.GetSubscriptions()); err != nil {
+		return nil, err
+	}
+	s.unsubscribeEvents(user, req.Msg.GetSubscriptions())
+
+	return connect.NewResponse(&cardinalv1.UnsubscribeEventsResponse{}), nil
+}
+
+// checkSubscriptionAddresses rejects subscriptions naming a different shard.
+func (s *Server) checkSubscriptionAddresses(subscriptions []*cardinalv1.EventSubscription) error {
+	for _, subscription := range subscriptions {
+		if micro.String(s.address) != micro.String(subscription.GetAddress()) {
+			return connect.NewError(connect.CodeInvalidArgument, eris.New("address doesn't match shard address"))
+		}
+	}
+	return nil
+}
+
+func (s *Server) addSubscriber(
+	ctx context.Context,
+	user *auth.User,
+	stream *connect.ServerStream[cardinalv1.StartEventStreamResponse],
+) (*streamSubscriber, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, exists := s.subscribers[user.ID]; exists {
+		return nil, eris.Errorf("user %s already has an open stream", user.ID)
+	}
+
+	subscriber := &streamSubscriber{
+		ctx:    ctx,
+		stream: stream,
+		events: make(map[string]struct{}),
+	}
+	s.subscribers[user.ID] = subscriber
+	return subscriber, nil
+}
+
+func (s *Server) removeSubscriber(user *auth.User) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	delete(s.subscribers, user.ID)
+}
+
+func (s *Server) subscribeEvents(user *auth.User, subscriptions []*cardinalv1.EventSubscription) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	subscriber := s.subscribers[user.ID]
+	assert.That(subscriber != nil, "subscriber should exist for authenticated stream")
+
+	for _, subscription := range subscriptions {
+		for _, eventName := range subscription.GetEvents() {
+			subscriber.events[eventName] = struct{}{}
+		}
+	}
+}
+
+func (s *Server) unsubscribeEvents(user *auth.User, subscriptions []*cardinalv1.EventSubscription) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	subscriber := s.subscribers[user.ID]
+	assert.That(subscriber != nil, "subscriber should exist for authenticated stream")
+
+	for _, subscription := range subscriptions {
+		for _, eventName := range subscription.GetEvents() {
+			delete(subscriber.events, eventName)
+		}
+	}
+}
+
+func (s *Server) hasSubscriber(user *auth.User) bool {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	_, ok := s.subscribers[user.ID]
+	return ok
+}
+
+// -------------------------------------------------------------------------------------------------
+// Event publishing
+// -------------------------------------------------------------------------------------------------
+
+// PublishEvent delivers evt to everyone waiting for it: any SendCommandWithReply call awaiting an
+// event of this name, and every stream subscriber whose subscriptions match it.
+//
+// A subscriber whose stream is closed or failing is skipped and logged rather than failing the
+// call, since one broken client must not stop an event reaching the rest.
+//
+//nolint:gocognit // Put everything here so you can understand the logic in one place.
+func (s *Server) PublishEvent(evt Event) error {
+	eventPb := &iscv1.Event{
+		Name:    evt.Name,
+		Payload: evt.Payload,
+	}
+
+	s.mu.RLock()
+	var subscribers []*streamSubscriber
+	//nolint:nestif // It's fine
+	if evt.Recipient != "" {
+		if subscriber, exists := s.subscribers[evt.Recipient]; exists {
+			for subscription := range subscriber.events {
+				if matchesEvent(subscription, eventPb.GetName()) {
+					subscribers = []*streamSubscriber{subscriber}
+					break
+				}
+			}
+		} else {
+			s.log.Debug().Str("recipient", evt.Recipient).Str("event", eventPb.GetName()).Msg("recipient has no open stream")
+		}
+	} else {
+		subscribers = make([]*streamSubscriber, 0, len(s.subscribers))
+		for _, subscriber := range s.subscribers {
+			for subscription := range subscriber.events {
+				if matchesEvent(subscription, eventPb.GetName()) {
+					subscribers = append(subscribers, subscriber)
+					break
+				}
+			}
+		}
+	}
+	waiters := append([]chan *iscv1.Event(nil), s.replyWaiters[eventPb.GetName()]...)
+	s.mu.RUnlock()
+
+	// Send events for SendCommandWithReply channels.
+	for _, waiter := range waiters {
+		select {
+		case waiter <- eventPb:
+		default:
+		}
+	}
+
+	// Send events to stream subscribers.
+	for _, subscriber := range subscribers {
+		select {
+		case <-subscriber.ctx.Done():
+			continue
+		default:
+		}
+
+		err := subscriber.send(&cardinalv1.StartEventStreamResponse{
+			Address: s.address,
+			Event:   eventPb,
+		})
+		if err != nil {
+			s.log.Error().Err(err).Str("event", eventPb.GetName()).Msg("failed to send event to subscriber")
+			continue
+		}
+	}
+
+	return nil
+}
+
+// matchesEvent reports whether a subscription covers an event name. "*" and ">" match everything,
+// a "prefix.>" subscription matches any event under that prefix, and anything else must match
+// exactly.
+func matchesEvent(subscription string, eventName string) bool {
+	return subscription == eventName ||
+		subscription == "*" ||
+		subscription == ">" ||
+		(strings.HasSuffix(subscription, ".>") && strings.HasPrefix(eventName, strings.TrimSuffix(subscription, ">")))
+}

--- a/pkg/shard/server_internal_test.go
+++ b/pkg/shard/server_internal_test.go
@@ -1,0 +1,274 @@
+package shard
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"connectrpc.com/authn"
+	"connectrpc.com/connect"
+	"github.com/argus-labs/world-engine/pkg/auth"
+	"github.com/argus-labs/world-engine/pkg/micro"
+	cardinalv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1"
+	iscv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/isc/v1"
+	"github.com/rotisserie/eris"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// This is the conformance suite for the client-facing protocol. Every runtime that serves it plugs
+// a CommandSink in here; these tests pin the behavior a client is entitled to regardless of which
+// runtime is behind the seam.
+
+// sinkFunc adapts a function to CommandSink.
+type sinkFunc func(ctx context.Context, cmd *iscv1.Command) error
+
+func (f sinkFunc) Submit(ctx context.Context, cmd *iscv1.Command) error { return f(ctx, cmd) }
+
+func testAddress(t *testing.T, id string) *micro.ServiceAddress {
+	t.Helper()
+
+	return micro.GetAddress("test-region", micro.RealmWorld, "test-org", "test-project", id)
+}
+
+func newTestServer(t *testing.T, sink CommandSink) *Server {
+	t.Helper()
+
+	server, err := NewServer(Config{
+		Address:  testAddress(t, "shard-under-test"),
+		Commands: sink,
+		Logger:   zerolog.Nop(),
+	})
+	require.NoError(t, err)
+	return server
+}
+
+// authedContext returns a context carrying an authenticated user, as the auth middleware would.
+func authedContext(t *testing.T, userID string) context.Context {
+	t.Helper()
+
+	return authn.SetInfo(t.Context(), &auth.User{ID: userID})
+}
+
+func testCommand(address *micro.ServiceAddress) *iscv1.Command {
+	return &iscv1.Command{
+		Name:    "test_command",
+		Address: address,
+		Persona: &iscv1.Persona{Id: "whatever-the-client-claimed"},
+		Payload: []byte("payload"),
+	}
+}
+
+func TestNewServer_RequiresAddressAndSink(t *testing.T) {
+	t.Parallel()
+
+	sink := sinkFunc(func(context.Context, *iscv1.Command) error { return nil })
+
+	_, err := NewServer(Config{Commands: sink})
+	require.Error(t, err, "a server with no address cannot tell its own commands from another shard's")
+
+	_, err = NewServer(Config{Address: testAddress(t, "s")})
+	require.Error(t, err, "a server with no sink would accept commands and drop them")
+}
+
+// TestSendCommand_PersonaComesFromAuthenticatedUser is the protocol's core security property: the
+// persona a command executes under is the authenticated identity, never what the client put in the
+// request body.
+func TestSendCommand_PersonaComesFromAuthenticatedUser(t *testing.T) {
+	t.Parallel()
+
+	var submitted *iscv1.Command
+	server := newTestServer(t, sinkFunc(func(_ context.Context, cmd *iscv1.Command) error {
+		submitted = cmd
+		return nil
+	}))
+
+	_, err := server.SendCommand(
+		authedContext(t, "the-real-user"),
+		connect.NewRequest(&cardinalv1.SendCommandRequest{Command: testCommand(server.address)}),
+	)
+	require.NoError(t, err)
+
+	require.NotNil(t, submitted)
+	assert.Equal(t, "the-real-user", submitted.GetPersona().GetId(),
+		"the client-supplied persona must be overwritten by the authenticated identity")
+}
+
+func TestSendCommand_RejectsAnotherShardsAddress(t *testing.T) {
+	t.Parallel()
+
+	called := false
+	server := newTestServer(t, sinkFunc(func(context.Context, *iscv1.Command) error {
+		called = true
+		return nil
+	}))
+
+	_, err := server.SendCommand(
+		authedContext(t, "user"),
+		connect.NewRequest(&cardinalv1.SendCommandRequest{Command: testCommand(testAddress(t, "some-other-shard"))}),
+	)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+	assert.False(t, called, "a command for another shard must not reach the runtime")
+}
+
+func TestSendCommand_SinkErrorRejectsRequest(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, sinkFunc(func(context.Context, *iscv1.Command) error {
+		return eris.New("runtime refused")
+	}))
+
+	_, err := server.SendCommand(
+		authedContext(t, "user"),
+		connect.NewRequest(&cardinalv1.SendCommandRequest{Command: testCommand(server.address)}),
+	)
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// TestSendCommandWithReply_SynchronousSink is the regression test for reply-waiter ordering. A
+// runtime that executes a command inside Submit publishes the reply event before Submit returns.
+// If the waiter were registered after dispatch — as it once was — the event would land with nobody
+// listening and this call would block until the client gave up.
+//
+// A ticked runtime never exposed the bug because its reply arrives a tick later, which is why the
+// ordering has to be pinned here rather than left to each runtime to rediscover.
+func TestSendCommandWithReply_SynchronousSink(t *testing.T) {
+	t.Parallel()
+
+	const replyEvent = "command_result"
+
+	var server *Server
+	server = newTestServer(t, sinkFunc(func(context.Context, *iscv1.Command) error {
+		// Execute and publish the outcome before returning, as a transactional runtime does.
+		return server.PublishEvent(Event{Name: replyEvent, Payload: []byte("result")})
+	}))
+
+	ctx, cancel := context.WithTimeout(authedContext(t, "user"), 2*time.Second)
+	t.Cleanup(cancel)
+
+	response, err := server.SendCommandWithReply(ctx, connect.NewRequest(
+		&cardinalv1.SendCommandWithReplyRequest{
+			Command:   testCommand(server.address),
+			EventName: replyEvent,
+		},
+	))
+	require.NoError(t, err, "reply published during Submit must still reach the waiter")
+	require.Equal(t, replyEvent, response.Msg.GetEvent().GetName())
+	require.Equal(t, []byte("result"), response.Msg.GetEvent().GetPayload())
+}
+
+// TestSendCommandWithReply_RejectedCommandDoesNotWait verifies a refused command fails immediately
+// rather than leaving the client waiting for a reply that will never come.
+func TestSendCommandWithReply_RejectedCommandDoesNotWait(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, sinkFunc(func(context.Context, *iscv1.Command) error { return nil }))
+
+	ctx, cancel := context.WithTimeout(authedContext(t, "user"), 2*time.Second)
+	t.Cleanup(cancel)
+
+	_, err := server.SendCommandWithReply(ctx, connect.NewRequest(
+		&cardinalv1.SendCommandWithReplyRequest{
+			Command:   testCommand(testAddress(t, "some-other-shard")),
+			EventName: "never_arrives",
+		},
+	))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeInvalidArgument, connect.CodeOf(err))
+}
+
+// TestReplyWaiters_CleanedUpAfterUse verifies a completed call leaves no waiter behind, so a
+// long-lived shard does not accumulate them.
+func TestReplyWaiters_CleanedUpAfterUse(t *testing.T) {
+	t.Parallel()
+
+	const replyEvent = "cleanup_check"
+
+	var server *Server
+	server = newTestServer(t, sinkFunc(func(context.Context, *iscv1.Command) error {
+		return server.PublishEvent(Event{Name: replyEvent})
+	}))
+
+	ctx, cancel := context.WithTimeout(authedContext(t, "user"), 2*time.Second)
+	t.Cleanup(cancel)
+
+	_, err := server.SendCommandWithReply(ctx, connect.NewRequest(
+		&cardinalv1.SendCommandWithReplyRequest{
+			Command:   testCommand(server.address),
+			EventName: replyEvent,
+		},
+	))
+	require.NoError(t, err)
+
+	server.mu.RLock()
+	defer server.mu.RUnlock()
+	assert.Empty(t, server.replyWaiters, "a finished call must not leave its waiter registered")
+}
+
+// TestSubscribeEvents_RequiresEstablishedStream verifies subscriptions are refused until the client
+// has a stream to deliver them on.
+func TestSubscribeEvents_RequiresEstablishedStream(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, sinkFunc(func(context.Context, *iscv1.Command) error { return nil }))
+
+	_, err := server.SubscribeEvents(authedContext(t, "user"), connect.NewRequest(
+		&cardinalv1.SubscribeEventsRequest{},
+	))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+
+	_, err = server.UnsubscribeEvents(authedContext(t, "user"), connect.NewRequest(
+		&cardinalv1.UnsubscribeEventsRequest{},
+	))
+	require.Error(t, err)
+	assert.Equal(t, connect.CodeFailedPrecondition, connect.CodeOf(err))
+}
+
+// TestPublishEvent_WithNoListeners verifies publishing into an empty shard is a no-op rather than
+// an error, so a runtime need not track whether anyone is listening.
+func TestPublishEvent_WithNoListeners(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, sinkFunc(func(context.Context, *iscv1.Command) error { return nil }))
+	require.NoError(t, server.PublishEvent(Event{Name: "nobody_listening"}))
+}
+
+func TestHandler_MountsWithInterceptors(t *testing.T) {
+	t.Parallel()
+
+	server := newTestServer(t, sinkFunc(func(context.Context, *iscv1.Command) error { return nil }))
+
+	path, handler, err := server.Handler()
+	require.NoError(t, err)
+	assert.NotEmpty(t, path)
+	assert.NotNil(t, handler)
+}
+
+// TestMatchesEvent pins the subscription matching rules. Clients rely on these exact semantics, so
+// a runtime must not be in a position to reimplement them differently.
+func TestMatchesEvent(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		subscription string
+		eventName    string
+		want         bool
+	}{
+		{subscription: "player_died", eventName: "player_died", want: true},
+		{subscription: "player_died", eventName: "player_spawned", want: false},
+		{subscription: "*", eventName: "anything", want: true},
+		{subscription: ">", eventName: "anything", want: true},
+		{subscription: "player.>", eventName: "player.died", want: true},
+		{subscription: "player.>", eventName: "player.", want: true},
+		{subscription: "player.>", eventName: "monster.died", want: false},
+		{subscription: "player.>", eventName: "player", want: false},
+		{subscription: "", eventName: "player_died", want: false},
+	} {
+		assert.Equal(t, tc.want, matchesEvent(tc.subscription, tc.eventName),
+			"matchesEvent(%q, %q)", tc.subscription, tc.eventName)
+	}
+}


### PR DESCRIPTION
## Decompose Cardinal so a world-free runtime can serve the same protocol

Everything a client can observe about the CardinalService protocol lived inside `pkg/cardinal`, welded to a world. ADR-057 needs a tickless shard to serve that same protocol, which would have meant reimplementing it — and every disagreement between the two copies would be a client-visible bug.

Four extractions, no behavior change for existing worlds:

- **`pkg/plugin/data`** — `Plugin.Load()`. Loading config never needed a world, only snapshot reconciliation did.
- **`pkg/auth`** — `User`, `Mode`, `NewMiddleware`, both authenticators.
- **`pkg/micro`** — `Service.ServeCommands` / `Client.SendCommand`. Inbound ISC was ~30 lines of validation ending in one line of runtime work.
- **`pkg/shard`** — the CardinalService handler, behind `CommandSink` + `EventBus`.`pkg/cardinal/service.go`: 759 → 248 lines. Cardinal's implementation of the seam is four
lines, and the same method now serves the ISC path, so client and inter-shard commands
converge on one implementation instead of two that happen to agree.

### Fixes a latent reply-waiter race

`SendCommandWithReply` registered its waiter *after* submitting the command. Harmless under a tick — the command waits in a queue, so the waiter always wins. A runtime that executes inside `Submit` publishes the reply before returning, so the event lands with nobody listening and the client blocks until timeout. The shared server registers first; regression test confirmed by restoring the old order (fails with `context deadline exceeded`).

### Behavior changes

- Reply-waiter ordering, above — closes a race, can't regress an existing world.
- ISC enqueue failure now reports `Internal` rather than `InvalidArgument`. Only fires for an unregistered command name, which is unreachable through a registered endpoint.

### Compatibility

`cardinal.User`, `AuthMode`, `ParseAuthMode`, `UserFromContext` remain as aliases — existing game code compiles unchanged. `newService` now returns an error (3 internal call sites updated).

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>