### PR TITLE
feat(immutable): add Slice, the value-only list a component may hold


### DIFF
--- a/docs/cardinal/ecs.mdx
+++ b/docs/cardinal/ecs.mdx
@@ -78,7 +78,9 @@ component may hold values only:
 - Structs of those
 - Fixed-size arrays such as `[8]Vec2`, at any depth
 - `immutable.Slice[T]` for a list with no fixed bound (see below)
-- `time.Time`
+- `time.Time`, the one sanctioned exception. It carries a location pointer, but it travels as a
+  protobuf Timestamp, so a restored value comes back in UTC with no monotonic reading. Compare
+  times with `Equal`, never `==`.
 
 A component may **not** hold pointers, maps, plain slices (`[]T`), interfaces, channels, or funcs.
 A plain slice inside a copy still shares its backing array with the stored component, so writing

--- a/docs/cardinal/ecs.mdx
+++ b/docs/cardinal/ecs.mdx
@@ -157,8 +157,8 @@ one, and changes to it never reach the Slice.
   `immutable.Slice` needs a World CLI new enough to generate it. An older one reports the field as an
   unsupported type when you run `world sdk generate`.
 
-  A Slice is also a struct, so a JSON tag of `omitempty` no longer omits an empty list: it encodes as
-  `[]`. That only matters if something reads your components as JSON; the wire format is protobuf.
+  A Slice has no JSON form of its own — the wire format is protobuf. Keep a `json` tag on the field if
+  you like, but do not expect a Slice to survive `encoding/json`.
 </Note>
 
 <Note>

--- a/docs/cardinal/ecs.mdx
+++ b/docs/cardinal/ecs.mdx
@@ -68,6 +68,95 @@ func (Position) Name() string {
   underscores (e.g. `Health`, `player_health`).
 </Note>
 
+### What a Component May Hold
+
+Components are copied. `Get` hands you a copy and `Set` stores one, and every snapshot is built
+from what went through `Set`. That only works if a copy is independent of the original, so a
+component may hold values only:
+
+- Numbers, booleans, and strings
+- Structs of those
+- Fixed-size arrays such as `[8]Vec2`, at any depth
+- `immutable.Slice[T]` for a list with no fixed bound (see below)
+- `time.Time`
+
+A component may **not** hold pointers, maps, plain slices (`[]T`), interfaces, channels, or funcs.
+A plain slice inside a copy still shares its backing array with the stored component, so writing
+through it changes the world without a `Set`. `world sdk generate` refuses such fields and prints
+the fix for each one. The same rule applies to commands and events, which cross the same generator.
+
+A list with a known upper bound is a fixed array plus a count:
+
+```go
+const MaxItems = 16
+
+type Inventory struct {
+	Items [MaxItems]Item `json:"items"`
+	Count int            `json:"count"`
+}
+```
+
+### Lists Without a Bound: `immutable.Slice`
+
+When the length has no bound you can defend, hold the list in `immutable.Slice[T]` from
+`github.com/argus-labs/world-engine/pkg/immutable`. On the wire it is the same repeated field a
+`[]T` would be. The difference is that nothing can write through it: the backing array is hidden,
+every reader returns a copy, and every change produces a new value.
+
+```go
+import "github.com/argus-labs/world-engine/pkg/immutable"
+
+type Buffs struct {
+	Active immutable.Slice[Buff] `json:"active"`
+}
+
+func (Buffs) Name() string {
+	return "buffs"
+}
+```
+
+Read a Slice with `Len`, `At`, and `All`. To change it, build the next list and store it with
+`Set`:
+
+```go
+func BuffSystem(state *BuffSystemState) error {
+	for _, mob := range state.Mobs.Iter() {
+		buffs := mob.Buffs.Get()
+
+		// Drop expired buffs and add a new one.
+		next := make([]Buff, 0, buffs.Active.Len()+1)
+		for _, buff := range buffs.Active.All() {
+			if buff.ExpiresAt > state.Tick() {
+				next = append(next, buff)
+			}
+		}
+		next = append(next, Buff{Kind: Haste, ExpiresAt: state.Tick() + 60})
+
+		buffs.Active = immutable.SliceOf(next...)
+		mob.Buffs.Set(buffs)
+	}
+	return nil
+}
+```
+
+`immutable.SliceOf(items...)` copies the plain slice it is given, so later changes to `next` never
+reach the component. For a single change, `Append` and `With` derive the new Slice directly:
+
+```go
+buffs.Active = buffs.Active.Append(newBuff)
+buffs.Active = buffs.Active.With(0, updatedBuff)
+mob.Buffs.Set(buffs)
+```
+
+`Clone` returns a plain `[]T` for APIs that need one, and changes to that copy never reach the
+Slice either.
+
+<Note>
+  The element type follows the same rule as any field: values only. A Slice directly inside another
+  Slice has no protobuf form, so wrap the inner one in a named struct, for example
+  `immutable.Slice[Row]` where `Row` holds `immutable.Slice[Cell]`.
+</Note>
+
 ### Tag Components
 
 Components don't need to contain data. You can use empty structs as "tags" to mark entities:
@@ -225,7 +314,9 @@ func MobSystem(state *MobSystemState) error {
 
 ### Reading and Writing Components
 
-Use `Get` and `Set` on component references to read and write component data:
+Use `Get` and `Set` on component references to read and write component data. `Get` returns a
+copy, so nothing you do to it reaches the world until you `Set` it back (see
+[What a Component May Hold](#what-a-component-may-hold)):
 
 ```go
 func MobSystem(state *MobSystemState) error {

--- a/docs/cardinal/ecs.mdx
+++ b/docs/cardinal/ecs.mdx
@@ -108,6 +108,11 @@ every reader returns a copy, and every change produces a new value.
 ```go
 import "github.com/argus-labs/world-engine/pkg/immutable"
 
+type Buff struct {
+	Kind      string `json:"kind"`
+	ExpiresAt uint64 `json:"expires_at"` // tick
+}
+
 type Buffs struct {
 	Active immutable.Slice[Buff] `json:"active"`
 }
@@ -117,41 +122,37 @@ func (Buffs) Name() string {
 }
 ```
 
-Read a Slice with `Len`, `At`, and `All`. To change it, build the next list and store it with
-`Set`:
+The API mirrors Go's `slices` package in full. Reads such as `At`, `All`, `IndexFunc`, and
+`MinFunc` are methods, and so are derivations such as `Append`, `Insert`, `With`, `Without`, `Sub`,
+`Filter`, `Delete`, `Reversed`, and `SortedFunc`. Anything that needs a type constraint is a package
+function, for example `Equal`, `Contains`, `Sorted`, `Min`, `Map`, and `Concat`. Every derivation
+returns a new Slice. Derive, then `Set` the component that holds it:
 
 ```go
 func BuffSystem(state *BuffSystemState) error {
+	now := state.Tick()
 	for _, mob := range state.Mobs.Iter() {
 		buffs := mob.Buffs.Get()
 
 		// Drop expired buffs and add a new one.
-		next := make([]Buff, 0, buffs.Active.Len()+1)
-		for _, buff := range buffs.Active.All() {
-			if buff.ExpiresAt > state.Tick() {
-				next = append(next, buff)
-			}
-		}
-		next = append(next, Buff{Kind: Haste, ExpiresAt: state.Tick() + 60})
+		buffs.Active = buffs.Active.
+			Filter(func(b Buff) bool { return b.ExpiresAt > now }).
+			Append(Buff{Kind: "haste", ExpiresAt: now + 60})
 
-		buffs.Active = immutable.SliceOf(next...)
 		mob.Buffs.Set(buffs)
 	}
 	return nil
 }
 ```
 
-`immutable.SliceOf(items...)` copies the plain slice it is given, so later changes to `next` never
-reach the component. For a single change, `Append` and `With` derive the new Slice directly:
+`immutable.SliceOf(items...)` builds a Slice from a plain slice and copies it, so later changes to
+that slice never reach the component. `Clone` goes the other way: a plain `[]T` for APIs that need
+one, and changes to it never reach the Slice.
 
-```go
-buffs.Active = buffs.Active.Append(newBuff)
-buffs.Active = buffs.Active.With(0, updatedBuff)
-mob.Buffs.Set(buffs)
-```
-
-`Clone` returns a plain `[]T` for APIs that need one, and changes to that copy never reach the
-Slice either.
+<Note>
+  A Slice is a struct, so a JSON tag of `omitempty` no longer omits an empty list: it encodes as
+  `[]`. This only matters if something reads your components as JSON; the wire format is protobuf.
+</Note>
 
 <Note>
   The element type follows the same rule as any field: values only. A Slice directly inside another

--- a/docs/cardinal/ecs.mdx
+++ b/docs/cardinal/ecs.mdx
@@ -102,8 +102,8 @@ type Inventory struct {
 
 When the length has no bound you can defend, hold the list in `immutable.Slice[T]` from
 `github.com/argus-labs/world-engine/pkg/immutable`. On the wire it is the same repeated field a
-`[]T` would be. The difference is that nothing can write through it: the backing array is hidden,
-every reader returns a copy, and every change produces a new value.
+`[]T` would be. The difference is that the backing array is hidden: no other package can index into
+it, reslice it, or hold on to it, and every reader hands back a copy of the element.
 
 ```go
 import "github.com/argus-labs/world-engine/pkg/immutable"
@@ -122,15 +122,16 @@ func (Buffs) Name() string {
 }
 ```
 
-The API follows Go's `slices` package closely, with one difference: nothing mutates in place, so an
-operation that would rewrite a slice returns a new Slice and is named for the result — `Reverse`
-becomes `Reversed`, and `Sort` and `SortFunc` become `Sorted` and `SortedFunc`.
+The API follows Go's `slices` package closely. Operations are named for their result rather than for
+an action on the receiver — `Reverse` becomes `Reversed`, and `Sort` and `SortFunc` become `Sorted`
+and `SortedFunc`.
 
 Reads such as `At`, `All`, `IndexFunc`, and `MinFunc` are methods, and so are derivations such as
 `Append`, `Insert`, `With`, `Without`, `Sub`, `Filter`, `Delete`, `Reversed`, and `SortedFunc`.
 Anything that needs a type constraint is a package function, for example `Equal`, `Contains`,
-`Sorted`, `Min`, `Map`, and `Concat`. Every derivation returns a new Slice. Derive, then `Set` the
-component that holds it:
+`Sorted`, `Min`, `Map`, and `Concat`.
+
+Derive, then `Set` the component that holds it:
 
 ```go
 func BuffSystem(state *BuffSystemState) error {
@@ -152,6 +153,24 @@ func BuffSystem(state *BuffSystemState) error {
 `immutable.SliceOf(items...)` builds a Slice from a plain slice and copies it, so later changes to
 that slice never reach the component. `Clone` goes the other way: a plain `[]T` for APIs that need
 one, and changes to it never reach the Slice.
+
+<Warning>
+  **Derivations do not copy, so the `Set` is not optional.** Most of them edit the hidden array in
+  place and return a Slice over that same array, which means the component has already changed by the
+  time the derivation returns. Deriving and then dropping the result does not leave the world alone —
+  it leaves the world holding an edit that no snapshot recorded.
+
+  `Append`, `Repeat`, and `Sub` leave the receiver alone; `Insert` and `Replace` leave it alone only
+  when they have to grow. The rest — `With`, `Without`, `Filter`, `Delete`, `Reversed`, `SortedFunc`,
+  `CompactFunc`, `Sorted`, and `Compact` — always write through. Ones that shrink leave the receiver
+  at its old length over a zero-filled tail, so the receiver is not just reordered but wrong.
+
+  Two rules follow. Call `Set` after every derivation, even one you think is read-only:
+  `s.SortedFunc(cmp).At(0)` reorders the stored list. And when the original has to survive, derive
+  from a copy with `immutable.SliceOf(s.Clone()...)`.
+
+  Each method's Go doc says whether it writes through.
+</Warning>
 
 <Note>
   `immutable.Slice` needs a World CLI new enough to generate it. An older one reports the field as an

--- a/docs/cardinal/ecs.mdx
+++ b/docs/cardinal/ecs.mdx
@@ -151,8 +151,10 @@ func BuffSystem(state *BuffSystemState) error {
 ```
 
 `immutable.SliceOf(items...)` builds a Slice from a plain slice and copies it, so later changes to
-that slice never reach the component. `Clone` goes the other way: a plain `[]T` for APIs that need
-one, and changes to it never reach the Slice.
+that slice never reach the component. To go the other way — a plain `[]T` for an API that needs one —
+range over `Values`, or use `immutable.Collect` to build a fresh Slice from the result: there is no
+`Clone` method, since a copy taken that way could look like it protects the original while
+derivations write through it regardless.
 
 <Warning>
   **Derivations do not copy, so the `Set` is not optional.** Most of them edit the hidden array in
@@ -167,7 +169,7 @@ one, and changes to it never reach the Slice.
 
   Two rules follow. Call `Set` after every derivation, even one you think is read-only:
   `s.SortedFunc(cmp).At(0)` reorders the stored list. And when the original has to survive, derive
-  from a copy with `immutable.SliceOf(s.Clone()...)`.
+  from a copy instead: `immutable.SliceOf(slices.Collect(s.Values())...)`.
 
   Each method's Go doc says whether it writes through.
 </Warning>

--- a/docs/cardinal/ecs.mdx
+++ b/docs/cardinal/ecs.mdx
@@ -122,11 +122,15 @@ func (Buffs) Name() string {
 }
 ```
 
-The API mirrors Go's `slices` package in full. Reads such as `At`, `All`, `IndexFunc`, and
-`MinFunc` are methods, and so are derivations such as `Append`, `Insert`, `With`, `Without`, `Sub`,
-`Filter`, `Delete`, `Reversed`, and `SortedFunc`. Anything that needs a type constraint is a package
-function, for example `Equal`, `Contains`, `Sorted`, `Min`, `Map`, and `Concat`. Every derivation
-returns a new Slice. Derive, then `Set` the component that holds it:
+The API follows Go's `slices` package closely, with one difference: nothing mutates in place, so an
+operation that would rewrite a slice returns a new Slice and is named for the result — `Reverse`
+becomes `Reversed`, and `Sort` and `SortFunc` become `Sorted` and `SortedFunc`.
+
+Reads such as `At`, `All`, `IndexFunc`, and `MinFunc` are methods, and so are derivations such as
+`Append`, `Insert`, `With`, `Without`, `Sub`, `Filter`, `Delete`, `Reversed`, and `SortedFunc`.
+Anything that needs a type constraint is a package function, for example `Equal`, `Contains`,
+`Sorted`, `Min`, `Map`, and `Concat`. Every derivation returns a new Slice. Derive, then `Set` the
+component that holds it:
 
 ```go
 func BuffSystem(state *BuffSystemState) error {
@@ -150,8 +154,11 @@ that slice never reach the component. `Clone` goes the other way: a plain `[]T` 
 one, and changes to it never reach the Slice.
 
 <Note>
-  A Slice is a struct, so a JSON tag of `omitempty` no longer omits an empty list: it encodes as
-  `[]`. This only matters if something reads your components as JSON; the wire format is protobuf.
+  `immutable.Slice` needs a World CLI new enough to generate it. An older one reports the field as an
+  unsupported type when you run `world sdk generate`.
+
+  A Slice is also a struct, so a JSON tag of `omitempty` no longer omits an empty list: it encodes as
+  `[]`. That only matters if something reads your components as JSON; the wire format is protobuf.
 </Note>
 
 <Note>

--- a/docs/cardinal/snapshots.mdx
+++ b/docs/cardinal/snapshots.mdx
@@ -5,7 +5,9 @@ title: 'Snapshots & Durability'
 A Cardinal shard keeps its whole world in memory. A **snapshot** is the only durable copy of that
 world: every `SnapshotRate` ticks the shard serializes its state and writes it to snapshot storage,
 replacing the previous snapshot. On boot the shard loads it back and continues from the tick it was
-taken at.
+taken at. A snapshot holds exactly the component data that went through `Set`, which is why
+components hold values only (see
+[What a Component May Hold](/cardinal/ecs#what-a-component-may-hold)).
 
 ## Configuration
 

--- a/pkg/cardinal/dst.go
+++ b/pkg/cardinal/dst.go
@@ -345,15 +345,15 @@ func fillRandom(prng *rand.Rand, v reflect.Value, liveEntityIDs []EntityID) {
 // it was one. The struct walk in fillRandom cannot do it: a Slice's only field is unexported, so
 // CanSet is false and the Slice would stay empty, leaving every command that carries one untested.
 //
-// The element type is read off that field (reflection can read what it cannot set), a random []T is
-// built with the ordinary recursion, and the Slice takes it through UnmarshalJSON — the one way into
-// a Slice that already exists, so immutable gains no setter. The random values are finite numbers,
-// short strings and structs of those, which JSON always carries.
+// immutable.SliceElem identifies the Slice and its element type, a random []T is built with the
+// ordinary recursion, and the Slice takes it through UnmarshalJSON — the one way into a Slice that
+// already exists, so immutable gains no setter. The random values are finite numbers, short strings
+// and structs of those, which JSON always carries. One blind spot: an element field tagged json:"-"
+// is filled and then dropped by that hop, so it is fuzzed everywhere except inside a Slice.
 func fillImmutableSlice(prng *rand.Rand, v reflect.Value, liveEntityIDs []EntityID) bool {
 	t := v.Type()
-	if t.PkgPath() != reflect.TypeFor[immutable.Slice[struct{}]]().PkgPath() ||
-		!strings.HasPrefix(t.Name(), "Slice[") ||
-		t.NumField() != 1 || t.Field(0).Type.Kind() != reflect.Slice {
+	elem, ok := immutable.SliceElem(t)
+	if !ok {
 		return false
 	}
 	// A Slice takes values only through UnmarshalJSON on its address. Falling through to the struct
@@ -363,7 +363,7 @@ func fillImmutableSlice(prng *rand.Rand, v reflect.Value, liveEntityIDs []Entity
 	}
 
 	n := prng.IntN(5)
-	items := reflect.MakeSlice(t.Field(0).Type, n, n)
+	items := reflect.MakeSlice(reflect.SliceOf(elem), n, n)
 	for i := range n {
 		fillRandom(prng, items.Index(i), liveEntityIDs)
 	}
@@ -374,7 +374,7 @@ func fillImmutableSlice(prng *rand.Rand, v reflect.Value, liveEntityIDs []Entity
 	}
 	target, ok := v.Addr().Interface().(json.Unmarshaler)
 	if !ok {
-		panic("dst: " + t.String() + " looks like an immutable.Slice but has no UnmarshalJSON")
+		panic("dst: " + t.String() + " lost UnmarshalJSON; immutable.Slice must keep it")
 	}
 	if err := target.UnmarshalJSON(data); err != nil {
 		panic("dst: random Slice elements did not decode: " + err.Error())

--- a/pkg/cardinal/dst.go
+++ b/pkg/cardinal/dst.go
@@ -32,7 +32,6 @@ import (
 	"github.com/argus-labs/world-engine/pkg/testutils"
 	cardinalv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1"
 	iscv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/isc/v1"
-	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -346,20 +345,18 @@ func fillRandom(prng *rand.Rand, v reflect.Value, liveEntityIDs []EntityID) {
 // CanSet is false and the Slice would stay empty, leaving every command that carries one untested.
 //
 // immutable.SliceElem identifies the Slice and its element type, a random []T is built with the
-// ordinary recursion, and the Slice takes it through UnmarshalJSON — the one way into a Slice that
-// already exists, so immutable gains no setter. The random values are finite numbers, short strings
-// and structs of those, which JSON always carries. One blind spot: an element field tagged json:"-"
-// is filled and then dropped by that hop, so it is fuzzed everywhere except inside a Slice.
+// ordinary recursion, and Append takes it in one call — Append is variadic, so CallSlice hands it the
+// whole slice at once. That is the Slice's own API, so immutable needs no setter and no codec.
 func fillImmutableSlice(prng *rand.Rand, v reflect.Value, liveEntityIDs []EntityID) bool {
 	t := v.Type()
 	elem, ok := immutable.SliceElem(t)
 	if !ok {
 		return false
 	}
-	// A Slice takes values only through UnmarshalJSON on its address. Falling through to the struct
-	// walk would leave it empty with no sign of it, the exact failure this function exists to prevent.
-	if !v.CanAddr() {
-		panic("dst: " + t.String() + " is not addressable, so it cannot be filled")
+	// A Slice has no settable field, so the struct walk would pass it by in silence — the exact
+	// failure this function exists to prevent.
+	if !v.CanSet() {
+		panic("dst: " + t.String() + " is not settable, so it cannot be filled")
 	}
 
 	n := prng.IntN(5)
@@ -367,18 +364,7 @@ func fillImmutableSlice(prng *rand.Rand, v reflect.Value, liveEntityIDs []Entity
 	for i := range n {
 		fillRandom(prng, items.Index(i), liveEntityIDs)
 	}
-
-	data, err := json.Marshal(items.Interface())
-	if err != nil {
-		panic("dst: random Slice elements did not encode: " + err.Error())
-	}
-	target, ok := v.Addr().Interface().(json.Unmarshaler)
-	if !ok {
-		panic("dst: " + t.String() + " lost UnmarshalJSON; immutable.Slice must keep it")
-	}
-	if err := target.UnmarshalJSON(data); err != nil {
-		panic("dst: random Slice elements did not decode: " + err.Error())
-	}
+	v.Set(v.MethodByName("Append").CallSlice([]reflect.Value{items})[0])
 	return true
 }
 

--- a/pkg/cardinal/dst.go
+++ b/pkg/cardinal/dst.go
@@ -353,9 +353,13 @@ func fillImmutableSlice(prng *rand.Rand, v reflect.Value, liveEntityIDs []Entity
 	t := v.Type()
 	if t.PkgPath() != reflect.TypeFor[immutable.Slice[struct{}]]().PkgPath() ||
 		!strings.HasPrefix(t.Name(), "Slice[") ||
-		t.NumField() != 1 || t.Field(0).Type.Kind() != reflect.Slice ||
-		!v.CanAddr() {
+		t.NumField() != 1 || t.Field(0).Type.Kind() != reflect.Slice {
 		return false
+	}
+	// A Slice takes values only through UnmarshalJSON on its address. Falling through to the struct
+	// walk would leave it empty with no sign of it, the exact failure this function exists to prevent.
+	if !v.CanAddr() {
+		panic("dst: " + t.String() + " is not addressable, so it cannot be filled")
 	}
 
 	n := prng.IntN(5)

--- a/pkg/cardinal/dst.go
+++ b/pkg/cardinal/dst.go
@@ -28,9 +28,11 @@ import (
 	"github.com/argus-labs/world-engine/pkg/cardinal/internal/ecs"
 	"github.com/argus-labs/world-engine/pkg/cardinal/internal/event"
 	"github.com/argus-labs/world-engine/pkg/cardinal/snapshot"
+	"github.com/argus-labs/world-engine/pkg/immutable"
 	"github.com/argus-labs/world-engine/pkg/testutils"
 	cardinalv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/cardinal/v1"
 	iscv1 "github.com/argus-labs/world-engine/proto/gen/go/worldengine/isc/v1"
+	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
@@ -317,6 +319,9 @@ func fillRandom(prng *rand.Rand, v reflect.Value, liveEntityIDs []EntityID) {
 		}
 		v.SetString(string(b))
 	case reflect.Struct:
+		if fillImmutableSlice(prng, v, liveEntityIDs) {
+			return
+		}
 		for i := range v.NumField() {
 			if v.Field(i).CanSet() {
 				fillRandom(prng, v.Field(i), liveEntityIDs)
@@ -334,6 +339,43 @@ func fillRandom(prng *rand.Rand, v reflect.Value, liveEntityIDs []EntityID) {
 			fillRandom(prng, v.Index(i), liveEntityIDs)
 		}
 	}
+}
+
+// fillImmutableSlice fills v with random elements when it is an immutable.Slice, and reports whether
+// it was one. The struct walk in fillRandom cannot do it: a Slice's only field is unexported, so
+// CanSet is false and the Slice would stay empty, leaving every command that carries one untested.
+//
+// The element type is read off that field (reflection can read what it cannot set), a random []T is
+// built with the ordinary recursion, and the Slice takes it through UnmarshalJSON — the one way into
+// a Slice that already exists, so immutable gains no setter. The random values are finite numbers,
+// short strings and structs of those, which JSON always carries.
+func fillImmutableSlice(prng *rand.Rand, v reflect.Value, liveEntityIDs []EntityID) bool {
+	t := v.Type()
+	if t.PkgPath() != reflect.TypeFor[immutable.Slice[struct{}]]().PkgPath() ||
+		!strings.HasPrefix(t.Name(), "Slice[") ||
+		t.NumField() != 1 || t.Field(0).Type.Kind() != reflect.Slice ||
+		!v.CanAddr() {
+		return false
+	}
+
+	n := prng.IntN(5)
+	items := reflect.MakeSlice(t.Field(0).Type, n, n)
+	for i := range n {
+		fillRandom(prng, items.Index(i), liveEntityIDs)
+	}
+
+	data, err := json.Marshal(items.Interface())
+	if err != nil {
+		panic("dst: random Slice elements did not encode: " + err.Error())
+	}
+	target, ok := v.Addr().Interface().(json.Unmarshaler)
+	if !ok {
+		panic("dst: " + t.String() + " looks like an immutable.Slice but has no UnmarshalJSON")
+	}
+	if err := target.UnmarshalJSON(data); err != nil {
+		panic("dst: random Slice elements did not decode: " + err.Error())
+	}
+	return true
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/pkg/cardinal/dst_fill_internal_test.go
+++ b/pkg/cardinal/dst_fill_internal_test.go
@@ -1,0 +1,53 @@
+package cardinal
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/argus-labs/world-engine/pkg/immutable"
+	"github.com/argus-labs/world-engine/pkg/testutils"
+	"github.com/stretchr/testify/require"
+)
+
+type fillProbeRow struct {
+	Cells immutable.Slice[int32]
+}
+
+// fillProbe is the shape of a command payload that carries lists: ids, and rows that hold a Slice of
+// their own, next to a plain field that must keep being filled as before.
+type fillProbe struct {
+	Ids   immutable.Slice[EntityID]
+	Rows  immutable.Slice[fillProbeRow]
+	Plain int32
+}
+
+// TestFillRandom_FillsImmutableSlices pins that DST's random filler reaches into an immutable.Slice.
+// The detection is a heuristic on package path, type name and field shape; if a refactor of
+// immutable stopped it matching, every Slice would arrive empty and DST would pass regardless, so
+// this is the only place that failure shows. It also pins that a payload the filler cannot address
+// fails loudly instead of the same silence.
+func TestFillRandom_FillsImmutableSlices(t *testing.T) {
+	t.Parallel()
+	prng := testutils.NewRand(t)
+	live := []EntityID{7, 8, 9}
+
+	var sawIDs, sawNested, sawPlain bool
+	for range 64 {
+		var probe fillProbe
+		fillRandom(prng, reflect.ValueOf(&probe).Elem(), live)
+
+		sawIDs = sawIDs || probe.Ids.Len() > 0
+		for _, row := range probe.Rows.All() {
+			sawNested = sawNested || row.Cells.Len() > 0
+		}
+		sawPlain = sawPlain || probe.Plain != 0
+	}
+	require.True(t, sawIDs, "Slice[EntityID] was never filled")
+	require.True(t, sawNested, "a Slice inside a Slice element was never filled")
+	require.True(t, sawPlain, "plain fields must still be filled")
+
+	// A non-addressable Slice cannot take values, and the struct walk would pass it by in silence.
+	require.Panics(t, func() {
+		fillRandom(prng, reflect.ValueOf(immutable.Slice[int32]{}), live)
+	}, "an unaddressable Slice must fail loudly")
+}

--- a/pkg/cardinal/system.go
+++ b/pkg/cardinal/system.go
@@ -12,6 +12,7 @@ import (
 	"github.com/argus-labs/world-engine/pkg/cardinal/internal/event"
 	"github.com/argus-labs/world-engine/pkg/cardinal/internal/introspect"
 	"github.com/argus-labs/world-engine/pkg/cardinal/internal/performance"
+	"github.com/argus-labs/world-engine/pkg/immutable"
 	"github.com/argus-labs/world-engine/pkg/micro"
 	"github.com/kelindar/bitmap"
 	"github.com/rotisserie/eris"
@@ -876,3 +877,15 @@ func (s SearchResult[E, C]) Single() (E, C, error) {
 	}
 	return re, rc, nil
 }
+
+// -------------------------------------------------------------------------------------------------
+// Re-exported immutable types
+// -------------------------------------------------------------------------------------------------
+
+// Slice is world-engine's immutable sequence, re-exported so a component can declare one without a
+// second import. It is an alias, so cardinal.Slice[T] and immutable.Slice[T] are the same type and
+// either spelling works.
+type Slice[T any] = immutable.Slice[T]
+
+// SliceOf returns a Slice holding a copy of items. See immutable.SliceOf.
+func SliceOf[T any](items ...T) Slice[T] { return immutable.SliceOf(items...) }

--- a/pkg/cardinal/system.go
+++ b/pkg/cardinal/system.go
@@ -882,9 +882,11 @@ func (s SearchResult[E, C]) Single() (E, C, error) {
 // Re-exported immutable types
 // -------------------------------------------------------------------------------------------------
 
-// Slice is world-engine's immutable sequence, re-exported so a component can declare one without a
-// second import. It is an alias, so cardinal.Slice[T] and immutable.Slice[T] are the same type and
-// either spelling works.
+// Slice is world-engine's sequence with a private backing array, re-exported so a component can
+// declare one without a second import. It is an alias, so cardinal.Slice[T] and immutable.Slice[T]
+// are the same type and either spelling works.
+//
+// Its derivations edit in place; see immutable.Slice for what that means at a call site.
 type Slice[T any] = immutable.Slice[T]
 
 // SliceOf returns a Slice holding a copy of items. See immutable.SliceOf.

--- a/pkg/immutable/slice.go
+++ b/pkg/immutable/slice.go
@@ -50,7 +50,7 @@ func SliceOf[T any](items ...T) Slice[T] {
 // backing array and cannot be changed, so nil is what "empty" has to look like — but slices.Clone,
 // Delete, DeleteFunc, Replace and the rest all hand back an empty slice that is NOT nil. Without
 // this, a component restored from a snapshot with an empty list would not compare equal to the same
-// component freshly built. Ten tests fail if it goes.
+// component freshly built.
 func wrap[T any](items []T) Slice[T] {
 	if len(items) == 0 {
 		return Slice[T]{}

--- a/pkg/immutable/slice.go
+++ b/pkg/immutable/slice.go
@@ -13,18 +13,48 @@ import (
 	"github.com/argus-labs/world-engine/pkg/assert"
 )
 
+// TODO(immutable): every derivation copies the whole list, which is one allocation per edit. Review
+// asked for the copy to go from the operations that keep the length — With, Reversed, SortedFunc —
+// on the grounds that games cannot afford it. It stays, for two reasons.
+//
+// It is the guarantee the type exists for. Get hands back a struct copy whose Slice still points at
+// the column's array, so an in-place derivation writes into the live world before any Set, and the
+// next snapshot serializes it. A read-only use such as s.SortedFunc(cmp).At(0) would reorder the
+// column, and no linter catches it because the result is used. In-place shrinking is worse than
+// reordering: the column would keep its old length over a shifted, zero-filled tail.
+//
+// And it buys little. The operations that keep the length are called once per edit, not in a loop,
+// so the allocation they save is one per tick, against a read path that is already zero-copy. The
+// case worth optimizing is many edits to one list in one tick, and none of these fix that.
+//
+// Ways to do that properly, once profiling says it matters:
+//   - Mutate(func([]T) []T): copy in, edit with the slices package, copy out. Two allocations for
+//     any number of edits, and nothing the callback keeps can reach the result.
+//   - Update(func(i int, v T) T): one copy, the callback sees one element at a time. Slot edits only.
+//   - Ownership in spare capacity: a clone allocates one spare slot and Set reslices it away, so the
+//     first derivation after Get copies and later ones go in place. Needs Set and the snapshot
+//     decoder to freeze the stored value, which means a generated hook per component.
+//   - A fixed array plus a count, for any list whose length has a bound worth defending. Arrays are
+//     values, so the copy is the struct copy Get and Set already do, and edits are free.
+
 // Slice is an immutable sequence for component fields whose length is genuinely unbounded. It is
 // the only variable-length collection a component may hold.
 //
 // A component column stores values and Get hands back a copy, but a raw []T inside that copy still
 // shares its backing array with the column: writing through it changes the live world without a Set,
-// and a snapshot only ever holds what went through Set. Slice closes that hole by construction — the
-// backing array is unexported and nothing mutates in place — so sharing it between copies is safe,
-// and Get stays zero-copy. To change one, derive a new one and Set the component that holds it:
+// and a snapshot only ever holds what went through Set. Slice narrows that hole: the backing array is
+// unexported and nothing mutates in place — so sharing it between copies is safe, and Get stays
+// zero-copy. To change one, derive a new one and Set the component that holds it:
 //
 //	inv := ref.Get()
 //	inv.Items = inv.Items.With(0, item)
 //	ref.Set(inv)
+//
+// Two empty Slices are not always reflect.DeepEqual. A derivation that empties one leaves its backing
+// array allocated, while the zero value and SliceOf have none, and DeepEqual looks at the field rather
+// than the elements. Compare with Equal or EqualFunc, which compare elements and agree with
+// slices.Equal that nil and empty are the same list. The generated decoder leaves an empty repeated
+// field as the zero value, so a component restored from a snapshot does match one built fresh.
 //
 // The element type must be value-safe too: scalars, strings, fixed arrays, or structs of those.
 // Slice does not check this — Slice[*T] compiles, and hands the pointer straight back out of At —
@@ -41,21 +71,7 @@ type Slice[T any] struct {
 // SliceOf returns a Slice holding a copy of items. Later changes to the caller's slice do not
 // reach the returned value.
 func SliceOf[T any](items ...T) Slice[T] {
-	return wrap(slices.Clone(items))
-}
-
-// wrap adopts a freshly built slice as a Slice. Callers pass a slice no one else holds.
-//
-// The empty case is what keeps every empty Slice equal to every other one. Go's zero value has a nil
-// backing array and cannot be changed, so nil is what "empty" has to look like — but slices.Clone,
-// Delete, DeleteFunc, Replace and the rest all hand back an empty slice that is NOT nil. Without
-// this, a component restored from a snapshot with an empty list would not compare equal to the same
-// component freshly built.
-func wrap[T any](items []T) Slice[T] {
-	if len(items) == 0 {
-		return Slice[T]{}
-	}
-	return Slice[T]{items: items}
+	return Slice[T]{items: slices.Clone(items)}
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -69,7 +85,6 @@ func (s Slice[T]) Len() int {
 
 // At returns a copy of the element at index i. It panics when i is out of range, like a slice.
 func (s Slice[T]) At(i int) T {
-	assert.That(i >= 0 && i < len(s.items), "immutable: At(%d) out of range, length %d", i, len(s.items))
 	return s.items[i]
 }
 
@@ -132,10 +147,7 @@ func (s Slice[T]) Chunk(n int) iter.Seq[Slice[T]] {
 }
 
 // Clone returns a fresh []T holding a copy of the elements, for an API that needs a plain slice.
-// Changes to the result never reach the Slice.
-//
-// It is never nil, which is why it does not simply call slices.Clone: that returns nil for an empty
-// Slice, and a nil result would encode as JSON null rather than [].
+// Changes to the result never reach the Slice. It is never nil, even for an empty Slice.
 func (s Slice[T]) Clone() []T {
 	out := make([]T, len(s.items))
 	copy(out, s.items)
@@ -148,7 +160,7 @@ func (s Slice[T]) Clone() []T {
 
 // Append returns a new Slice with items added at the end. The receiver is unchanged.
 func (s Slice[T]) Append(items ...T) Slice[T] {
-	return wrap(slices.Concat(s.items, items))
+	return Slice[T]{items: slices.Concat(s.items, items)}
 }
 
 // With returns a new Slice with the element at index i replaced by v. The receiver is unchanged.
@@ -164,13 +176,13 @@ func (s Slice[T]) With(i int, v T) Slice[T] {
 // It panics when i is out of range, like a slice.
 func (s Slice[T]) Without(i int) Slice[T] {
 	assert.That(i >= 0 && i < len(s.items), "immutable: Without(%d) out of range, length %d", i, len(s.items))
-	return wrap(slices.Delete(s.Clone(), i, i+1))
+	return Slice[T]{items: slices.Delete(s.Clone(), i, i+1)}
 }
 
 // Filter returns a new Slice holding the elements for which keep is true, in order. The receiver is
 // unchanged, and keep runs once per element.
 func (s Slice[T]) Filter(keep func(T) bool) Slice[T] {
-	return wrap(slices.DeleteFunc(s.Clone(), func(v T) bool { return !keep(v) }))
+	return Slice[T]{items: slices.DeleteFunc(s.Clone(), func(v T) bool { return !keep(v) })}
 }
 
 // Insert returns a new Slice with items inserted at index i, which may equal Len. The receiver is
@@ -180,7 +192,7 @@ func (s Slice[T]) Insert(i int, items ...T) Slice[T] {
 	// The clone is sized for the result, so slices.Insert finishes in place instead of growing.
 	out := make([]T, len(s.items), len(s.items)+len(items))
 	copy(out, s.items)
-	return wrap(slices.Insert(out, i, items...))
+	return Slice[T]{items: slices.Insert(out, i, items...)}
 }
 
 // Sub returns a new Slice holding the elements in [lo, hi). The receiver is unchanged. It panics
@@ -194,22 +206,24 @@ func (s Slice[T]) Sub(lo, hi int) Slice[T] {
 	// Three-index, so the runtime bounds the range by LENGTH rather than capacity. A derived Slice can
 	// carry spare capacity, and a plain s.items[lo:hi] would happily read into it. This check is the one
 	// that has to survive a release build, where assert.That compiles away.
-	return wrap(slices.Clone(s.items[lo:hi:len(s.items)]))
+	return Slice[T]{items: slices.Clone(s.items[lo:hi:len(s.items)])}
 }
 
-// Reversed returns a new Slice with the elements in reverse order. The receiver is unchanged.
+// Reversed returns a new Slice with the elements in reverse order. The receiver is unchanged. To
+// read in reverse without deriving anything, use Backward.
 func (s Slice[T]) Reversed() Slice[T] {
 	out := s.Clone()
 	slices.Reverse(out)
-	return wrap(out)
+	return Slice[T]{items: out}
 }
 
 // SortedFunc returns a new Slice sorted by compare, which reports a<b as negative, a==b as zero and
 // a>b as positive. The sort is stable, so equal elements keep their order. The receiver is unchanged.
+// To find one extreme without deriving anything, use MinFunc or MaxFunc.
 func (s Slice[T]) SortedFunc(compare func(a, b T) int) Slice[T] {
 	out := s.Clone()
 	slices.SortStableFunc(out, compare)
-	return wrap(out)
+	return Slice[T]{items: out}
 }
 
 // Delete returns a new Slice with the elements in [i, j) removed. The receiver is unchanged. It
@@ -217,7 +231,7 @@ func (s Slice[T]) SortedFunc(compare func(a, b T) int) Slice[T] {
 func (s Slice[T]) Delete(i, j int) Slice[T] {
 	assert.That(0 <= i && i <= j && j <= len(s.items),
 		"immutable: Delete(%d, %d) out of range, length %d", i, j, len(s.items))
-	return wrap(slices.Delete(s.Clone(), i, j))
+	return Slice[T]{items: slices.Delete(s.Clone(), i, j)}
 }
 
 // Replace returns a new Slice with the elements in [i, j) replaced by items. The receiver is
@@ -228,20 +242,20 @@ func (s Slice[T]) Replace(i, j int, items ...T) Slice[T] {
 	// The clone is sized for the result, so slices.Replace finishes in place instead of growing.
 	out := make([]T, len(s.items), len(s.items)+max(len(items)-(j-i), 0))
 	copy(out, s.items)
-	return wrap(slices.Replace(out, i, j, items...))
+	return Slice[T]{items: slices.Replace(out, i, j, items...)}
 }
 
 // CompactFunc returns a new Slice with runs of consecutive elements that eq reports equal collapsed
 // to one, like slices.CompactFunc. The receiver is unchanged.
 func (s Slice[T]) CompactFunc(eq func(a, b T) bool) Slice[T] {
-	return wrap(slices.CompactFunc(s.Clone(), eq))
+	return Slice[T]{items: slices.CompactFunc(s.Clone(), eq)}
 }
 
 // Repeat returns a new Slice holding the elements count times over. It panics when count is
 // negative or the result would overflow, like slices.Repeat.
 func (s Slice[T]) Repeat(count int) Slice[T] {
 	assert.That(count >= 0, "immutable: Repeat(%d) must not be negative", count)
-	return wrap(slices.Repeat(s.items, count))
+	return Slice[T]{items: slices.Repeat(s.items, count)}
 }
 
 // -------------------------------------------------------------------------------------------------
@@ -293,7 +307,7 @@ func Sorted[T cmp.Ordered](s Slice[T]) Slice[T] {
 // Compact returns a new Slice with runs of consecutive equal elements collapsed to one, like
 // slices.Compact.
 func Compact[T comparable](s Slice[T]) Slice[T] {
-	return wrap(slices.Compact(s.Clone()))
+	return Slice[T]{items: slices.Compact(s.Clone())}
 }
 
 // Min returns the smallest element of s. It panics when s is empty, like slices.Min.
@@ -357,7 +371,7 @@ func Concat[T any](ss ...Slice[T]) Slice[T] {
 
 // Collect returns a Slice holding every element of seq, in order.
 func Collect[T any](seq iter.Seq[T]) Slice[T] {
-	return wrap(slices.Collect(seq))
+	return Slice[T]{items: slices.Collect(seq)}
 }
 
 // -------------------------------------------------------------------------------------------------

--- a/pkg/immutable/slice.go
+++ b/pkg/immutable/slice.go
@@ -1,0 +1,129 @@
+// Package immutable holds value types whose contents cannot change in place. A value is built once,
+// read freely, and replaced as a whole when something new is needed. That is what lets a component
+// hold one without breaking the rule that world state only ever changes through Set.
+package immutable
+
+import (
+	"iter"
+
+	"github.com/goccy/go-json"
+)
+
+// Slice is an immutable sequence for component fields whose length is genuinely unbounded. It is
+// the only variable-length collection a component may hold.
+//
+// A component column stores values, and Get hands back a copy, but a raw []T inside that copy still
+// shares its backing array with the column. Writing through it changes the live world without a Set,
+// which breaks the rule that snapshots only ever see state that went through Set. Slice closes that
+// hole by construction: the backing array is unexported, every constructor copies its input, every
+// reader returns a copy, and nothing mutates in place. Sharing the backing array between copies is
+// therefore safe, so Get stays zero-copy.
+//
+// To change a Slice, derive a new one and Set the component that holds it:
+//
+//	inv := ref.Get()
+//	inv.Items = inv.Items.With(0, item)
+//	ref.Set(inv)
+//
+// The element type must itself be value-safe: scalars, strings, fixed arrays, or structs of those.
+// The wire generator enforces that rule.
+//
+// A Slice directly inside a Slice has no protobuf form, because a repeated field cannot hold another
+// repeated field. For jagged rows, put the inner Slice in a named struct:
+//
+//	type Row struct{ Cells Slice[int32] }
+//	type Board struct{ Rows Slice[Row] }
+type Slice[T any] struct {
+	items []T
+}
+
+// SliceOf returns a Slice holding a copy of items. Later changes to the caller's slice do not
+// reach the returned value.
+func SliceOf[T any](items ...T) Slice[T] {
+	if len(items) == 0 {
+		return Slice[T]{}
+	}
+	out := make([]T, len(items))
+	copy(out, items)
+	return Slice[T]{items: out}
+}
+
+// Len returns the number of elements.
+func (s Slice[T]) Len() int {
+	return len(s.items)
+}
+
+// At returns a copy of the element at index i. It panics when i is out of range, like a slice.
+func (s Slice[T]) At(i int) T {
+	return s.items[i]
+}
+
+// All returns an iterator over index and element, in order. Elements are yielded by value.
+func (s Slice[T]) All() iter.Seq2[int, T] {
+	return func(yield func(int, T) bool) {
+		for i, v := range s.items {
+			if !yield(i, v) {
+				return
+			}
+		}
+	}
+}
+
+// Clone returns a fresh []T holding a copy of the elements. Use it when an API needs a plain slice;
+// changes to the result never reach the Slice.
+func (s Slice[T]) Clone() []T {
+	out := make([]T, len(s.items))
+	copy(out, s.items)
+	return out
+}
+
+// Append returns a new Slice with items added at the end. The receiver is unchanged.
+func (s Slice[T]) Append(items ...T) Slice[T] {
+	if len(items) == 0 {
+		return s
+	}
+	out := make([]T, len(s.items)+len(items))
+	copy(out, s.items)
+	copy(out[len(s.items):], items)
+	return Slice[T]{items: out}
+}
+
+// With returns a new Slice with the element at index i replaced by v. The receiver is unchanged.
+// It panics when i is out of range, like a slice.
+func (s Slice[T]) With(i int, v T) Slice[T] {
+	out := s.Clone()
+	out[i] = v
+	return Slice[T]{items: out}
+}
+
+// EqualFunc reports whether both slices have the same length and eq holds for every pair of
+// elements at the same index.
+func (s Slice[T]) EqualFunc(other Slice[T], eq func(a, b T) bool) bool {
+	if len(s.items) != len(other.items) {
+		return false
+	}
+	for i := range s.items {
+		if !eq(s.items[i], other.items[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// MarshalJSON encodes the elements as a JSON array. An empty Slice encodes as [] rather than null.
+func (s Slice[T]) MarshalJSON() ([]byte, error) {
+	if len(s.items) == 0 {
+		return []byte("[]"), nil
+	}
+	return json.Marshal(s.items)
+}
+
+// UnmarshalJSON decodes a JSON array into the Slice. JSON null decodes to an empty Slice.
+func (s *Slice[T]) UnmarshalJSON(data []byte) error {
+	var items []T
+	if err := json.Unmarshal(data, &items); err != nil {
+		return err
+	}
+	s.items = items
+	return nil
+}

--- a/pkg/immutable/slice.go
+++ b/pkg/immutable/slice.go
@@ -5,13 +5,12 @@ package immutable
 
 import (
 	"cmp"
-	"fmt"
 	"iter"
 	"reflect"
 	"slices"
 	"strings"
 
-	"github.com/goccy/go-json"
+	"github.com/argus-labs/world-engine/pkg/assert"
 )
 
 // Slice is an immutable sequence for component fields whose length is genuinely unbounded. It is
@@ -45,20 +44,13 @@ func SliceOf[T any](items ...T) Slice[T] {
 	return wrap(slices.Clone(items))
 }
 
-// clonedWithRoom copies the elements into a slice with capacity for extra more, so an in-place
-// stdlib helper can finish the job without allocating a second time. Clone alone would return
-// capacity equal to length, forcing a grow. A negative extra means the caller is shrinking.
-func (s Slice[T]) clonedWithRoom(extra int) []T {
-	if extra < 0 {
-		extra = 0
-	}
-	out := make([]T, len(s.items), len(s.items)+extra)
-	copy(out, s.items)
-	return out
-}
-
-// wrap adopts a freshly built slice as a Slice, keeping empty canonical. Callers pass a slice no one
-// else holds.
+// wrap adopts a freshly built slice as a Slice. Callers pass a slice no one else holds.
+//
+// The empty case is what keeps every empty Slice equal to every other one. Go's zero value has a nil
+// backing array and cannot be changed, so nil is what "empty" has to look like — but slices.Clone,
+// Delete, DeleteFunc, Replace and the rest all hand back an empty slice that is NOT nil. Without
+// this, a component restored from a snapshot with an empty list would not compare equal to the same
+// component freshly built. Ten tests fail if it goes.
 func wrap[T any](items []T) Slice[T] {
 	if len(items) == 0 {
 		return Slice[T]{}
@@ -77,6 +69,7 @@ func (s Slice[T]) Len() int {
 
 // At returns a copy of the element at index i. It panics when i is out of range, like a slice.
 func (s Slice[T]) At(i int) T {
+	assert.That(i >= 0 && i < len(s.items), "immutable: At(%d) out of range, length %d", i, len(s.items))
 	return s.items[i]
 }
 
@@ -125,11 +118,12 @@ func (s Slice[T]) IsSortedFunc(compare func(a, b T) int) bool {
 // Chunk returns an iterator over consecutive sub-Slices of up to n elements. It panics when n is
 // less than one, like slices.Chunk.
 func (s Slice[T]) Chunk(n int) iter.Seq[Slice[T]] {
-	if n < 1 {
-		panic("immutable: Chunk size must be at least one")
-	}
+	assert.That(n >= 1, "immutable: Chunk(%d) size must be at least one", n)
+	// Called here rather than inside the closure so its own size check runs now, not on the first
+	// range — that is the check that survives a release build, where assert.That compiles away.
+	parts := slices.Chunk(s.items, n)
 	return func(yield func(Slice[T]) bool) {
-		for part := range slices.Chunk(s.items, n) {
+		for part := range parts {
 			if !yield(Slice[T]{items: slices.Clone(part)}) {
 				return
 			}
@@ -160,7 +154,7 @@ func (s Slice[T]) Append(items ...T) Slice[T] {
 // With returns a new Slice with the element at index i replaced by v. The receiver is unchanged.
 // It panics when i is out of range, like a slice.
 func (s Slice[T]) With(i int, v T) Slice[T] {
-	_ = s.items[i] // bounds-check before copying, with the runtime's own panic message
+	assert.That(i >= 0 && i < len(s.items), "immutable: With(%d) out of range, length %d", i, len(s.items))
 	out := s.Clone()
 	out[i] = v
 	return Slice[T]{items: out}
@@ -169,6 +163,7 @@ func (s Slice[T]) With(i int, v T) Slice[T] {
 // Without returns a new Slice with the element at index i removed. The receiver is unchanged.
 // It panics when i is out of range, like a slice.
 func (s Slice[T]) Without(i int) Slice[T] {
+	assert.That(i >= 0 && i < len(s.items), "immutable: Without(%d) out of range, length %d", i, len(s.items))
 	return wrap(slices.Delete(s.Clone(), i, i+1))
 }
 
@@ -181,7 +176,11 @@ func (s Slice[T]) Filter(keep func(T) bool) Slice[T] {
 // Insert returns a new Slice with items inserted at index i, which may equal Len. The receiver is
 // unchanged. It panics when i is out of range, like slices.Insert.
 func (s Slice[T]) Insert(i int, items ...T) Slice[T] {
-	return wrap(slices.Insert(s.clonedWithRoom(len(items)), i, items...))
+	assert.That(i >= 0 && i <= len(s.items), "immutable: Insert(%d) out of range, length %d", i, len(s.items))
+	// The clone is sized for the result, so slices.Insert finishes in place instead of growing.
+	out := make([]T, len(s.items), len(s.items)+len(items))
+	copy(out, s.items)
+	return wrap(slices.Insert(out, i, items...))
 }
 
 // Sub returns a new Slice holding the elements in [lo, hi). The receiver is unchanged. It panics
@@ -190,10 +189,12 @@ func (s Slice[T]) Insert(i int, items ...T) Slice[T] {
 // The bounds are checked against Len explicitly: a derived Slice can have spare capacity, and a
 // plain slice expression would read past the end into it.
 func (s Slice[T]) Sub(lo, hi int) Slice[T] {
-	if lo < 0 || hi > len(s.items) || lo > hi {
-		panic(fmt.Sprintf("immutable: Sub bounds out of range [%d:%d] with length %d", lo, hi, len(s.items)))
-	}
-	return wrap(slices.Clone(s.items[lo:hi]))
+	assert.That(0 <= lo && lo <= hi && hi <= len(s.items),
+		"immutable: Sub(%d, %d) out of range, length %d", lo, hi, len(s.items))
+	// Three-index, so the runtime bounds the range by LENGTH rather than capacity. A derived Slice can
+	// carry spare capacity, and a plain s.items[lo:hi] would happily read into it. This check is the one
+	// that has to survive a release build, where assert.That compiles away.
+	return wrap(slices.Clone(s.items[lo:hi:len(s.items)]))
 }
 
 // Reversed returns a new Slice with the elements in reverse order. The receiver is unchanged.
@@ -214,13 +215,20 @@ func (s Slice[T]) SortedFunc(compare func(a, b T) int) Slice[T] {
 // Delete returns a new Slice with the elements in [i, j) removed. The receiver is unchanged. It
 // panics when the range is out of bounds, like slices.Delete.
 func (s Slice[T]) Delete(i, j int) Slice[T] {
+	assert.That(0 <= i && i <= j && j <= len(s.items),
+		"immutable: Delete(%d, %d) out of range, length %d", i, j, len(s.items))
 	return wrap(slices.Delete(s.Clone(), i, j))
 }
 
 // Replace returns a new Slice with the elements in [i, j) replaced by items. The receiver is
 // unchanged. It panics when the range is out of bounds, like slices.Replace.
 func (s Slice[T]) Replace(i, j int, items ...T) Slice[T] {
-	return wrap(slices.Replace(s.clonedWithRoom(len(items)-(j-i)), i, j, items...))
+	assert.That(0 <= i && i <= j && j <= len(s.items),
+		"immutable: Replace(%d, %d) out of range, length %d", i, j, len(s.items))
+	// The clone is sized for the result, so slices.Replace finishes in place instead of growing.
+	out := make([]T, len(s.items), len(s.items)+max(len(items)-(j-i), 0))
+	copy(out, s.items)
+	return wrap(slices.Replace(out, i, j, items...))
 }
 
 // CompactFunc returns a new Slice with runs of consecutive elements that eq reports equal collapsed
@@ -232,6 +240,7 @@ func (s Slice[T]) CompactFunc(eq func(a, b T) bool) Slice[T] {
 // Repeat returns a new Slice holding the elements count times over. It panics when count is
 // negative or the result would overflow, like slices.Repeat.
 func (s Slice[T]) Repeat(count int) Slice[T] {
+	assert.That(count >= 0, "immutable: Repeat(%d) must not be negative", count)
 	return wrap(slices.Repeat(s.items, count))
 }
 
@@ -352,32 +361,8 @@ func Collect[T any](seq iter.Seq[T]) Slice[T] {
 }
 
 // -------------------------------------------------------------------------------------------------
-// JSON and reflection
+// Reflection
 // -------------------------------------------------------------------------------------------------
-
-// MarshalJSON encodes the elements as a JSON array. An empty Slice encodes as [] rather than null.
-func (s Slice[T]) MarshalJSON() ([]byte, error) {
-	if len(s.items) == 0 {
-		return []byte("[]"), nil
-	}
-	return json.Marshal(s.items)
-}
-
-// UnmarshalJSON decodes a JSON array into the Slice. JSON null decodes to an empty Slice.
-func (s *Slice[T]) UnmarshalJSON(data []byte) error {
-	var items []T
-	if err := json.Unmarshal(data, &items); err != nil {
-		return err
-	}
-	if len(items) == 0 {
-		// One representation for empty. A decoded [] would otherwise hold an empty non-nil backing
-		// slice while SliceOf() holds nil, and reflect.DeepEqual (so require.Equal on a component)
-		// would call two empty Slices different.
-		items = nil
-	}
-	s.items = items
-	return nil
-}
 
 // SliceElem reports whether t is an instantiation of Slice and, if so, returns its element type.
 // It exists so tooling that works through reflection, such as the DST random filler, can recognise

--- a/pkg/immutable/slice.go
+++ b/pkg/immutable/slice.go
@@ -38,7 +38,8 @@ import (
 //	ref.Set(inv)                        // this republishes what is already true
 //
 // Deriving and dropping the result does not leave the world untouched — it leaves the world holding
-// an edit no snapshot recorded. Clone first when the original has to survive. Each derivation's doc
+// an edit no snapshot recorded. Copy the elements out first (Values, or immutable.Collect) when the
+// original has to survive. Each derivation's doc
 // says whether it writes through.
 //
 // Two empty Slices are not always reflect.DeepEqual. A derivation that empties one leaves its backing
@@ -141,17 +142,6 @@ func (s Slice[T]) Chunk(n int) iter.Seq[Slice[T]] {
 	}
 }
 
-// Clone returns a fresh []T holding a copy of the elements, for an API that needs a plain slice.
-// Changes to the result never reach the Slice. It is never nil, even for an empty Slice.
-//
-// Because derivations edit in place, this is also how a caller keeps the original: deriving from
-// SliceOf(s.Clone()...) cannot reach s.
-func (s Slice[T]) Clone() []T {
-	out := make([]T, len(s.items))
-	copy(out, s.items)
-	return out
-}
-
 // -------------------------------------------------------------------------------------------------
 // Deriving
 // -------------------------------------------------------------------------------------------------
@@ -163,7 +153,8 @@ func (s Slice[T]) Clone() []T {
 // Two consequences worth stating plainly. Deriving and discarding the result still changes the
 // world. And the ones that shrink (Without, Filter, Delete, CompactFunc) leave the receiver at its
 // old length over a shifted, zero-filled tail, so the receiver is not merely reordered but wrong.
-// Set the component after every derivation, and Clone first when the original has to survive.
+// Set the component after every derivation, and copy the elements out first (immutable.Collect) when
+// the original has to survive.
 
 // Append returns a Slice with items added at the end. It allocates a new array, so the receiver is
 // unchanged.

--- a/pkg/immutable/slice.go
+++ b/pkg/immutable/slice.go
@@ -4,8 +4,12 @@
 package immutable
 
 import (
+	"cmp"
+	"fmt"
 	"iter"
+	"reflect"
 	"slices"
+	"strings"
 
 	"github.com/goccy/go-json"
 )
@@ -37,20 +41,39 @@ import (
 //
 //	type Row struct{ Cells Slice[int32] }
 //	type Board struct{ Rows Slice[Row] }
+//
+// The API mirrors the standard slices package in full, apart from the helpers that only make sense
+// in place (Sort, Clip, Grow). Reads and derivations that work for any element type are methods;
+// the ones that need a constraint or a second type parameter (Equal, Compare, Index, Contains,
+// Sorted, IsSorted, Min, Max, BinarySearch, Compact, Map, Concat, Collect and their Func forms) are
+// package functions, since a method cannot add either. Every derivation returns a new Slice and
+// leaves the receiver as it was.
 type Slice[T any] struct {
 	items []T
 }
 
+// -------------------------------------------------------------------------------------------------
+// Construction
+// -------------------------------------------------------------------------------------------------
+
 // SliceOf returns a Slice holding a copy of items. Later changes to the caller's slice do not
 // reach the returned value.
 func SliceOf[T any](items ...T) Slice[T] {
+	return wrap(slices.Clone(items))
+}
+
+// wrap adopts a freshly built slice as a Slice, keeping empty canonical. Callers pass a slice no one
+// else holds.
+func wrap[T any](items []T) Slice[T] {
 	if len(items) == 0 {
 		return Slice[T]{}
 	}
-	out := make([]T, len(items))
-	copy(out, items)
-	return Slice[T]{items: out}
+	return Slice[T]{items: items}
 }
+
+// -------------------------------------------------------------------------------------------------
+// Reading
+// -------------------------------------------------------------------------------------------------
 
 // Len returns the number of elements.
 func (s Slice[T]) Len() int {
@@ -64,33 +87,79 @@ func (s Slice[T]) At(i int) T {
 
 // All returns an iterator over index and element, in order. Elements are yielded by value.
 func (s Slice[T]) All() iter.Seq2[int, T] {
-	return func(yield func(int, T) bool) {
-		for i, v := range s.items {
-			if !yield(i, v) {
+	return slices.All(s.items)
+}
+
+// Values returns an iterator over the elements, in order. Elements are yielded by value.
+func (s Slice[T]) Values() iter.Seq[T] {
+	return slices.Values(s.items)
+}
+
+// Backward returns an iterator over index and element from the last element to the first.
+func (s Slice[T]) Backward() iter.Seq2[int, T] {
+	return slices.Backward(s.items)
+}
+
+// IndexFunc returns the index of the first element for which f is true, or -1.
+func (s Slice[T]) IndexFunc(f func(T) bool) int {
+	return slices.IndexFunc(s.items, f)
+}
+
+// ContainsFunc reports whether f is true for any element.
+func (s Slice[T]) ContainsFunc(f func(T) bool) bool {
+	return slices.ContainsFunc(s.items, f)
+}
+
+// MinFunc returns the minimal element according to compare. It panics when the Slice is empty,
+// like slices.MinFunc.
+func (s Slice[T]) MinFunc(compare func(a, b T) int) T {
+	return slices.MinFunc(s.items, compare)
+}
+
+// MaxFunc returns the maximal element according to compare. It panics when the Slice is empty,
+// like slices.MaxFunc.
+func (s Slice[T]) MaxFunc(compare func(a, b T) int) T {
+	return slices.MaxFunc(s.items, compare)
+}
+
+// IsSortedFunc reports whether the elements are in ascending order according to compare.
+func (s Slice[T]) IsSortedFunc(compare func(a, b T) int) bool {
+	return slices.IsSortedFunc(s.items, compare)
+}
+
+// Chunk returns an iterator over consecutive sub-Slices of up to n elements. It panics when n is
+// less than one, like slices.Chunk.
+func (s Slice[T]) Chunk(n int) iter.Seq[Slice[T]] {
+	if n < 1 {
+		panic("immutable: Chunk size must be at least one")
+	}
+	return func(yield func(Slice[T]) bool) {
+		for part := range slices.Chunk(s.items, n) {
+			if !yield(Slice[T]{items: slices.Clone(part)}) {
 				return
 			}
 		}
 	}
 }
 
-// Clone returns a fresh []T holding a copy of the elements. It is never nil: an empty Slice clones
-// to an empty slice. Use it when an API needs a plain slice; changes to the result never reach the
-// Slice.
+// Clone returns a fresh []T holding a copy of the elements, for an API that needs a plain slice.
+// Changes to the result never reach the Slice.
+//
+// It is never nil, which is why it does not simply call slices.Clone: that returns nil for an empty
+// Slice, and a nil result would encode as JSON null rather than [].
 func (s Slice[T]) Clone() []T {
 	out := make([]T, len(s.items))
 	copy(out, s.items)
 	return out
 }
 
+// -------------------------------------------------------------------------------------------------
+// Deriving
+// -------------------------------------------------------------------------------------------------
+
 // Append returns a new Slice with items added at the end. The receiver is unchanged.
 func (s Slice[T]) Append(items ...T) Slice[T] {
-	if len(items) == 0 {
-		return s
-	}
-	out := make([]T, len(s.items)+len(items))
-	copy(out, s.items)
-	copy(out[len(s.items):], items)
-	return Slice[T]{items: out}
+	return wrap(slices.Concat(s.items, items))
 }
 
 // With returns a new Slice with the element at index i replaced by v. The receiver is unchanged.
@@ -102,18 +171,83 @@ func (s Slice[T]) With(i int, v T) Slice[T] {
 	return Slice[T]{items: out}
 }
 
+// Without returns a new Slice with the element at index i removed. The receiver is unchanged.
+// It panics when i is out of range, like a slice.
+func (s Slice[T]) Without(i int) Slice[T] {
+	return wrap(slices.Delete(s.Clone(), i, i+1))
+}
+
+// Filter returns a new Slice holding the elements for which keep is true, in order. The receiver is
+// unchanged, and keep runs once per element.
+func (s Slice[T]) Filter(keep func(T) bool) Slice[T] {
+	return wrap(slices.DeleteFunc(s.Clone(), func(v T) bool { return !keep(v) }))
+}
+
+// Insert returns a new Slice with items inserted at index i, which may equal Len. The receiver is
+// unchanged. It panics when i is out of range, like slices.Insert.
+func (s Slice[T]) Insert(i int, items ...T) Slice[T] {
+	return wrap(slices.Insert(s.Clone(), i, items...))
+}
+
+// Sub returns a new Slice holding the elements in [lo, hi). The receiver is unchanged. It panics
+// when the range is out of bounds, like s[lo:hi].
+//
+// The bounds are checked against Len explicitly: a derived Slice can have spare capacity, and a
+// plain slice expression would read past the end into it.
+func (s Slice[T]) Sub(lo, hi int) Slice[T] {
+	if lo < 0 || hi > len(s.items) || lo > hi {
+		panic(fmt.Sprintf("immutable: Sub bounds out of range [%d:%d] with length %d", lo, hi, len(s.items)))
+	}
+	return wrap(slices.Clone(s.items[lo:hi]))
+}
+
+// Reversed returns a new Slice with the elements in reverse order. The receiver is unchanged.
+func (s Slice[T]) Reversed() Slice[T] {
+	out := s.Clone()
+	slices.Reverse(out)
+	return wrap(out)
+}
+
+// SortedFunc returns a new Slice sorted by compare, which reports a<b as negative, a==b as zero and
+// a>b as positive. The sort is stable, so equal elements keep their order. The receiver is unchanged.
+func (s Slice[T]) SortedFunc(compare func(a, b T) int) Slice[T] {
+	out := s.Clone()
+	slices.SortStableFunc(out, compare)
+	return wrap(out)
+}
+
+// Delete returns a new Slice with the elements in [i, j) removed. The receiver is unchanged. It
+// panics when the range is out of bounds, like slices.Delete.
+func (s Slice[T]) Delete(i, j int) Slice[T] {
+	return wrap(slices.Delete(s.Clone(), i, j))
+}
+
+// Replace returns a new Slice with the elements in [i, j) replaced by items. The receiver is
+// unchanged. It panics when the range is out of bounds, like slices.Replace.
+func (s Slice[T]) Replace(i, j int, items ...T) Slice[T] {
+	return wrap(slices.Replace(s.Clone(), i, j, items...))
+}
+
+// CompactFunc returns a new Slice with runs of consecutive elements that eq reports equal collapsed
+// to one, like slices.CompactFunc. The receiver is unchanged.
+func (s Slice[T]) CompactFunc(eq func(a, b T) bool) Slice[T] {
+	return wrap(slices.CompactFunc(s.Clone(), eq))
+}
+
+// Repeat returns a new Slice holding the elements count times over. It panics when count is
+// negative or the result would overflow, like slices.Repeat.
+func (s Slice[T]) Repeat(count int) Slice[T] {
+	return wrap(slices.Repeat(s.items, count))
+}
+
+// -------------------------------------------------------------------------------------------------
+// Comparing
+// -------------------------------------------------------------------------------------------------
+
 // EqualFunc reports whether both slices have the same length and eq holds for every pair of
 // elements at the same index.
 func (s Slice[T]) EqualFunc(other Slice[T], eq func(a, b T) bool) bool {
-	if len(s.items) != len(other.items) {
-		return false
-	}
-	for i := range s.items {
-		if !eq(s.items[i], other.items[i]) {
-			return false
-		}
-	}
-	return true
+	return slices.EqualFunc(s.items, other.items, eq)
 }
 
 // Equal reports whether a and b hold the same elements in the same order. It is a function rather
@@ -121,6 +255,110 @@ func (s Slice[T]) EqualFunc(other Slice[T], eq func(a, b T) bool) bool {
 func Equal[T comparable](a, b Slice[T]) bool {
 	return slices.Equal(a.items, b.items)
 }
+
+// Compare compares a and b element by element, like slices.Compare.
+func Compare[T cmp.Ordered](a, b Slice[T]) int {
+	return slices.Compare(a.items, b.items)
+}
+
+// CompareFunc is Compare with a comparison function, whose Slices may hold different element
+// types, like slices.CompareFunc.
+func CompareFunc[E1, E2 any](a Slice[E1], b Slice[E2], compare func(E1, E2) int) int {
+	return slices.CompareFunc(a.items, b.items, compare)
+}
+
+// -------------------------------------------------------------------------------------------------
+// Comparable and ordered elements
+// -------------------------------------------------------------------------------------------------
+
+// Index returns the index of the first element of s equal to v, or -1.
+func Index[T comparable](s Slice[T], v T) int {
+	return slices.Index(s.items, v)
+}
+
+// Contains reports whether v is an element of s.
+func Contains[T comparable](s Slice[T], v T) bool {
+	return slices.Contains(s.items, v)
+}
+
+// Sorted returns a new Slice with the elements of s in ascending order. The sort is stable.
+func Sorted[T cmp.Ordered](s Slice[T]) Slice[T] {
+	return s.SortedFunc(cmp.Compare[T])
+}
+
+// Compact returns a new Slice with runs of consecutive equal elements collapsed to one, like
+// slices.Compact.
+func Compact[T comparable](s Slice[T]) Slice[T] {
+	return wrap(slices.Compact(s.Clone()))
+}
+
+// Min returns the smallest element of s. It panics when s is empty, like slices.Min.
+func Min[T cmp.Ordered](s Slice[T]) T {
+	return slices.Min(s.items)
+}
+
+// Max returns the largest element of s. It panics when s is empty, like slices.Max.
+func Max[T cmp.Ordered](s Slice[T]) T {
+	return slices.Max(s.items)
+}
+
+// IsSorted reports whether the elements of s are in ascending order.
+func IsSorted[T cmp.Ordered](s Slice[T]) bool {
+	return slices.IsSorted(s.items)
+}
+
+// BinarySearch searches a sorted s for target and returns the position where it is, or would be
+// inserted, and whether it was found, like slices.BinarySearch.
+func BinarySearch[T cmp.Ordered](s Slice[T], target T) (int, bool) {
+	return slices.BinarySearch(s.items, target)
+}
+
+// BinarySearchFunc is BinarySearch with a comparison function, whose target may be of another type,
+// like slices.BinarySearchFunc.
+func BinarySearchFunc[E, T any](s Slice[E], target T, compare func(E, T) int) (int, bool) {
+	return slices.BinarySearchFunc(s.items, target, compare)
+}
+
+// -------------------------------------------------------------------------------------------------
+// Building from other values
+// -------------------------------------------------------------------------------------------------
+
+// Map returns a new Slice holding f applied to each element of s, in order.
+func Map[T, U any](s Slice[T], f func(T) U) Slice[U] {
+	if len(s.items) == 0 {
+		return Slice[U]{}
+	}
+	out := make([]U, len(s.items))
+	for i, v := range s.items {
+		out[i] = f(v)
+	}
+	return Slice[U]{items: out}
+}
+
+// Concat returns a new Slice holding the elements of every argument, in order.
+func Concat[T any](ss ...Slice[T]) Slice[T] {
+	total := 0
+	for _, s := range ss {
+		total += len(s.items)
+	}
+	if total == 0 {
+		return Slice[T]{}
+	}
+	out := make([]T, 0, total)
+	for _, s := range ss {
+		out = append(out, s.items...)
+	}
+	return Slice[T]{items: out}
+}
+
+// Collect returns a Slice holding every element of seq, in order.
+func Collect[T any](seq iter.Seq[T]) Slice[T] {
+	return wrap(slices.Collect(seq))
+}
+
+// -------------------------------------------------------------------------------------------------
+// JSON and reflection
+// -------------------------------------------------------------------------------------------------
 
 // MarshalJSON encodes the elements as a JSON array. An empty Slice encodes as [] rather than null.
 func (s Slice[T]) MarshalJSON() ([]byte, error) {
@@ -144,4 +382,21 @@ func (s *Slice[T]) UnmarshalJSON(data []byte) error {
 	}
 	s.items = items
 	return nil
+}
+
+// SliceElem reports whether t is an instantiation of Slice and, if so, returns its element type.
+// It exists so tooling that works through reflection, such as the DST random filler, can recognise
+// a Slice without depending on how it is laid out.
+func SliceElem(t reflect.Type) (reflect.Type, bool) {
+	if t == nil || t.Kind() != reflect.Struct || !strings.HasPrefix(t.Name(), "Slice[") {
+		return nil, false
+	}
+	if t.PkgPath() != reflect.TypeFor[Slice[struct{}]]().PkgPath() {
+		return nil, false
+	}
+	items, ok := t.FieldByName("items")
+	if !ok || items.Type.Kind() != reflect.Slice {
+		return nil, false
+	}
+	return items.Type.Elem(), true
 }

--- a/pkg/immutable/slice.go
+++ b/pkg/immutable/slice.go
@@ -124,6 +124,12 @@ func (s *Slice[T]) UnmarshalJSON(data []byte) error {
 	if err := json.Unmarshal(data, &items); err != nil {
 		return err
 	}
+	if len(items) == 0 {
+		// One representation for empty. A decoded [] would otherwise hold an empty non-nil backing
+		// slice while SliceOf() holds nil, and reflect.DeepEqual (so require.Equal on a component)
+		// would call two empty Slices different.
+		items = nil
+	}
 	s.items = items
 	return nil
 }

--- a/pkg/immutable/slice.go
+++ b/pkg/immutable/slice.go
@@ -17,37 +17,20 @@ import (
 // Slice is an immutable sequence for component fields whose length is genuinely unbounded. It is
 // the only variable-length collection a component may hold.
 //
-// A component column stores values, and Get hands back a copy, but a raw []T inside that copy still
-// shares its backing array with the column. Writing through it changes the live world without a Set,
-// which breaks the rule that snapshots only ever see state that went through Set. Slice closes that
-// hole by construction: the backing array is unexported, every constructor copies its input, every
-// reader returns a copy, and nothing mutates in place. Sharing the backing array between copies is
-// therefore safe, so Get stays zero-copy.
-//
-// To change a Slice, derive a new one and Set the component that holds it:
+// A component column stores values and Get hands back a copy, but a raw []T inside that copy still
+// shares its backing array with the column: writing through it changes the live world without a Set,
+// and a snapshot only ever holds what went through Set. Slice closes that hole by construction — the
+// backing array is unexported and nothing mutates in place — so sharing it between copies is safe,
+// and Get stays zero-copy. To change one, derive a new one and Set the component that holds it:
 //
 //	inv := ref.Get()
 //	inv.Items = inv.Items.With(0, item)
 //	ref.Set(inv)
 //
-// The element type must itself be value-safe: scalars, strings, fixed arrays, or structs of those.
-// Slice does not check this. Slice[*T], Slice[[]T] and Slice[map[K]V] all compile, and each hands
-// the shared pointer or backing array back out of At, which defeats the guarantee the type exists
-// for. The wire generator refuses such elements in every command, event and component it generates;
-// a hand-written codec is the only way around it.
-//
-// A Slice directly inside a Slice has no protobuf form, because a repeated field cannot hold another
-// repeated field. For jagged rows, put the inner Slice in a named struct:
-//
-//	type Row struct{ Cells Slice[int32] }
-//	type Board struct{ Rows Slice[Row] }
-//
-// The API mirrors the standard slices package in full, apart from the helpers that only make sense
-// in place (Sort, Clip, Grow). Reads and derivations that work for any element type are methods;
-// the ones that need a constraint or a second type parameter (Equal, Compare, Index, Contains,
-// Sorted, IsSorted, Min, Max, BinarySearch, Compact, Map, Concat, Collect and their Func forms) are
-// package functions, since a method cannot add either. Every derivation returns a new Slice and
-// leaves the receiver as it was.
+// The element type must be value-safe too: scalars, strings, fixed arrays, or structs of those.
+// Slice does not check this — Slice[*T] compiles, and hands the pointer straight back out of At —
+// but the wire generator refuses such an element, and refuses a Slice directly inside a Slice, which
+// protobuf cannot carry (wrap the inner one in a named struct).
 type Slice[T any] struct {
 	items []T
 }
@@ -60,6 +43,18 @@ type Slice[T any] struct {
 // reach the returned value.
 func SliceOf[T any](items ...T) Slice[T] {
 	return wrap(slices.Clone(items))
+}
+
+// clonedWithRoom copies the elements into a slice with capacity for extra more, so an in-place
+// stdlib helper can finish the job without allocating a second time. Clone alone would return
+// capacity equal to length, forcing a grow. A negative extra means the caller is shrinking.
+func (s Slice[T]) clonedWithRoom(extra int) []T {
+	if extra < 0 {
+		extra = 0
+	}
+	out := make([]T, len(s.items), len(s.items)+extra)
+	copy(out, s.items)
+	return out
 }
 
 // wrap adopts a freshly built slice as a Slice, keeping empty canonical. Callers pass a slice no one
@@ -186,7 +181,7 @@ func (s Slice[T]) Filter(keep func(T) bool) Slice[T] {
 // Insert returns a new Slice with items inserted at index i, which may equal Len. The receiver is
 // unchanged. It panics when i is out of range, like slices.Insert.
 func (s Slice[T]) Insert(i int, items ...T) Slice[T] {
-	return wrap(slices.Insert(s.Clone(), i, items...))
+	return wrap(slices.Insert(s.clonedWithRoom(len(items)), i, items...))
 }
 
 // Sub returns a new Slice holding the elements in [lo, hi). The receiver is unchanged. It panics
@@ -225,7 +220,7 @@ func (s Slice[T]) Delete(i, j int) Slice[T] {
 // Replace returns a new Slice with the elements in [i, j) replaced by items. The receiver is
 // unchanged. It panics when the range is out of bounds, like slices.Replace.
 func (s Slice[T]) Replace(i, j int, items ...T) Slice[T] {
-	return wrap(slices.Replace(s.Clone(), i, j, items...))
+	return wrap(slices.Replace(s.clonedWithRoom(len(items)-(j-i)), i, j, items...))
 }
 
 // CompactFunc returns a new Slice with runs of consecutive elements that eq reports equal collapsed

--- a/pkg/immutable/slice.go
+++ b/pkg/immutable/slice.go
@@ -5,6 +5,7 @@ package immutable
 
 import (
 	"iter"
+	"slices"
 
 	"github.com/goccy/go-json"
 )
@@ -26,7 +27,10 @@ import (
 //	ref.Set(inv)
 //
 // The element type must itself be value-safe: scalars, strings, fixed arrays, or structs of those.
-// The wire generator enforces that rule.
+// Slice does not check this. Slice[*T], Slice[[]T] and Slice[map[K]V] all compile, and each hands
+// the shared pointer or backing array back out of At, which defeats the guarantee the type exists
+// for. The wire generator refuses such elements in every command, event and component it generates;
+// a hand-written codec is the only way around it.
 //
 // A Slice directly inside a Slice has no protobuf form, because a repeated field cannot hold another
 // repeated field. For jagged rows, put the inner Slice in a named struct:
@@ -69,8 +73,9 @@ func (s Slice[T]) All() iter.Seq2[int, T] {
 	}
 }
 
-// Clone returns a fresh []T holding a copy of the elements. Use it when an API needs a plain slice;
-// changes to the result never reach the Slice.
+// Clone returns a fresh []T holding a copy of the elements. It is never nil: an empty Slice clones
+// to an empty slice. Use it when an API needs a plain slice; changes to the result never reach the
+// Slice.
 func (s Slice[T]) Clone() []T {
 	out := make([]T, len(s.items))
 	copy(out, s.items)
@@ -91,6 +96,7 @@ func (s Slice[T]) Append(items ...T) Slice[T] {
 // With returns a new Slice with the element at index i replaced by v. The receiver is unchanged.
 // It panics when i is out of range, like a slice.
 func (s Slice[T]) With(i int, v T) Slice[T] {
+	_ = s.items[i] // bounds-check before copying, with the runtime's own panic message
 	out := s.Clone()
 	out[i] = v
 	return Slice[T]{items: out}
@@ -108,6 +114,12 @@ func (s Slice[T]) EqualFunc(other Slice[T], eq func(a, b T) bool) bool {
 		}
 	}
 	return true
+}
+
+// Equal reports whether a and b hold the same elements in the same order. It is a function rather
+// than a method because a method cannot narrow T to comparable; use EqualFunc for other element types.
+func Equal[T comparable](a, b Slice[T]) bool {
+	return slices.Equal(a.items, b.items)
 }
 
 // MarshalJSON encodes the elements as a JSON array. An empty Slice encodes as [] rather than null.

--- a/pkg/immutable/slice.go
+++ b/pkg/immutable/slice.go
@@ -1,6 +1,10 @@
-// Package immutable holds value types whose contents cannot change in place. A value is built once,
-// read freely, and replaced as a whole when something new is needed. That is what lets a component
-// hold one without breaking the rule that world state only ever changes through Set.
+// Package immutable holds value types that keep their storage private, so nothing outside this
+// package can reach into one. A value is built once, read freely, and replaced as a whole when
+// something new is needed. That encapsulation is what lets a component hold one without handing the
+// world's backing memory to every caller of Get.
+//
+// The name describes the intended discipline rather than a guarantee the compiler enforces. Slice
+// derivations edit in place by review decision, so read Slice's own doc before using one.
 package immutable
 
 import (
@@ -13,42 +17,29 @@ import (
 	"github.com/argus-labs/world-engine/pkg/assert"
 )
 
-// TODO(immutable): every derivation copies the whole list, which is one allocation per edit. Review
-// asked for the copy to go from the operations that keep the length — With, Reversed, SortedFunc —
-// on the grounds that games cannot afford it. It stays, for two reasons.
-//
-// It is the guarantee the type exists for. Get hands back a struct copy whose Slice still points at
-// the column's array, so an in-place derivation writes into the live world before any Set, and the
-// next snapshot serializes it. A read-only use such as s.SortedFunc(cmp).At(0) would reorder the
-// column, and no linter catches it because the result is used. In-place shrinking is worse than
-// reordering: the column would keep its old length over a shifted, zero-filled tail.
-//
-// And it buys little. The operations that keep the length are called once per edit, not in a loop,
-// so the allocation they save is one per tick, against a read path that is already zero-copy. The
-// case worth optimizing is many edits to one list in one tick, and none of these fix that.
-//
-// Ways to do that properly, once profiling says it matters:
-//   - Mutate(func([]T) []T): copy in, edit with the slices package, copy out. Two allocations for
-//     any number of edits, and nothing the callback keeps can reach the result.
-//   - Update(func(i int, v T) T): one copy, the callback sees one element at a time. Slot edits only.
-//   - Ownership in spare capacity: a clone allocates one spare slot and Set reslices it away, so the
-//     first derivation after Get copies and later ones go in place. Needs Set and the snapshot
-//     decoder to freeze the stored value, which means a generated hook per component.
-//   - A fixed array plus a count, for any list whose length has a bound worth defending. Arrays are
-//     values, so the copy is the struct copy Get and Set already do, and edits are free.
+// TODO(immutable): derivations edit in place and do not copy, by review decision — one allocation
+// per edit was judged too expensive for a game loop. The cost is that a derivation reaches the
+// column's array before any Set, so derive-then-Set is a requirement rather than a convention. See
+// the note above the Deriving section for what that means at a call site.
 
-// Slice is an immutable sequence for component fields whose length is genuinely unbounded. It is
-// the only variable-length collection a component may hold.
+// Slice is a sequence with a private backing array, for component fields whose length is genuinely
+// unbounded. It is the only variable-length collection a component may hold.
 //
 // A component column stores values and Get hands back a copy, but a raw []T inside that copy still
-// shares its backing array with the column: writing through it changes the live world without a Set,
-// and a snapshot only ever holds what went through Set. Slice narrows that hole: the backing array is
-// unexported and nothing mutates in place — so sharing it between copies is safe, and Get stays
-// zero-copy. To change one, derive a new one and Set the component that holds it:
+// shares its backing array with the column. Slice keeps that array unexported, so no caller can
+// index into it, reslice it, or pass it to another package, and Get stays zero-copy.
+//
+// What Slice does not do is copy on a derivation. Most derivations edit the backing array in place
+// and return a Slice over that same array, so the column has already changed by the time the
+// derivation returns. Always Set the component afterwards:
 //
 //	inv := ref.Get()
-//	inv.Items = inv.Items.With(0, item)
-//	ref.Set(inv)
+//	inv.Items = inv.Items.With(0, item) // the column's array has changed here
+//	ref.Set(inv)                        // this republishes what is already true
+//
+// Deriving and dropping the result does not leave the world untouched — it leaves the world holding
+// an edit no snapshot recorded. Clone first when the original has to survive. Each derivation's doc
+// says whether it writes through.
 //
 // Two empty Slices are not always reflect.DeepEqual. A derivation that empties one leaves its backing
 // array allocated, while the zero value and SliceOf have none, and DeepEqual looks at the field rather
@@ -132,6 +123,8 @@ func (s Slice[T]) IsSortedFunc(compare func(a, b T) int) bool {
 
 // Chunk returns an iterator over consecutive sub-Slices of up to n elements. It panics when n is
 // less than one, like slices.Chunk.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) Chunk(n int) iter.Seq[Slice[T]] {
 	assert.That(n >= 1, "immutable: Chunk(%d) size must be at least one", n)
 	// Called here rather than inside the closure so its own size check runs now, not on the first
@@ -139,7 +132,9 @@ func (s Slice[T]) Chunk(n int) iter.Seq[Slice[T]] {
 	parts := slices.Chunk(s.items, n)
 	return func(yield func(Slice[T]) bool) {
 		for part := range parts {
-			if !yield(Slice[T]{items: slices.Clone(part)}) {
+			// Each part is a window onto the receiver's array rather than a copy, so deriving from
+			// one writes into the receiver.
+			if !yield(Slice[T]{items: part}) {
 				return
 			}
 		}
@@ -148,6 +143,9 @@ func (s Slice[T]) Chunk(n int) iter.Seq[Slice[T]] {
 
 // Clone returns a fresh []T holding a copy of the elements, for an API that needs a plain slice.
 // Changes to the result never reach the Slice. It is never nil, even for an empty Slice.
+//
+// Because derivations edit in place, this is also how a caller keeps the original: deriving from
+// SliceOf(s.Clone()...) cannot reach s.
 func (s Slice[T]) Clone() []T {
 	out := make([]T, len(s.items))
 	copy(out, s.items)
@@ -157,102 +155,136 @@ func (s Slice[T]) Clone() []T {
 // -------------------------------------------------------------------------------------------------
 // Deriving
 // -------------------------------------------------------------------------------------------------
+//
+// These do not copy. Where the result fits in the receiver's array they edit it in place and return
+// a Slice over that same array, so the receiver — and every other Slice sharing it, including the
+// one the component column still holds — sees the edit immediately.
+//
+// Two consequences worth stating plainly. Deriving and discarding the result still changes the
+// world. And the ones that shrink (Without, Filter, Delete, CompactFunc) leave the receiver at its
+// old length over a shifted, zero-filled tail, so the receiver is not merely reordered but wrong.
+// Set the component after every derivation, and Clone first when the original has to survive.
 
-// Append returns a new Slice with items added at the end. The receiver is unchanged.
+// Append returns a Slice with items added at the end. It allocates a new array, so the receiver is
+// unchanged.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) Append(items ...T) Slice[T] {
 	return Slice[T]{items: slices.Concat(s.items, items)}
 }
 
-// With returns a new Slice with the element at index i replaced by v. The receiver is unchanged.
-// It panics when i is out of range, like a slice.
+// With returns a Slice with the element at index i replaced by v. It writes through: the receiver
+// holds v at i as well. It panics when i is out of range, like a slice.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) With(i int, v T) Slice[T] {
 	assert.That(i >= 0 && i < len(s.items), "immutable: With(%d) out of range, length %d", i, len(s.items))
-	out := s.Clone()
-	out[i] = v
-	return Slice[T]{items: out}
+	s.items[i] = v
+	return Slice[T]{items: s.items}
 }
 
-// Without returns a new Slice with the element at index i removed. The receiver is unchanged.
-// It panics when i is out of range, like a slice.
+// Without returns a Slice with the element at index i removed. It writes through: the receiver keeps
+// its old length over the shifted, zero-filled tail. It panics when i is out of range, like a slice.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) Without(i int) Slice[T] {
 	assert.That(i >= 0 && i < len(s.items), "immutable: Without(%d) out of range, length %d", i, len(s.items))
-	return Slice[T]{items: slices.Delete(s.Clone(), i, i+1)}
+	return Slice[T]{items: slices.Delete(s.items, i, i+1)}
 }
 
-// Filter returns a new Slice holding the elements for which keep is true, in order. The receiver is
-// unchanged, and keep runs once per element.
+// Filter returns a Slice holding the elements for which keep is true, in order, and keep runs once
+// per element. It writes through: the receiver keeps its old length over the shifted, zero-filled
+// tail.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) Filter(keep func(T) bool) Slice[T] {
-	return Slice[T]{items: slices.DeleteFunc(s.Clone(), func(v T) bool { return !keep(v) })}
+	return Slice[T]{items: slices.DeleteFunc(s.items, func(v T) bool { return !keep(v) })}
 }
 
-// Insert returns a new Slice with items inserted at index i, which may equal Len. The receiver is
-// unchanged. It panics when i is out of range, like slices.Insert.
+// Insert returns a Slice with items inserted at index i, which may equal Len. It writes through
+// whenever the receiver has the spare capacity to hold the result and allocates otherwise, so treat
+// the receiver as changed either way. It panics when i is out of range, like slices.Insert.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) Insert(i int, items ...T) Slice[T] {
 	assert.That(i >= 0 && i <= len(s.items), "immutable: Insert(%d) out of range, length %d", i, len(s.items))
-	// The clone is sized for the result, so slices.Insert finishes in place instead of growing.
-	out := make([]T, len(s.items), len(s.items)+len(items))
-	copy(out, s.items)
-	return Slice[T]{items: slices.Insert(out, i, items...)}
+	return Slice[T]{items: slices.Insert(s.items, i, items...)}
 }
 
-// Sub returns a new Slice holding the elements in [lo, hi). The receiver is unchanged. It panics
-// when the range is out of bounds, like s[lo:hi].
+// Sub returns a Slice holding the elements in [lo, hi). It is the one derivation that writes
+// nothing, but the result is a window onto the receiver's array, so deriving from that window writes
+// into the receiver. It panics when the range is out of bounds, like s[lo:hi].
 //
 // The bounds are checked against Len explicitly: a derived Slice can have spare capacity, and a
 // plain slice expression would read past the end into it.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) Sub(lo, hi int) Slice[T] {
 	assert.That(0 <= lo && lo <= hi && hi <= len(s.items),
 		"immutable: Sub(%d, %d) out of range, length %d", lo, hi, len(s.items))
 	// Three-index, so the runtime bounds the range by LENGTH rather than capacity. A derived Slice can
 	// carry spare capacity, and a plain s.items[lo:hi] would happily read into it. This check is the one
 	// that has to survive a release build, where assert.That compiles away.
-	return Slice[T]{items: slices.Clone(s.items[lo:hi:len(s.items)])}
+	return Slice[T]{items: s.items[lo:hi:len(s.items)]}
 }
 
-// Reversed returns a new Slice with the elements in reverse order. The receiver is unchanged. To
-// read in reverse without deriving anything, use Backward.
+// Reversed returns a Slice with the elements in reverse order. It writes through: the receiver is
+// reversed too, so calling it once a tick in a query flips the stored order every tick. To read in
+// reverse without deriving anything, use Backward.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) Reversed() Slice[T] {
-	out := s.Clone()
-	slices.Reverse(out)
-	return Slice[T]{items: out}
+	slices.Reverse(s.items)
+	return Slice[T]{items: s.items}
 }
 
-// SortedFunc returns a new Slice sorted by compare, which reports a<b as negative, a==b as zero and
-// a>b as positive. The sort is stable, so equal elements keep their order. The receiver is unchanged.
-// To find one extreme without deriving anything, use MinFunc or MaxFunc.
+// SortedFunc returns a Slice sorted by compare, which reports a<b as negative, a==b as zero and a>b
+// as positive. The sort is stable, so equal elements keep their order. It writes through: the
+// receiver is sorted too, so even a read-only use such as s.SortedFunc(cmp).At(0) reorders the
+// column. To find one extreme without deriving anything, use MinFunc or MaxFunc.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) SortedFunc(compare func(a, b T) int) Slice[T] {
-	out := s.Clone()
-	slices.SortStableFunc(out, compare)
-	return Slice[T]{items: out}
+	slices.SortStableFunc(s.items, compare)
+	return Slice[T]{items: s.items}
 }
 
-// Delete returns a new Slice with the elements in [i, j) removed. The receiver is unchanged. It
-// panics when the range is out of bounds, like slices.Delete.
+// Delete returns a Slice with the elements in [i, j) removed. It writes through: the receiver keeps
+// its old length over the shifted, zero-filled tail. It panics when the range is out of bounds, like
+// slices.Delete.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) Delete(i, j int) Slice[T] {
 	assert.That(0 <= i && i <= j && j <= len(s.items),
 		"immutable: Delete(%d, %d) out of range, length %d", i, j, len(s.items))
-	return Slice[T]{items: slices.Delete(s.Clone(), i, j)}
+	return Slice[T]{items: slices.Delete(s.items, i, j)}
 }
 
-// Replace returns a new Slice with the elements in [i, j) replaced by items. The receiver is
-// unchanged. It panics when the range is out of bounds, like slices.Replace.
+// Replace returns a Slice with the elements in [i, j) replaced by items. It writes through whenever
+// the receiver has the spare capacity to hold the result and allocates otherwise, so treat the
+// receiver as changed either way. It panics when the range is out of bounds, like slices.Replace.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) Replace(i, j int, items ...T) Slice[T] {
 	assert.That(0 <= i && i <= j && j <= len(s.items),
 		"immutable: Replace(%d, %d) out of range, length %d", i, j, len(s.items))
-	// The clone is sized for the result, so slices.Replace finishes in place instead of growing.
-	out := make([]T, len(s.items), len(s.items)+max(len(items)-(j-i), 0))
-	copy(out, s.items)
-	return Slice[T]{items: slices.Replace(out, i, j, items...)}
+	return Slice[T]{items: slices.Replace(s.items, i, j, items...)}
 }
 
-// CompactFunc returns a new Slice with runs of consecutive elements that eq reports equal collapsed
-// to one, like slices.CompactFunc. The receiver is unchanged.
+// CompactFunc returns a Slice with runs of consecutive elements that eq reports equal collapsed to
+// one, like slices.CompactFunc. It writes through: the receiver keeps its old length over the
+// shifted, zero-filled tail.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) CompactFunc(eq func(a, b T) bool) Slice[T] {
-	return Slice[T]{items: slices.CompactFunc(s.Clone(), eq)}
+	return Slice[T]{items: slices.CompactFunc(s.items, eq)}
 }
 
-// Repeat returns a new Slice holding the elements count times over. It panics when count is
-// negative or the result would overflow, like slices.Repeat.
+// Repeat returns a Slice holding the elements count times over. It allocates a new array, so the
+// receiver is unchanged. It panics when count is negative or the result would overflow, like
+// slices.Repeat.
+//
+// NOTE: Requires component set if used.
 func (s Slice[T]) Repeat(count int) Slice[T] {
 	assert.That(count >= 0, "immutable: Repeat(%d) must not be negative", count)
 	return Slice[T]{items: slices.Repeat(s.items, count)}
@@ -299,15 +331,21 @@ func Contains[T comparable](s Slice[T], v T) bool {
 	return slices.Contains(s.items, v)
 }
 
-// Sorted returns a new Slice with the elements of s in ascending order. The sort is stable.
+// Sorted returns a Slice with the elements of s in ascending order. The sort is stable. Like
+// SortedFunc it writes through, so s ends up sorted too.
+//
+// NOTE: Requires component set if used.
 func Sorted[T cmp.Ordered](s Slice[T]) Slice[T] {
 	return s.SortedFunc(cmp.Compare[T])
 }
 
-// Compact returns a new Slice with runs of consecutive equal elements collapsed to one, like
-// slices.Compact.
+// Compact returns a Slice with runs of consecutive equal elements collapsed to one, like
+// slices.Compact. Like CompactFunc it writes through, so s keeps its old length over the shifted,
+// zero-filled tail.
+//
+// NOTE: Requires component set if used.
 func Compact[T comparable](s Slice[T]) Slice[T] {
-	return Slice[T]{items: slices.Compact(s.Clone())}
+	return Slice[T]{items: slices.Compact(s.items)}
 }
 
 // Min returns the smallest element of s. It panics when s is empty, like slices.Min.

--- a/pkg/immutable/slice_test.go
+++ b/pkg/immutable/slice_test.go
@@ -15,12 +15,19 @@ type point struct {
 	X, Y int
 }
 
+// collect copies a Slice's elements out to a plain []T for comparison. Slice has no Clone method —
+// derivations write through, so a test that needs a stable snapshot copies via Values, same as any
+// other caller would.
+func collect[T any](s immutable.Slice[T]) []T {
+	return slices.Collect(s.Values())
+}
+
 func TestSlice_ZeroValueIsEmpty(t *testing.T) {
 	t.Parallel()
 
 	var s immutable.Slice[int]
 	require.Equal(t, 0, s.Len())
-	require.Empty(t, s.Clone())
+	require.Empty(t, collect(s))
 	for range s.All() {
 		t.Fatal("zero Slice must yield nothing")
 	}
@@ -35,17 +42,17 @@ func TestSliceOf_CopiesInput(t *testing.T) {
 	in[0] = 99
 
 	require.Equal(t, 1, s.At(0), "changing the input after construction must not reach the Slice")
-	require.Equal(t, []int{1, 2, 3}, s.Clone())
+	require.Equal(t, []int{1, 2, 3}, collect(s))
 }
 
-func TestSlice_CloneIsIndependent(t *testing.T) {
+func TestSlice_ValuesCopyIsIndependent(t *testing.T) {
 	t.Parallel()
 
 	s := immutable.SliceOf(1, 2, 3)
-	out := s.Clone()
+	out := collect(s)
 	out[0] = 99
 
-	require.Equal(t, 1, s.At(0), "changing a Clone must not reach the Slice")
+	require.Equal(t, 1, s.At(0), "changing a copy taken via Values must not reach the Slice")
 }
 
 func TestSlice_AtReturnsCopy(t *testing.T) {
@@ -67,10 +74,10 @@ func TestSlice_AppendDoesNotShareBacking(t *testing.T) {
 	a := base.Append(4)
 	b := base.Append(5, 6)
 
-	require.Equal(t, []int{1, 2, 3}, base.Clone(), "receiver must be unchanged")
-	require.Equal(t, []int{1, 2, 3, 4}, a.Clone())
-	require.Equal(t, []int{1, 2, 3, 5, 6}, b.Clone(), "two appends from one base must not clobber")
-	require.Equal(t, base.Clone(), base.Append().Clone(), "empty append is a no-op")
+	require.Equal(t, []int{1, 2, 3}, collect(base), "receiver must be unchanged")
+	require.Equal(t, []int{1, 2, 3, 4}, collect(a))
+	require.Equal(t, []int{1, 2, 3, 5, 6}, collect(b), "two appends from one base must not clobber")
+	require.Equal(t, collect(base), collect(base.Append()), "empty append is a no-op")
 }
 
 func TestSlice_WithReplacesOneElement(t *testing.T) {
@@ -79,8 +86,8 @@ func TestSlice_WithReplacesOneElement(t *testing.T) {
 	s := immutable.SliceOf(1, 2, 3)
 	w := s.With(1, 42)
 
-	require.Equal(t, []int{1, 42, 3}, w.Clone())
-	require.Equal(t, []int{1, 42, 3}, s.Clone(), "With writes through to the receiver")
+	require.Equal(t, []int{1, 42, 3}, collect(w))
+	require.Equal(t, []int{1, 42, 3}, collect(s), "With writes through to the receiver")
 	require.Panics(t, func() { immutable.SliceOf(1, 2, 3).With(3, 0) })
 }
 
@@ -90,15 +97,15 @@ func TestSlice_WithoutDropsOneElement(t *testing.T) {
 	// Each case starts from a fresh receiver: Without writes through, so reusing one would feed the
 	// next case a shrunken list.
 	fresh := func() immutable.Slice[int] { return immutable.SliceOf(1, 2, 3) }
-	require.Equal(t, []int{2, 3}, fresh().Without(0).Clone())
-	require.Equal(t, []int{1, 3}, fresh().Without(1).Clone())
-	require.Equal(t, []int{1, 2}, fresh().Without(2).Clone())
+	require.Equal(t, []int{2, 3}, collect(fresh().Without(0)))
+	require.Equal(t, []int{1, 3}, collect(fresh().Without(1)))
+	require.Equal(t, []int{1, 2}, collect(fresh().Without(2)))
 	require.Equal(t, 0, immutable.SliceOf(1).Without(0).Len(), "dropping the last leaves it empty")
 	require.Panics(t, func() { fresh().Without(3) })
 
 	s := fresh()
 	s.Without(0)
-	require.Equal(t, []int{2, 3, 0}, s.Clone(),
+	require.Equal(t, []int{2, 3, 0}, collect(s),
 		"Without writes through: the receiver keeps its length over a zero-filled tail")
 }
 
@@ -110,14 +117,14 @@ func TestSlice_FilterKeepsMatches(t *testing.T) {
 	fresh := func() immutable.Slice[int] { return immutable.SliceOf(1, 2, 3, 4) }
 	even := func(v int) bool { return v%2 == 0 }
 
-	require.Equal(t, []int{2, 4}, fresh().Filter(even).Clone())
+	require.Equal(t, []int{2, 4}, collect(fresh().Filter(even)))
 	require.Equal(t, 0, fresh().Filter(func(int) bool { return false }).Len(), "dropping all leaves it empty")
-	require.Equal(t, []int{1, 2, 3, 4}, fresh().Filter(func(int) bool { return true }).Clone(),
+	require.Equal(t, []int{1, 2, 3, 4}, collect(fresh().Filter(func(int) bool { return true })),
 		"keeping all keeps order")
 
 	s := fresh()
 	s.Filter(even)
-	require.Equal(t, []int{2, 4, 0, 0}, s.Clone(),
+	require.Equal(t, []int{2, 4, 0, 0}, collect(s),
 		"Filter writes through: the receiver keeps its length over a zero-filled tail")
 
 	calls := 0
@@ -256,10 +263,10 @@ func TestSlice_Insert(t *testing.T) {
 	// Insert writes through when the receiver has the spare capacity to hold the result and
 	// allocates otherwise, so every case starts from a fresh receiver rather than reusing one.
 	fresh := func() immutable.Slice[int] { return immutable.SliceOf(1, 3) }
-	require.Equal(t, []int{0, 1, 3}, fresh().Insert(0, 0).Clone())
-	require.Equal(t, []int{1, 2, 3}, fresh().Insert(1, 2).Clone())
-	require.Equal(t, []int{1, 3, 4, 5}, fresh().Insert(2, 4, 5).Clone(), "at Len appends")
-	require.Equal(t, []int{1, 3}, fresh().Insert(1).Clone(), "no items is a no-op")
+	require.Equal(t, []int{0, 1, 3}, collect(fresh().Insert(0, 0)))
+	require.Equal(t, []int{1, 2, 3}, collect(fresh().Insert(1, 2)))
+	require.Equal(t, []int{1, 3, 4, 5}, collect(fresh().Insert(2, 4, 5)), "at Len appends")
+	require.Equal(t, []int{1, 3}, collect(fresh().Insert(1)), "no items is a no-op")
 	require.Panics(t, func() { fresh().Insert(3, 9) })
 	require.Panics(t, func() { fresh().Insert(-1, 9) })
 }
@@ -268,10 +275,10 @@ func TestSlice_Sub(t *testing.T) {
 	t.Parallel()
 
 	s := immutable.SliceOf(1, 2, 3, 4)
-	require.Equal(t, []int{2, 3}, s.Sub(1, 3).Clone())
-	require.Equal(t, []int{1, 2, 3, 4}, s.Sub(0, 4).Clone())
+	require.Equal(t, []int{2, 3}, collect(s.Sub(1, 3)))
+	require.Equal(t, []int{1, 2, 3, 4}, collect(s.Sub(0, 4)))
 	require.Equal(t, 0, s.Sub(2, 2).Len(), "empty range")
-	require.Equal(t, []int{1, 2, 3, 4}, s.Clone(), "Sub is the one derivation that writes nothing")
+	require.Equal(t, []int{1, 2, 3, 4}, collect(s), "Sub is the one derivation that writes nothing")
 	require.Panics(t, func() { s.Sub(0, 5) })
 	require.Panics(t, func() { s.Sub(3, 2) })
 	require.Panics(t, func() { s.Sub(-1, 2) })
@@ -288,23 +295,23 @@ func TestSlice_ReversedAndSorted(t *testing.T) {
 
 	// Both reorder in place, so every case starts from a fresh receiver.
 	fresh := func() immutable.Slice[int] { return immutable.SliceOf(3, 1, 2) }
-	require.Equal(t, []int{2, 1, 3}, fresh().Reversed().Clone())
-	require.Equal(t, []int{1, 2, 3}, immutable.Sorted(fresh()).Clone())
-	require.Equal(t, []int{3, 2, 1}, fresh().SortedFunc(func(a, b int) int { return b - a }).Clone())
+	require.Equal(t, []int{2, 1, 3}, collect(fresh().Reversed()))
+	require.Equal(t, []int{1, 2, 3}, collect(immutable.Sorted(fresh())))
+	require.Equal(t, []int{3, 2, 1}, collect(fresh().SortedFunc(func(a, b int) int { return b - a })))
 	require.Equal(t, 0, immutable.Slice[int]{}.Reversed().Len())
 	require.Equal(t, 0, immutable.Sorted(immutable.Slice[int]{}).Len())
 
 	s := fresh()
 	s.Reversed()
-	require.Equal(t, []int{2, 1, 3}, s.Clone(), "Reversed writes through to the receiver")
+	require.Equal(t, []int{2, 1, 3}, collect(s), "Reversed writes through to the receiver")
 
 	s = fresh()
 	immutable.Sorted(s)
-	require.Equal(t, []int{1, 2, 3}, s.Clone(), "Sorted writes through to the receiver")
+	require.Equal(t, []int{1, 2, 3}, collect(s), "Sorted writes through to the receiver")
 
 	// Stable: equal keys keep their original order.
 	byLen := func(a, b string) int { return len(a) - len(b) }
-	got := immutable.SliceOf("bb", "a", "cc", "b").SortedFunc(byLen).Clone()
+	got := collect(immutable.SliceOf("bb", "a", "cc", "b").SortedFunc(byLen))
 	require.Equal(t, []string{"a", "b", "bb", "cc"}, got)
 }
 
@@ -312,18 +319,18 @@ func TestSlice_MapConcatCollectCompact(t *testing.T) {
 	t.Parallel()
 
 	s := immutable.SliceOf(1, 2, 3)
-	require.Equal(t, []string{"1", "2", "3"}, immutable.Map(s, strconv.Itoa).Clone())
+	require.Equal(t, []string{"1", "2", "3"}, collect(immutable.Map(s, strconv.Itoa)))
 	require.Equal(t, 0, immutable.Map(immutable.Slice[int]{}, strconv.Itoa).Len())
 
-	require.Equal(t, []int{1, 2, 3, 4, 5}, immutable.Concat(s, immutable.Slice[int]{}, immutable.SliceOf(4, 5)).Clone())
+	require.Equal(t, []int{1, 2, 3, 4, 5}, collect(immutable.Concat(s, immutable.Slice[int]{}, immutable.SliceOf(4, 5))))
 	require.Equal(t, 0, immutable.Concat[int]().Len())
 
-	require.Equal(t, []int{1, 2, 3}, immutable.Collect(s.Values()).Clone())
+	require.Equal(t, []int{1, 2, 3}, collect(immutable.Collect(s.Values())))
 	require.Equal(t, 0, immutable.Collect(immutable.Slice[int]{}.Values()).Len())
 
 	dup := immutable.SliceOf(1, 1, 2, 2, 2, 1)
-	require.Equal(t, []int{1, 2, 1}, immutable.Compact(dup).Clone())
-	require.Equal(t, []int{1, 2, 1, 0, 0, 0}, dup.Clone(),
+	require.Equal(t, []int{1, 2, 1}, collect(immutable.Compact(dup)))
+	require.Equal(t, []int{1, 2, 1, 0, 0, 0}, collect(dup),
 		"Compact writes through: the receiver keeps its length over a zero-filled tail")
 	require.Equal(t, 0, immutable.Compact(immutable.Slice[int]{}).Len())
 }
@@ -374,44 +381,44 @@ func TestSlice_DeleteReplaceRepeatChunkCompactFunc(t *testing.T) {
 
 	// Delete, Replace and CompactFunc all reach the receiver, so every case starts from a fresh one.
 	fresh := func() immutable.Slice[int] { return immutable.SliceOf(1, 2, 3, 4) }
-	require.Equal(t, []int{1, 4}, fresh().Delete(1, 3).Clone())
-	require.Equal(t, []int{1, 2, 3, 4}, fresh().Delete(2, 2).Clone(), "empty range is a no-op")
+	require.Equal(t, []int{1, 4}, collect(fresh().Delete(1, 3)))
+	require.Equal(t, []int{1, 2, 3, 4}, collect(fresh().Delete(2, 2)), "empty range is a no-op")
 	require.Equal(t, 0, fresh().Delete(0, 4).Len(), "deleting all leaves it empty")
 	require.Panics(t, func() { fresh().Delete(3, 5) })
 
 	s := fresh()
 	s.Delete(1, 3)
-	require.Equal(t, []int{1, 4, 0, 0}, s.Clone(),
+	require.Equal(t, []int{1, 4, 0, 0}, collect(s),
 		"Delete writes through: the receiver keeps its length over a zero-filled tail")
 
-	require.Equal(t, []int{1, 9, 9, 4}, fresh().Replace(1, 3, 9, 9).Clone())
-	require.Equal(t, []int{1, 4}, fresh().Replace(1, 3).Clone(), "replace with nothing deletes")
+	require.Equal(t, []int{1, 9, 9, 4}, collect(fresh().Replace(1, 3, 9, 9)))
+	require.Equal(t, []int{1, 4}, collect(fresh().Replace(1, 3)), "replace with nothing deletes")
 	require.Equal(t, 0, fresh().Replace(0, 4).Len(), "replacing all with nothing leaves it empty")
 
-	require.Equal(t, []int{1, 2, 1, 2}, immutable.SliceOf(1, 2).Repeat(2).Clone())
+	require.Equal(t, []int{1, 2, 1, 2}, collect(immutable.SliceOf(1, 2).Repeat(2)))
 	require.Equal(t, 0, fresh().Repeat(0).Len())
 	require.Panics(t, func() { fresh().Repeat(-1) })
 
 	var chunks [][]int
 	for part := range fresh().Chunk(3) {
-		chunks = append(chunks, part.Clone())
+		chunks = append(chunks, collect(part))
 	}
 	require.Equal(t, [][]int{{1, 2, 3}, {4}}, chunks)
 	require.Panics(t, func() { fresh().Chunk(0) })
 
 	sameParity := func(a, b int) bool { return a%2 == b%2 }
-	require.Equal(t, []int{1, 2, 3}, immutable.SliceOf(1, 1, 2, 2, 3).CompactFunc(sameParity).Clone())
+	require.Equal(t, []int{1, 2, 3}, collect(immutable.SliceOf(1, 1, 2, 2, 3).CompactFunc(sameParity)))
 
 	c := immutable.SliceOf(1, 1, 2, 2, 3)
 	c.CompactFunc(sameParity)
-	require.Equal(t, []int{1, 2, 3, 0, 0}, c.Clone(),
+	require.Equal(t, []int{1, 2, 3, 0, 0}, collect(c),
 		"CompactFunc writes through: the receiver keeps its length over a zero-filled tail")
 }
 
 // TestSlice_DerivationsWriteThrough pins, for every derivation at once, whether it reaches the
 // receiver's backing array. Review removed the copy from each one that can finish in place, so this
 // table is the contract callers work against rather than an implementation detail: derive, then Set,
-// and Clone first when the original has to survive.
+// and copy the elements out first (immutable.Collect) when the original has to survive.
 //
 // The base has length 4 and no spare capacity, so the ops that grow past it are forced to allocate
 // and leave the receiver alone. Give one spare room and Insert and Replace write through too, which
@@ -468,8 +475,8 @@ func TestSlice_DerivationsWriteThrough(t *testing.T) {
 			t.Parallel()
 
 			s := base()
-			require.Equal(t, c.want, c.derive(s).Clone(), "result")
-			require.Equal(t, c.receiver, s.Clone(), "receiver after %s", c.name)
+			require.Equal(t, c.want, collect(c.derive(s)), "result")
+			require.Equal(t, c.receiver, collect(s), "receiver after %s", c.name)
 		})
 	}
 }

--- a/pkg/immutable/slice_test.go
+++ b/pkg/immutable/slice_test.go
@@ -1,0 +1,162 @@
+package immutable_test
+
+import (
+	"testing"
+
+	"github.com/argus-labs/world-engine/pkg/immutable"
+	"github.com/goccy/go-json"
+	"github.com/stretchr/testify/require"
+)
+
+type point struct {
+	X, Y int
+}
+
+func TestSlice_ZeroValueIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	var s immutable.Slice[int]
+	require.Equal(t, 0, s.Len())
+	require.Empty(t, s.Clone())
+	for range s.All() {
+		t.Fatal("zero Slice must yield nothing")
+	}
+	require.Equal(t, 1, s.Append(1).Len(), "a zero Slice can be appended to")
+}
+
+func TestSliceOf_CopiesInput(t *testing.T) {
+	t.Parallel()
+
+	in := []int{1, 2, 3}
+	s := immutable.SliceOf(in...)
+	in[0] = 99
+
+	require.Equal(t, 1, s.At(0), "changing the input after construction must not reach the Slice")
+	require.Equal(t, []int{1, 2, 3}, s.Clone())
+}
+
+func TestSlice_CloneIsIndependent(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(1, 2, 3)
+	out := s.Clone()
+	out[0] = 99
+
+	require.Equal(t, 1, s.At(0), "changing a Clone must not reach the Slice")
+}
+
+func TestSlice_AtReturnsCopy(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(point{X: 1, Y: 2})
+	p := s.At(0)
+	p.X = 99
+
+	require.Equal(t, 99, p.X, "the copy changes")
+	require.Equal(t, point{X: 1, Y: 2}, s.At(0), "the Slice does not")
+	require.Panics(t, func() { s.At(1) })
+}
+
+func TestSlice_AppendDoesNotShareBacking(t *testing.T) {
+	t.Parallel()
+
+	base := immutable.SliceOf(1, 2, 3)
+	a := base.Append(4)
+	b := base.Append(5, 6)
+
+	require.Equal(t, []int{1, 2, 3}, base.Clone(), "receiver must be unchanged")
+	require.Equal(t, []int{1, 2, 3, 4}, a.Clone())
+	require.Equal(t, []int{1, 2, 3, 5, 6}, b.Clone(), "two appends from one base must not clobber")
+	require.Equal(t, base.Clone(), base.Append().Clone(), "empty append is a no-op")
+}
+
+func TestSlice_WithReplacesOneElement(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(1, 2, 3)
+	w := s.With(1, 42)
+
+	require.Equal(t, []int{1, 2, 3}, s.Clone(), "receiver must be unchanged")
+	require.Equal(t, []int{1, 42, 3}, w.Clone())
+	require.Panics(t, func() { s.With(3, 0) })
+}
+
+func TestSlice_AllYieldsInOrderAndStopsEarly(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf("a", "b", "c")
+
+	var got []string
+	for i, v := range s.All() {
+		require.Equal(t, v, s.At(i))
+		got = append(got, v)
+	}
+	require.Equal(t, []string{"a", "b", "c"}, got)
+
+	seen := 0
+	for range s.All() {
+		seen++
+		break
+	}
+	require.Equal(t, 1, seen)
+}
+
+func TestSlice_EqualFunc(t *testing.T) {
+	t.Parallel()
+
+	eq := func(a, b int) bool { return a == b }
+	s := immutable.SliceOf(1, 2, 3)
+
+	require.True(t, s.EqualFunc(immutable.SliceOf(1, 2, 3), eq))
+	require.False(t, s.EqualFunc(immutable.SliceOf(1, 2), eq), "different length")
+	require.False(t, s.EqualFunc(immutable.SliceOf(1, 2, 4), eq), "different element")
+	require.True(t, immutable.Slice[int]{}.EqualFunc(immutable.SliceOf[int](), eq), "empty equals empty")
+}
+
+func TestSlice_JSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(point{X: 1, Y: 2}, point{X: 3, Y: 4})
+
+	data, err := json.Marshal(s)
+	require.NoError(t, err)
+	require.JSONEq(t, `[{"X":1,"Y":2},{"X":3,"Y":4}]`, string(data))
+
+	var back immutable.Slice[point]
+	require.NoError(t, json.Unmarshal(data, &back))
+	require.Equal(t, s.Clone(), back.Clone())
+}
+
+func TestSlice_JSONEmptyAndNull(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(immutable.Slice[int]{})
+	require.NoError(t, err)
+	require.JSONEq(t, `[]`, string(data), "empty encodes as [] not null")
+
+	var fromNull immutable.Slice[int]
+	require.NoError(t, json.Unmarshal([]byte(`null`), &fromNull))
+	require.Equal(t, 0, fromNull.Len())
+
+	var fromEmpty immutable.Slice[int]
+	require.NoError(t, json.Unmarshal([]byte(`[]`), &fromEmpty))
+	require.Equal(t, 0, fromEmpty.Len())
+}
+
+// A Slice is a struct, so omitempty does not omit it. Pinned here because migrating a []T field
+// tagged omitempty to a Slice changes the encoded shape from absent to [].
+func TestSlice_JSONInsideStructIgnoresOmitempty(t *testing.T) {
+	t.Parallel()
+
+	type holder struct {
+		Points immutable.Slice[point] `json:"points,omitempty"`
+	}
+
+	data, err := json.Marshal(holder{})
+	require.NoError(t, err)
+	require.JSONEq(t, `{"points":[]}`, string(data))
+
+	var back holder
+	require.NoError(t, json.Unmarshal([]byte(`{"points":[{"X":5,"Y":6}]}`), &back))
+	require.Equal(t, []point{{X: 5, Y: 6}}, back.Points.Clone())
+}

--- a/pkg/immutable/slice_test.go
+++ b/pkg/immutable/slice_test.go
@@ -143,6 +143,22 @@ func TestSlice_JSONEmptyAndNull(t *testing.T) {
 	require.Equal(t, 0, fromEmpty.Len())
 }
 
+// Every empty Slice must be the same value however it was made: reflect.DeepEqual, and so
+// require.Equal on a whole component, must not tell a decoded [] or null apart from SliceOf().
+func TestSlice_EmptyIsOneValue(t *testing.T) {
+	t.Parallel()
+
+	var fromEmpty, fromNull immutable.Slice[int]
+	require.NoError(t, json.Unmarshal([]byte(`[]`), &fromEmpty))
+	require.NoError(t, json.Unmarshal([]byte(`null`), &fromNull))
+
+	empty := immutable.SliceOf[int]()
+	require.Equal(t, immutable.Slice[int]{}, empty, "zero value")
+	require.Equal(t, empty, fromEmpty, "decoded []")
+	require.Equal(t, empty, fromNull, "decoded null")
+	require.Equal(t, empty, empty.Append(), "empty append")
+}
+
 // A Slice is a struct, so omitempty does not omit it. Pinned here because migrating a []T field
 // tagged omitempty to a Slice changes the encoded shape from absent to [].
 func TestSlice_JSONInsideStructIgnoresOmitempty(t *testing.T) {

--- a/pkg/immutable/slice_test.go
+++ b/pkg/immutable/slice_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 
 	"github.com/argus-labs/world-engine/pkg/immutable"
-	"github.com/goccy/go-json"
 	"github.com/stretchr/testify/require"
 )
 
@@ -156,68 +155,25 @@ func TestEqual(t *testing.T) {
 	require.True(t, immutable.Equal(immutable.Slice[int]{}, immutable.SliceOf[int]()), "empty equals empty")
 }
 
-func TestSlice_JSONRoundTrip(t *testing.T) {
-	t.Parallel()
-
-	s := immutable.SliceOf(point{X: 1, Y: 2}, point{X: 3, Y: 4})
-
-	data, err := json.Marshal(s)
-	require.NoError(t, err)
-	require.JSONEq(t, `[{"X":1,"Y":2},{"X":3,"Y":4}]`, string(data))
-
-	var back immutable.Slice[point]
-	require.NoError(t, json.Unmarshal(data, &back))
-	require.Equal(t, s.Clone(), back.Clone())
-}
-
-func TestSlice_JSONEmptyAndNull(t *testing.T) {
-	t.Parallel()
-
-	data, err := json.Marshal(immutable.Slice[int]{})
-	require.NoError(t, err)
-	require.JSONEq(t, `[]`, string(data), "empty encodes as [] not null")
-
-	var fromNull immutable.Slice[int]
-	require.NoError(t, json.Unmarshal([]byte(`null`), &fromNull))
-	require.Equal(t, 0, fromNull.Len())
-
-	var fromEmpty immutable.Slice[int]
-	require.NoError(t, json.Unmarshal([]byte(`[]`), &fromEmpty))
-	require.Equal(t, 0, fromEmpty.Len())
-}
-
-// Every empty Slice must be the same value however it was made: reflect.DeepEqual, and so
-// require.Equal on a whole component, must not tell a decoded [] or null apart from SliceOf().
+// Every empty Slice must be the same value however it was produced: reflect.DeepEqual, and so
+// require.Equal on a whole component, must not tell them apart. Only the zero value is naturally
+// nil — the stdlib helpers behind these derivations all hand back an empty but non-nil slice, so
+// each one relies on wrap to canonicalise it.
 func TestSlice_EmptyIsOneValue(t *testing.T) {
 	t.Parallel()
 
-	var fromEmpty, fromNull immutable.Slice[int]
-	require.NoError(t, json.Unmarshal([]byte(`[]`), &fromEmpty))
-	require.NoError(t, json.Unmarshal([]byte(`null`), &fromNull))
-
 	empty := immutable.SliceOf[int]()
+	full := immutable.SliceOf(1, 2, 3)
+
 	require.Equal(t, immutable.Slice[int]{}, empty, "zero value")
-	require.Equal(t, empty, fromEmpty, "decoded []")
-	require.Equal(t, empty, fromNull, "decoded null")
+	require.Equal(t, empty, immutable.SliceOf([]int{}...), "built from an empty non-nil slice")
 	require.Equal(t, empty, empty.Append(), "empty append")
-}
-
-// A Slice is a struct, so omitempty does not omit it. Pinned here because migrating a []T field
-// tagged omitempty to a Slice changes the encoded shape from absent to [].
-func TestSlice_JSONInsideStructIgnoresOmitempty(t *testing.T) {
-	t.Parallel()
-
-	type holder struct {
-		Points immutable.Slice[point] `json:"points,omitempty"`
-	}
-
-	data, err := json.Marshal(holder{})
-	require.NoError(t, err)
-	require.JSONEq(t, `{"points":[]}`, string(data))
-
-	var back holder
-	require.NoError(t, json.Unmarshal([]byte(`{"points":[{"X":5,"Y":6}]}`), &back))
-	require.Equal(t, []point{{X: 5, Y: 6}}, back.Points.Clone())
+	require.Equal(t, empty, full.Filter(func(int) bool { return false }), "filtered to nothing")
+	require.Equal(t, empty, full.Delete(0, 3), "deleted everything")
+	require.Equal(t, empty, full.Without(0).Without(0).Without(0), "removed one at a time")
+	require.Equal(t, empty, full.Sub(1, 1), "empty range")
+	require.Equal(t, empty, immutable.Compact(empty), "compacted")
+	require.Equal(t, empty, immutable.Collect(empty.Values()), "collected from an empty iterator")
 }
 
 // Slice copies the engine type's name and layout but lives in this package, so SliceElem must
@@ -400,7 +356,8 @@ func TestSlice_DeleteReplaceRepeatChunkCompactFunc(t *testing.T) {
 
 	require.Equal(t, []int{1, 9, 9, 4}, s.Replace(1, 3, 9, 9).Clone())
 	require.Equal(t, []int{1, 4}, s.Replace(1, 3).Clone(), "replace with nothing deletes")
-	require.Equal(t, immutable.SliceOf[int](), s.Replace(0, 4), "replacing all with nothing gives the one empty value")
+	require.Equal(t, immutable.SliceOf[int](), s.Replace(0, 4),
+		"replacing all with nothing gives the one empty value")
 
 	require.Equal(t, []int{1, 2, 1, 2}, immutable.SliceOf(1, 2).Repeat(2).Clone())
 	require.Equal(t, immutable.SliceOf[int](), s.Repeat(0))

--- a/pkg/immutable/slice_test.go
+++ b/pkg/immutable/slice_test.go
@@ -1,6 +1,10 @@
 package immutable_test
 
 import (
+	"reflect"
+	"slices"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/argus-labs/world-engine/pkg/immutable"
@@ -79,6 +83,36 @@ func TestSlice_WithReplacesOneElement(t *testing.T) {
 	require.Equal(t, []int{1, 2, 3}, s.Clone(), "receiver must be unchanged")
 	require.Equal(t, []int{1, 42, 3}, w.Clone())
 	require.Panics(t, func() { s.With(3, 0) })
+}
+
+func TestSlice_WithoutDropsOneElement(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(1, 2, 3)
+	require.Equal(t, []int{2, 3}, s.Without(0).Clone())
+	require.Equal(t, []int{1, 3}, s.Without(1).Clone())
+	require.Equal(t, []int{1, 2}, s.Without(2).Clone())
+	require.Equal(t, []int{1, 2, 3}, s.Clone(), "receiver must be unchanged")
+	require.Equal(t, immutable.SliceOf[int](), immutable.SliceOf(1).Without(0),
+		"dropping the last gives the one empty value")
+	require.Panics(t, func() { s.Without(3) })
+}
+
+func TestSlice_FilterKeepsMatches(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(1, 2, 3, 4)
+	even := func(v int) bool { return v%2 == 0 }
+
+	require.Equal(t, []int{2, 4}, s.Filter(even).Clone())
+	require.Equal(t, []int{1, 2, 3, 4}, s.Clone(), "receiver must be unchanged")
+	require.Equal(t, immutable.SliceOf[int](), s.Filter(func(int) bool { return false }),
+		"dropping all gives the one empty value")
+	require.Equal(t, s.Clone(), s.Filter(func(int) bool { return true }).Clone(), "keeping all keeps order")
+
+	calls := 0
+	s.Filter(func(v int) bool { calls++; return v != 2 })
+	require.Equal(t, 4, calls, "keep runs once per element")
 }
 
 func TestSlice_AllYieldsInOrderAndStopsEarly(t *testing.T) {
@@ -184,4 +218,249 @@ func TestSlice_JSONInsideStructIgnoresOmitempty(t *testing.T) {
 	var back holder
 	require.NoError(t, json.Unmarshal([]byte(`{"points":[{"X":5,"Y":6}]}`), &back))
 	require.Equal(t, []point{{X: 5, Y: 6}}, back.Points.Clone())
+}
+
+// Slice copies the engine type's name and layout but lives in this package, so SliceElem must
+// refuse it.
+//
+//nolint:unused // the field is never read on purpose; only the layout matters
+type Slice[T any] struct{ items []T }
+
+func TestSliceElem(t *testing.T) {
+	t.Parallel()
+
+	elem, ok := immutable.SliceElem(reflect.TypeFor[immutable.Slice[point]]())
+	require.True(t, ok)
+	require.Equal(t, reflect.TypeFor[point](), elem)
+
+	nested, ok := immutable.SliceElem(reflect.TypeFor[immutable.Slice[immutable.Slice[int]]]())
+	require.True(t, ok)
+	require.Equal(t, reflect.TypeFor[immutable.Slice[int]](), nested)
+
+	_, ok = immutable.SliceElem(reflect.TypeFor[[]point]())
+	require.False(t, ok, "a raw slice is not a Slice")
+	_, ok = immutable.SliceElem(reflect.TypeFor[Slice[point]]())
+	require.False(t, ok, "a look-alike from another package is not a Slice")
+	_, ok = immutable.SliceElem(nil)
+	require.False(t, ok)
+}
+
+func TestSlice_ValuesAndBackward(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(1, 2, 3)
+	require.Equal(t, []int{1, 2, 3}, slices.Collect(s.Values()))
+
+	var idx, vals []int
+	for i, v := range s.Backward() {
+		idx, vals = append(idx, i), append(vals, v)
+	}
+	require.Equal(t, []int{2, 1, 0}, idx)
+	require.Equal(t, []int{3, 2, 1}, vals)
+
+	seen := 0
+	for range s.Values() {
+		seen++
+		break
+	}
+	require.Equal(t, 1, seen, "early break")
+}
+
+func TestSlice_Search(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(10, 20, 30)
+	even := func(v int) bool { return v%20 == 0 }
+	require.Equal(t, 1, s.IndexFunc(even))
+	require.Equal(t, -1, s.IndexFunc(func(int) bool { return false }))
+	require.True(t, s.ContainsFunc(even))
+	require.False(t, s.ContainsFunc(func(int) bool { return false }))
+	require.Equal(t, 2, immutable.Index(s, 30))
+	require.Equal(t, -1, immutable.Index(s, 99))
+	require.True(t, immutable.Contains(s, 10))
+	require.False(t, immutable.Contains(s, 99))
+}
+
+func TestSlice_Insert(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(1, 3)
+	require.Equal(t, []int{0, 1, 3}, s.Insert(0, 0).Clone())
+	require.Equal(t, []int{1, 2, 3}, s.Insert(1, 2).Clone())
+	require.Equal(t, []int{1, 3, 4, 5}, s.Insert(2, 4, 5).Clone(), "at Len appends")
+	require.Equal(t, []int{1, 3}, s.Clone(), "receiver must be unchanged")
+	require.Equal(t, s.Clone(), s.Insert(1).Clone(), "no items is a no-op")
+	require.Panics(t, func() { s.Insert(3, 9) })
+	require.Panics(t, func() { s.Insert(-1, 9) })
+}
+
+func TestSlice_Sub(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(1, 2, 3, 4)
+	require.Equal(t, []int{2, 3}, s.Sub(1, 3).Clone())
+	require.Equal(t, []int{1, 2, 3, 4}, s.Sub(0, 4).Clone())
+	require.Equal(t, immutable.SliceOf[int](), s.Sub(2, 2), "empty range gives the one empty value")
+	require.Equal(t, []int{1, 2, 3, 4}, s.Clone(), "receiver must be unchanged")
+	require.Panics(t, func() { s.Sub(0, 5) })
+	require.Panics(t, func() { s.Sub(3, 2) })
+	require.Panics(t, func() { s.Sub(-1, 2) })
+
+	// A Filter result carries spare capacity; Sub must still refuse to read past Len into it.
+	spare := s.Filter(func(v int) bool { return v != 4 })
+	require.Equal(t, 3, spare.Len())
+	require.Panics(t, func() { spare.Sub(0, 4) })
+}
+
+func TestSlice_ReversedAndSorted(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(3, 1, 2)
+	require.Equal(t, []int{2, 1, 3}, s.Reversed().Clone())
+	require.Equal(t, []int{1, 2, 3}, immutable.Sorted(s).Clone())
+	require.Equal(t, []int{3, 2, 1}, s.SortedFunc(func(a, b int) int { return b - a }).Clone())
+	require.Equal(t, []int{3, 1, 2}, s.Clone(), "receiver must be unchanged")
+	require.Equal(t, immutable.SliceOf[int](), immutable.Slice[int]{}.Reversed())
+	require.Equal(t, immutable.SliceOf[int](), immutable.Sorted(immutable.Slice[int]{}))
+
+	// Stable: equal keys keep their original order.
+	byLen := func(a, b string) int { return len(a) - len(b) }
+	got := immutable.SliceOf("bb", "a", "cc", "b").SortedFunc(byLen).Clone()
+	require.Equal(t, []string{"a", "b", "bb", "cc"}, got)
+}
+
+func TestSlice_MapConcatCollectCompact(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(1, 2, 3)
+	require.Equal(t, []string{"1", "2", "3"}, immutable.Map(s, strconv.Itoa).Clone())
+	require.Equal(t, immutable.SliceOf[string](), immutable.Map(immutable.Slice[int]{}, strconv.Itoa))
+
+	require.Equal(t, []int{1, 2, 3, 4, 5}, immutable.Concat(s, immutable.Slice[int]{}, immutable.SliceOf(4, 5)).Clone())
+	require.Equal(t, immutable.SliceOf[int](), immutable.Concat[int]())
+
+	require.Equal(t, []int{1, 2, 3}, immutable.Collect(s.Values()).Clone())
+	require.Equal(t, immutable.SliceOf[int](), immutable.Collect(immutable.Slice[int]{}.Values()))
+
+	dup := immutable.SliceOf(1, 1, 2, 2, 2, 1)
+	require.Equal(t, []int{1, 2, 1}, immutable.Compact(dup).Clone())
+	require.Equal(t, []int{1, 1, 2, 2, 2, 1}, dup.Clone(), "receiver must be unchanged")
+	require.Equal(t, immutable.SliceOf[int](), immutable.Compact(immutable.Slice[int]{}))
+}
+
+func TestSlice_MinMaxAndSortedChecks(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(3, 1, 2)
+	byValue := func(a, b int) int { return a - b }
+	require.Equal(t, 1, immutable.Min(s))
+	require.Equal(t, 3, immutable.Max(s))
+	require.Equal(t, 1, s.MinFunc(byValue))
+	require.Equal(t, 3, s.MaxFunc(byValue))
+	require.Panics(t, func() { immutable.Min(immutable.Slice[int]{}) })
+	require.Panics(t, func() { immutable.Slice[int]{}.MaxFunc(byValue) })
+
+	require.False(t, immutable.IsSorted(s))
+	require.True(t, immutable.IsSorted(immutable.Sorted(s)))
+	require.True(t, s.IsSortedFunc(func(int, int) int { return 0 }), "everything equal counts as sorted")
+}
+
+func TestSlice_BinarySearchAndCompare(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(10, 20, 30)
+	i, found := immutable.BinarySearch(s, 20)
+	require.True(t, found)
+	require.Equal(t, 1, i)
+	i, found = immutable.BinarySearch(s, 25)
+	require.False(t, found)
+	require.Equal(t, 2, i, "insertion point")
+
+	i, found = immutable.BinarySearchFunc(s, "30", func(e int, target string) int {
+		return strings.Compare(strconv.Itoa(e), target)
+	})
+	require.True(t, found)
+	require.Equal(t, 2, i)
+
+	require.Equal(t, 0, immutable.Compare(s, immutable.SliceOf(10, 20, 30)))
+	require.Equal(t, -1, immutable.Compare(s, immutable.SliceOf(10, 20, 31)))
+	require.Equal(t, 1, immutable.Compare(s, immutable.SliceOf(10, 20)), "longer wins when the prefix ties")
+	require.Equal(t, 0, immutable.CompareFunc(s, immutable.SliceOf("10", "20", "30"),
+		func(e int, o string) int { return strings.Compare(strconv.Itoa(e), o) }))
+}
+
+func TestSlice_DeleteReplaceRepeatChunkCompactFunc(t *testing.T) {
+	t.Parallel()
+
+	s := immutable.SliceOf(1, 2, 3, 4)
+	require.Equal(t, []int{1, 4}, s.Delete(1, 3).Clone())
+	require.Equal(t, s.Clone(), s.Delete(2, 2).Clone(), "empty range is a no-op")
+	require.Equal(t, immutable.SliceOf[int](), s.Delete(0, 4), "deleting all gives the one empty value")
+	require.Panics(t, func() { s.Delete(3, 5) })
+
+	require.Equal(t, []int{1, 9, 9, 4}, s.Replace(1, 3, 9, 9).Clone())
+	require.Equal(t, []int{1, 4}, s.Replace(1, 3).Clone(), "replace with nothing deletes")
+	require.Equal(t, immutable.SliceOf[int](), s.Replace(0, 4), "replacing all with nothing gives the one empty value")
+
+	require.Equal(t, []int{1, 2, 1, 2}, immutable.SliceOf(1, 2).Repeat(2).Clone())
+	require.Equal(t, immutable.SliceOf[int](), s.Repeat(0))
+	require.Panics(t, func() { s.Repeat(-1) })
+
+	var chunks [][]int
+	for part := range s.Chunk(3) {
+		chunks = append(chunks, part.Clone())
+	}
+	require.Equal(t, [][]int{{1, 2, 3}, {4}}, chunks)
+	require.Panics(t, func() { s.Chunk(0) })
+
+	sameParity := func(a, b int) bool { return a%2 == b%2 }
+	require.Equal(t, []int{1, 2, 3}, immutable.SliceOf(1, 1, 2, 2, 3).CompactFunc(sameParity).Clone())
+	require.Equal(t, []int{1, 2, 3, 4}, s.Clone(), "receiver must be unchanged")
+}
+
+// TestSlice_DerivationsNeverWriteSharedBacking is the guarantee the type exists for, checked across
+// every derivation at once: none of them may write into a backing array another Slice can see.
+//
+// The base is built with Delete, which leaves spare capacity (length 2, capacity 4). That is the
+// shape the hazard needs: a derivation implemented as append(s.items, ...) would write into the
+// spare room instead of allocating, so two derivations from one base would land on the same memory
+// and the second would silently rewrite the first. Every result is computed before any is checked,
+// so cross-contamination in either direction fails here.
+func TestSlice_DerivationsNeverWriteSharedBacking(t *testing.T) {
+	t.Parallel()
+
+	base := immutable.SliceOf(1, 2, 3, 4).Delete(1, 3)
+	require.Equal(t, []int{1, 4}, base.Clone())
+
+	cases := []struct {
+		name   string
+		derive func() immutable.Slice[int]
+		want   []int
+	}{
+		{"Append", func() immutable.Slice[int] { return base.Append(9) }, []int{1, 4, 9}},
+		{"Insert", func() immutable.Slice[int] { return base.Insert(1, 8) }, []int{1, 8, 4}},
+		{"With", func() immutable.Slice[int] { return base.With(0, 7) }, []int{7, 4}},
+		{"Without", func() immutable.Slice[int] { return base.Without(0) }, []int{4}},
+		{"Filter", func() immutable.Slice[int] { return base.Filter(func(v int) bool { return v == 4 }) }, []int{4}},
+		{"Delete", func() immutable.Slice[int] { return base.Delete(0, 1) }, []int{4}},
+		{"Replace", func() immutable.Slice[int] { return base.Replace(0, 1, 6, 6) }, []int{6, 6, 4}},
+		{"Sub", func() immutable.Slice[int] { return base.Sub(0, 1) }, []int{1}},
+		{"Reversed", base.Reversed, []int{4, 1}},
+		{"SortedFunc", func() immutable.Slice[int] {
+			return base.SortedFunc(func(a, b int) int { return b - a })
+		}, []int{4, 1}},
+		{"CompactFunc", func() immutable.Slice[int] {
+			return base.CompactFunc(func(int, int) bool { return true })
+		}, []int{1}},
+		{"Repeat", func() immutable.Slice[int] { return base.Repeat(2) }, []int{1, 4, 1, 4}},
+	}
+
+	got := make([]immutable.Slice[int], len(cases))
+	for i, c := range cases {
+		got[i] = c.derive()
+	}
+	for i, c := range cases {
+		require.Equal(t, c.want, got[i].Clone(), "%s was rewritten by a later derivation", c.name)
+	}
+	require.Equal(t, []int{1, 4}, base.Clone(), "the base must survive every derivation")
 }

--- a/pkg/immutable/slice_test.go
+++ b/pkg/immutable/slice_test.go
@@ -79,36 +79,49 @@ func TestSlice_WithReplacesOneElement(t *testing.T) {
 	s := immutable.SliceOf(1, 2, 3)
 	w := s.With(1, 42)
 
-	require.Equal(t, []int{1, 2, 3}, s.Clone(), "receiver must be unchanged")
 	require.Equal(t, []int{1, 42, 3}, w.Clone())
-	require.Panics(t, func() { s.With(3, 0) })
+	require.Equal(t, []int{1, 42, 3}, s.Clone(), "With writes through to the receiver")
+	require.Panics(t, func() { immutable.SliceOf(1, 2, 3).With(3, 0) })
 }
 
 func TestSlice_WithoutDropsOneElement(t *testing.T) {
 	t.Parallel()
 
-	s := immutable.SliceOf(1, 2, 3)
-	require.Equal(t, []int{2, 3}, s.Without(0).Clone())
-	require.Equal(t, []int{1, 3}, s.Without(1).Clone())
-	require.Equal(t, []int{1, 2}, s.Without(2).Clone())
-	require.Equal(t, []int{1, 2, 3}, s.Clone(), "receiver must be unchanged")
+	// Each case starts from a fresh receiver: Without writes through, so reusing one would feed the
+	// next case a shrunken list.
+	fresh := func() immutable.Slice[int] { return immutable.SliceOf(1, 2, 3) }
+	require.Equal(t, []int{2, 3}, fresh().Without(0).Clone())
+	require.Equal(t, []int{1, 3}, fresh().Without(1).Clone())
+	require.Equal(t, []int{1, 2}, fresh().Without(2).Clone())
 	require.Equal(t, 0, immutable.SliceOf(1).Without(0).Len(), "dropping the last leaves it empty")
-	require.Panics(t, func() { s.Without(3) })
+	require.Panics(t, func() { fresh().Without(3) })
+
+	s := fresh()
+	s.Without(0)
+	require.Equal(t, []int{2, 3, 0}, s.Clone(),
+		"Without writes through: the receiver keeps its length over a zero-filled tail")
 }
 
 func TestSlice_FilterKeepsMatches(t *testing.T) {
 	t.Parallel()
 
-	s := immutable.SliceOf(1, 2, 3, 4)
+	// Each case starts from a fresh receiver: Filter writes through, so reusing one would feed the
+	// next case a shrunken list.
+	fresh := func() immutable.Slice[int] { return immutable.SliceOf(1, 2, 3, 4) }
 	even := func(v int) bool { return v%2 == 0 }
 
-	require.Equal(t, []int{2, 4}, s.Filter(even).Clone())
-	require.Equal(t, []int{1, 2, 3, 4}, s.Clone(), "receiver must be unchanged")
-	require.Equal(t, 0, s.Filter(func(int) bool { return false }).Len(), "dropping all leaves it empty")
-	require.Equal(t, s.Clone(), s.Filter(func(int) bool { return true }).Clone(), "keeping all keeps order")
+	require.Equal(t, []int{2, 4}, fresh().Filter(even).Clone())
+	require.Equal(t, 0, fresh().Filter(func(int) bool { return false }).Len(), "dropping all leaves it empty")
+	require.Equal(t, []int{1, 2, 3, 4}, fresh().Filter(func(int) bool { return true }).Clone(),
+		"keeping all keeps order")
+
+	s := fresh()
+	s.Filter(even)
+	require.Equal(t, []int{2, 4, 0, 0}, s.Clone(),
+		"Filter writes through: the receiver keeps its length over a zero-filled tail")
 
 	calls := 0
-	s.Filter(func(v int) bool { calls++; return v != 2 })
+	fresh().Filter(func(v int) bool { calls++; return v != 2 })
 	require.Equal(t, 4, calls, "keep runs once per element")
 }
 
@@ -240,14 +253,15 @@ func TestSlice_Search(t *testing.T) {
 func TestSlice_Insert(t *testing.T) {
 	t.Parallel()
 
-	s := immutable.SliceOf(1, 3)
-	require.Equal(t, []int{0, 1, 3}, s.Insert(0, 0).Clone())
-	require.Equal(t, []int{1, 2, 3}, s.Insert(1, 2).Clone())
-	require.Equal(t, []int{1, 3, 4, 5}, s.Insert(2, 4, 5).Clone(), "at Len appends")
-	require.Equal(t, []int{1, 3}, s.Clone(), "receiver must be unchanged")
-	require.Equal(t, s.Clone(), s.Insert(1).Clone(), "no items is a no-op")
-	require.Panics(t, func() { s.Insert(3, 9) })
-	require.Panics(t, func() { s.Insert(-1, 9) })
+	// Insert writes through when the receiver has the spare capacity to hold the result and
+	// allocates otherwise, so every case starts from a fresh receiver rather than reusing one.
+	fresh := func() immutable.Slice[int] { return immutable.SliceOf(1, 3) }
+	require.Equal(t, []int{0, 1, 3}, fresh().Insert(0, 0).Clone())
+	require.Equal(t, []int{1, 2, 3}, fresh().Insert(1, 2).Clone())
+	require.Equal(t, []int{1, 3, 4, 5}, fresh().Insert(2, 4, 5).Clone(), "at Len appends")
+	require.Equal(t, []int{1, 3}, fresh().Insert(1).Clone(), "no items is a no-op")
+	require.Panics(t, func() { fresh().Insert(3, 9) })
+	require.Panics(t, func() { fresh().Insert(-1, 9) })
 }
 
 func TestSlice_Sub(t *testing.T) {
@@ -257,13 +271,14 @@ func TestSlice_Sub(t *testing.T) {
 	require.Equal(t, []int{2, 3}, s.Sub(1, 3).Clone())
 	require.Equal(t, []int{1, 2, 3, 4}, s.Sub(0, 4).Clone())
 	require.Equal(t, 0, s.Sub(2, 2).Len(), "empty range")
-	require.Equal(t, []int{1, 2, 3, 4}, s.Clone(), "receiver must be unchanged")
+	require.Equal(t, []int{1, 2, 3, 4}, s.Clone(), "Sub is the one derivation that writes nothing")
 	require.Panics(t, func() { s.Sub(0, 5) })
 	require.Panics(t, func() { s.Sub(3, 2) })
 	require.Panics(t, func() { s.Sub(-1, 2) })
 
-	// A Filter result carries spare capacity; Sub must still refuse to read past Len into it.
-	spare := s.Filter(func(v int) bool { return v != 4 })
+	// A Filter result carries spare capacity; Sub must still refuse to read past Len into it. It
+	// derives from its own slice because Filter writes through.
+	spare := immutable.SliceOf(1, 2, 3, 4).Filter(func(v int) bool { return v != 4 })
 	require.Equal(t, 3, spare.Len())
 	require.Panics(t, func() { spare.Sub(0, 4) })
 }
@@ -271,13 +286,21 @@ func TestSlice_Sub(t *testing.T) {
 func TestSlice_ReversedAndSorted(t *testing.T) {
 	t.Parallel()
 
-	s := immutable.SliceOf(3, 1, 2)
-	require.Equal(t, []int{2, 1, 3}, s.Reversed().Clone())
-	require.Equal(t, []int{1, 2, 3}, immutable.Sorted(s).Clone())
-	require.Equal(t, []int{3, 2, 1}, s.SortedFunc(func(a, b int) int { return b - a }).Clone())
-	require.Equal(t, []int{3, 1, 2}, s.Clone(), "receiver must be unchanged")
+	// Both reorder in place, so every case starts from a fresh receiver.
+	fresh := func() immutable.Slice[int] { return immutable.SliceOf(3, 1, 2) }
+	require.Equal(t, []int{2, 1, 3}, fresh().Reversed().Clone())
+	require.Equal(t, []int{1, 2, 3}, immutable.Sorted(fresh()).Clone())
+	require.Equal(t, []int{3, 2, 1}, fresh().SortedFunc(func(a, b int) int { return b - a }).Clone())
 	require.Equal(t, 0, immutable.Slice[int]{}.Reversed().Len())
 	require.Equal(t, 0, immutable.Sorted(immutable.Slice[int]{}).Len())
+
+	s := fresh()
+	s.Reversed()
+	require.Equal(t, []int{2, 1, 3}, s.Clone(), "Reversed writes through to the receiver")
+
+	s = fresh()
+	immutable.Sorted(s)
+	require.Equal(t, []int{1, 2, 3}, s.Clone(), "Sorted writes through to the receiver")
 
 	// Stable: equal keys keep their original order.
 	byLen := func(a, b string) int { return len(a) - len(b) }
@@ -300,7 +323,8 @@ func TestSlice_MapConcatCollectCompact(t *testing.T) {
 
 	dup := immutable.SliceOf(1, 1, 2, 2, 2, 1)
 	require.Equal(t, []int{1, 2, 1}, immutable.Compact(dup).Clone())
-	require.Equal(t, []int{1, 1, 2, 2, 2, 1}, dup.Clone(), "receiver must be unchanged")
+	require.Equal(t, []int{1, 2, 1, 0, 0, 0}, dup.Clone(),
+		"Compact writes through: the receiver keeps its length over a zero-filled tail")
 	require.Equal(t, 0, immutable.Compact(immutable.Slice[int]{}).Len())
 }
 
@@ -348,75 +372,104 @@ func TestSlice_BinarySearchAndCompare(t *testing.T) {
 func TestSlice_DeleteReplaceRepeatChunkCompactFunc(t *testing.T) {
 	t.Parallel()
 
-	s := immutable.SliceOf(1, 2, 3, 4)
-	require.Equal(t, []int{1, 4}, s.Delete(1, 3).Clone())
-	require.Equal(t, s.Clone(), s.Delete(2, 2).Clone(), "empty range is a no-op")
-	require.Equal(t, 0, s.Delete(0, 4).Len(), "deleting all leaves it empty")
-	require.Panics(t, func() { s.Delete(3, 5) })
+	// Delete, Replace and CompactFunc all reach the receiver, so every case starts from a fresh one.
+	fresh := func() immutable.Slice[int] { return immutable.SliceOf(1, 2, 3, 4) }
+	require.Equal(t, []int{1, 4}, fresh().Delete(1, 3).Clone())
+	require.Equal(t, []int{1, 2, 3, 4}, fresh().Delete(2, 2).Clone(), "empty range is a no-op")
+	require.Equal(t, 0, fresh().Delete(0, 4).Len(), "deleting all leaves it empty")
+	require.Panics(t, func() { fresh().Delete(3, 5) })
 
-	require.Equal(t, []int{1, 9, 9, 4}, s.Replace(1, 3, 9, 9).Clone())
-	require.Equal(t, []int{1, 4}, s.Replace(1, 3).Clone(), "replace with nothing deletes")
-	require.Equal(t, 0, s.Replace(0, 4).Len(), "replacing all with nothing leaves it empty")
+	s := fresh()
+	s.Delete(1, 3)
+	require.Equal(t, []int{1, 4, 0, 0}, s.Clone(),
+		"Delete writes through: the receiver keeps its length over a zero-filled tail")
+
+	require.Equal(t, []int{1, 9, 9, 4}, fresh().Replace(1, 3, 9, 9).Clone())
+	require.Equal(t, []int{1, 4}, fresh().Replace(1, 3).Clone(), "replace with nothing deletes")
+	require.Equal(t, 0, fresh().Replace(0, 4).Len(), "replacing all with nothing leaves it empty")
 
 	require.Equal(t, []int{1, 2, 1, 2}, immutable.SliceOf(1, 2).Repeat(2).Clone())
-	require.Equal(t, 0, s.Repeat(0).Len())
-	require.Panics(t, func() { s.Repeat(-1) })
+	require.Equal(t, 0, fresh().Repeat(0).Len())
+	require.Panics(t, func() { fresh().Repeat(-1) })
 
 	var chunks [][]int
-	for part := range s.Chunk(3) {
+	for part := range fresh().Chunk(3) {
 		chunks = append(chunks, part.Clone())
 	}
 	require.Equal(t, [][]int{{1, 2, 3}, {4}}, chunks)
-	require.Panics(t, func() { s.Chunk(0) })
+	require.Panics(t, func() { fresh().Chunk(0) })
 
 	sameParity := func(a, b int) bool { return a%2 == b%2 }
 	require.Equal(t, []int{1, 2, 3}, immutable.SliceOf(1, 1, 2, 2, 3).CompactFunc(sameParity).Clone())
-	require.Equal(t, []int{1, 2, 3, 4}, s.Clone(), "receiver must be unchanged")
+
+	c := immutable.SliceOf(1, 1, 2, 2, 3)
+	c.CompactFunc(sameParity)
+	require.Equal(t, []int{1, 2, 3, 0, 0}, c.Clone(),
+		"CompactFunc writes through: the receiver keeps its length over a zero-filled tail")
 }
 
-// TestSlice_DerivationsNeverWriteSharedBacking is the guarantee the type exists for, checked across
-// every derivation at once: none of them may write into a backing array another Slice can see.
+// TestSlice_DerivationsWriteThrough pins, for every derivation at once, whether it reaches the
+// receiver's backing array. Review removed the copy from each one that can finish in place, so this
+// table is the contract callers work against rather than an implementation detail: derive, then Set,
+// and Clone first when the original has to survive.
 //
-// The base is built with Delete, which leaves spare capacity (length 2, capacity 4). That is the
-// shape the hazard needs: a derivation implemented as append(s.items, ...) would write into the
-// spare room instead of allocating, so two derivations from one base would land on the same memory
-// and the second would silently rewrite the first. Every result is computed before any is checked,
-// so cross-contamination in either direction fails here.
-func TestSlice_DerivationsNeverWriteSharedBacking(t *testing.T) {
+// The base has length 4 and no spare capacity, so the ops that grow past it are forced to allocate
+// and leave the receiver alone. Give one spare room and Insert and Replace write through too, which
+// is why their docs promise nothing either way.
+func TestSlice_DerivationsWriteThrough(t *testing.T) {
 	t.Parallel()
 
-	base := immutable.SliceOf(1, 2, 3, 4).Delete(1, 3)
-	require.Equal(t, []int{1, 4}, base.Clone())
+	base := func() immutable.Slice[int] { return immutable.SliceOf(1, 2, 3, 4) }
 
 	cases := []struct {
-		name   string
-		derive func() immutable.Slice[int]
-		want   []int
+		name     string
+		derive   func(immutable.Slice[int]) immutable.Slice[int]
+		want     []int
+		receiver []int // the receiver as it stands after the derivation
 	}{
-		{"Append", func() immutable.Slice[int] { return base.Append(9) }, []int{1, 4, 9}},
-		{"Insert", func() immutable.Slice[int] { return base.Insert(1, 8) }, []int{1, 8, 4}},
-		{"With", func() immutable.Slice[int] { return base.With(0, 7) }, []int{7, 4}},
-		{"Reversed", base.Reversed, []int{4, 1}},
-		{"SortedFunc", func() immutable.Slice[int] {
-			return base.SortedFunc(func(a, b int) int { return b - a })
-		}, []int{4, 1}},
-		{"Without", func() immutable.Slice[int] { return base.Without(0) }, []int{4}},
-		{"Filter", func() immutable.Slice[int] { return base.Filter(func(v int) bool { return v == 4 }) }, []int{4}},
-		{"Delete", func() immutable.Slice[int] { return base.Delete(0, 1) }, []int{4}},
-		{"Replace", func() immutable.Slice[int] { return base.Replace(0, 1, 6, 6) }, []int{6, 6, 4}},
-		{"Sub", func() immutable.Slice[int] { return base.Sub(0, 1) }, []int{1}},
-		{"CompactFunc", func() immutable.Slice[int] {
-			return base.CompactFunc(func(int, int) bool { return true })
-		}, []int{1}},
-		{"Repeat", func() immutable.Slice[int] { return base.Repeat(2) }, []int{1, 4, 1, 4}},
+		// Allocate a new array, so the receiver survives.
+		{"Append", func(s immutable.Slice[int]) immutable.Slice[int] { return s.Append(9) },
+			[]int{1, 2, 3, 4, 9}, []int{1, 2, 3, 4}},
+		{"Insert", func(s immutable.Slice[int]) immutable.Slice[int] { return s.Insert(1, 8) },
+			[]int{1, 8, 2, 3, 4}, []int{1, 2, 3, 4}},
+		{"Replace", func(s immutable.Slice[int]) immutable.Slice[int] { return s.Replace(0, 1, 6, 6) },
+			[]int{6, 6, 2, 3, 4}, []int{1, 2, 3, 4}},
+		{"Repeat", func(s immutable.Slice[int]) immutable.Slice[int] { return s.Repeat(2) },
+			[]int{1, 2, 3, 4, 1, 2, 3, 4}, []int{1, 2, 3, 4}},
+
+		// Read-only window: writes nothing, but shares the array it reads.
+		{"Sub", func(s immutable.Slice[int]) immutable.Slice[int] { return s.Sub(0, 1) },
+			[]int{1}, []int{1, 2, 3, 4}},
+
+		// Reorder in place.
+		{"With", func(s immutable.Slice[int]) immutable.Slice[int] { return s.With(0, 7) },
+			[]int{7, 2, 3, 4}, []int{7, 2, 3, 4}},
+		{"Reversed", immutable.Slice[int].Reversed,
+			[]int{4, 3, 2, 1}, []int{4, 3, 2, 1}},
+		{"SortedFunc", func(s immutable.Slice[int]) immutable.Slice[int] {
+			return s.SortedFunc(func(a, b int) int { return b - a })
+		}, []int{4, 3, 2, 1}, []int{4, 3, 2, 1}},
+
+		// Shrink in place, leaving the receiver long over a zero-filled tail.
+		{"Without", func(s immutable.Slice[int]) immutable.Slice[int] { return s.Without(0) },
+			[]int{2, 3, 4}, []int{2, 3, 4, 0}},
+		{"Filter", func(s immutable.Slice[int]) immutable.Slice[int] {
+			return s.Filter(func(v int) bool { return v == 4 })
+		}, []int{4}, []int{4, 0, 0, 0}},
+		{"Delete", func(s immutable.Slice[int]) immutable.Slice[int] { return s.Delete(0, 1) },
+			[]int{2, 3, 4}, []int{2, 3, 4, 0}},
+		{"CompactFunc", func(s immutable.Slice[int]) immutable.Slice[int] {
+			return s.CompactFunc(func(int, int) bool { return true })
+		}, []int{1}, []int{1, 0, 0, 0}},
 	}
 
-	got := make([]immutable.Slice[int], len(cases))
-	for i, c := range cases {
-		got[i] = c.derive()
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+
+			s := base()
+			require.Equal(t, c.want, c.derive(s).Clone(), "result")
+			require.Equal(t, c.receiver, s.Clone(), "receiver after %s", c.name)
+		})
 	}
-	for i, c := range cases {
-		require.Equal(t, c.want, got[i].Clone(), "%s was rewritten by a later derivation", c.name)
-	}
-	require.Equal(t, []int{1, 4}, base.Clone(), "the base must survive every derivation")
 }

--- a/pkg/immutable/slice_test.go
+++ b/pkg/immutable/slice_test.go
@@ -92,8 +92,7 @@ func TestSlice_WithoutDropsOneElement(t *testing.T) {
 	require.Equal(t, []int{1, 3}, s.Without(1).Clone())
 	require.Equal(t, []int{1, 2}, s.Without(2).Clone())
 	require.Equal(t, []int{1, 2, 3}, s.Clone(), "receiver must be unchanged")
-	require.Equal(t, immutable.SliceOf[int](), immutable.SliceOf(1).Without(0),
-		"dropping the last gives the one empty value")
+	require.Equal(t, 0, immutable.SliceOf(1).Without(0).Len(), "dropping the last leaves it empty")
 	require.Panics(t, func() { s.Without(3) })
 }
 
@@ -105,8 +104,7 @@ func TestSlice_FilterKeepsMatches(t *testing.T) {
 
 	require.Equal(t, []int{2, 4}, s.Filter(even).Clone())
 	require.Equal(t, []int{1, 2, 3, 4}, s.Clone(), "receiver must be unchanged")
-	require.Equal(t, immutable.SliceOf[int](), s.Filter(func(int) bool { return false }),
-		"dropping all gives the one empty value")
+	require.Equal(t, 0, s.Filter(func(int) bool { return false }).Len(), "dropping all leaves it empty")
 	require.Equal(t, s.Clone(), s.Filter(func(int) bool { return true }).Clone(), "keeping all keeps order")
 
 	calls := 0
@@ -155,25 +153,27 @@ func TestEqual(t *testing.T) {
 	require.True(t, immutable.Equal(immutable.Slice[int]{}, immutable.SliceOf[int]()), "empty equals empty")
 }
 
-// Every empty Slice must be the same value however it was produced: reflect.DeepEqual, and so
-// require.Equal on a whole component, must not tell them apart. Only the zero value is naturally
-// nil — the stdlib helpers behind these derivations all hand back an empty but non-nil slice, so
-// each one relies on wrap to canonicalise it.
-func TestSlice_EmptyIsOneValue(t *testing.T) {
+// Empty Slices are not interchangeable under reflect.DeepEqual, and that is the deliberate trade:
+// a derivation that empties one leaves its backing array allocated, while the zero value has none.
+// Equal compares elements and agrees with slices.Equal that nil and empty are the same list, so that
+// is what comparisons go through.
+//
+// The case this used to protect — a component restored from a snapshot versus one built fresh — is
+// handled on the decode side instead: the generated FromProto leaves an empty repeated field as the
+// zero value rather than building an allocated empty.
+func TestSlice_EmptyComparison(t *testing.T) {
 	t.Parallel()
 
-	empty := immutable.SliceOf[int]()
-	full := immutable.SliceOf(1, 2, 3)
+	zero := immutable.Slice[int]{}
+	built := immutable.SliceOf[int]()
+	derived := immutable.SliceOf(1, 2, 3).Filter(func(int) bool { return false })
 
-	require.Equal(t, immutable.Slice[int]{}, empty, "zero value")
-	require.Equal(t, empty, immutable.SliceOf([]int{}...), "built from an empty non-nil slice")
-	require.Equal(t, empty, empty.Append(), "empty append")
-	require.Equal(t, empty, full.Filter(func(int) bool { return false }), "filtered to nothing")
-	require.Equal(t, empty, full.Delete(0, 3), "deleted everything")
-	require.Equal(t, empty, full.Without(0).Without(0).Without(0), "removed one at a time")
-	require.Equal(t, empty, full.Sub(1, 1), "empty range")
-	require.Equal(t, empty, immutable.Compact(empty), "compacted")
-	require.Equal(t, empty, immutable.Collect(empty.Values()), "collected from an empty iterator")
+	require.Equal(t, 0, derived.Len())
+	require.True(t, immutable.Equal(zero, built), "Equal compares elements")
+	require.True(t, immutable.Equal(zero, derived), "Equal compares elements")
+	require.True(t, zero.EqualFunc(derived, func(a, b int) bool { return a == b }))
+
+	require.NotEqual(t, zero, derived, "use Equal, not require.Equal, on a possibly-empty Slice")
 }
 
 // Slice copies the engine type's name and layout but lives in this package, so SliceElem must
@@ -256,7 +256,7 @@ func TestSlice_Sub(t *testing.T) {
 	s := immutable.SliceOf(1, 2, 3, 4)
 	require.Equal(t, []int{2, 3}, s.Sub(1, 3).Clone())
 	require.Equal(t, []int{1, 2, 3, 4}, s.Sub(0, 4).Clone())
-	require.Equal(t, immutable.SliceOf[int](), s.Sub(2, 2), "empty range gives the one empty value")
+	require.Equal(t, 0, s.Sub(2, 2).Len(), "empty range")
 	require.Equal(t, []int{1, 2, 3, 4}, s.Clone(), "receiver must be unchanged")
 	require.Panics(t, func() { s.Sub(0, 5) })
 	require.Panics(t, func() { s.Sub(3, 2) })
@@ -276,8 +276,8 @@ func TestSlice_ReversedAndSorted(t *testing.T) {
 	require.Equal(t, []int{1, 2, 3}, immutable.Sorted(s).Clone())
 	require.Equal(t, []int{3, 2, 1}, s.SortedFunc(func(a, b int) int { return b - a }).Clone())
 	require.Equal(t, []int{3, 1, 2}, s.Clone(), "receiver must be unchanged")
-	require.Equal(t, immutable.SliceOf[int](), immutable.Slice[int]{}.Reversed())
-	require.Equal(t, immutable.SliceOf[int](), immutable.Sorted(immutable.Slice[int]{}))
+	require.Equal(t, 0, immutable.Slice[int]{}.Reversed().Len())
+	require.Equal(t, 0, immutable.Sorted(immutable.Slice[int]{}).Len())
 
 	// Stable: equal keys keep their original order.
 	byLen := func(a, b string) int { return len(a) - len(b) }
@@ -290,18 +290,18 @@ func TestSlice_MapConcatCollectCompact(t *testing.T) {
 
 	s := immutable.SliceOf(1, 2, 3)
 	require.Equal(t, []string{"1", "2", "3"}, immutable.Map(s, strconv.Itoa).Clone())
-	require.Equal(t, immutable.SliceOf[string](), immutable.Map(immutable.Slice[int]{}, strconv.Itoa))
+	require.Equal(t, 0, immutable.Map(immutable.Slice[int]{}, strconv.Itoa).Len())
 
 	require.Equal(t, []int{1, 2, 3, 4, 5}, immutable.Concat(s, immutable.Slice[int]{}, immutable.SliceOf(4, 5)).Clone())
-	require.Equal(t, immutable.SliceOf[int](), immutable.Concat[int]())
+	require.Equal(t, 0, immutable.Concat[int]().Len())
 
 	require.Equal(t, []int{1, 2, 3}, immutable.Collect(s.Values()).Clone())
-	require.Equal(t, immutable.SliceOf[int](), immutable.Collect(immutable.Slice[int]{}.Values()))
+	require.Equal(t, 0, immutable.Collect(immutable.Slice[int]{}.Values()).Len())
 
 	dup := immutable.SliceOf(1, 1, 2, 2, 2, 1)
 	require.Equal(t, []int{1, 2, 1}, immutable.Compact(dup).Clone())
 	require.Equal(t, []int{1, 1, 2, 2, 2, 1}, dup.Clone(), "receiver must be unchanged")
-	require.Equal(t, immutable.SliceOf[int](), immutable.Compact(immutable.Slice[int]{}))
+	require.Equal(t, 0, immutable.Compact(immutable.Slice[int]{}).Len())
 }
 
 func TestSlice_MinMaxAndSortedChecks(t *testing.T) {
@@ -351,16 +351,15 @@ func TestSlice_DeleteReplaceRepeatChunkCompactFunc(t *testing.T) {
 	s := immutable.SliceOf(1, 2, 3, 4)
 	require.Equal(t, []int{1, 4}, s.Delete(1, 3).Clone())
 	require.Equal(t, s.Clone(), s.Delete(2, 2).Clone(), "empty range is a no-op")
-	require.Equal(t, immutable.SliceOf[int](), s.Delete(0, 4), "deleting all gives the one empty value")
+	require.Equal(t, 0, s.Delete(0, 4).Len(), "deleting all leaves it empty")
 	require.Panics(t, func() { s.Delete(3, 5) })
 
 	require.Equal(t, []int{1, 9, 9, 4}, s.Replace(1, 3, 9, 9).Clone())
 	require.Equal(t, []int{1, 4}, s.Replace(1, 3).Clone(), "replace with nothing deletes")
-	require.Equal(t, immutable.SliceOf[int](), s.Replace(0, 4),
-		"replacing all with nothing gives the one empty value")
+	require.Equal(t, 0, s.Replace(0, 4).Len(), "replacing all with nothing leaves it empty")
 
 	require.Equal(t, []int{1, 2, 1, 2}, immutable.SliceOf(1, 2).Repeat(2).Clone())
-	require.Equal(t, immutable.SliceOf[int](), s.Repeat(0))
+	require.Equal(t, 0, s.Repeat(0).Len())
 	require.Panics(t, func() { s.Repeat(-1) })
 
 	var chunks [][]int
@@ -397,15 +396,15 @@ func TestSlice_DerivationsNeverWriteSharedBacking(t *testing.T) {
 		{"Append", func() immutable.Slice[int] { return base.Append(9) }, []int{1, 4, 9}},
 		{"Insert", func() immutable.Slice[int] { return base.Insert(1, 8) }, []int{1, 8, 4}},
 		{"With", func() immutable.Slice[int] { return base.With(0, 7) }, []int{7, 4}},
+		{"Reversed", base.Reversed, []int{4, 1}},
+		{"SortedFunc", func() immutable.Slice[int] {
+			return base.SortedFunc(func(a, b int) int { return b - a })
+		}, []int{4, 1}},
 		{"Without", func() immutable.Slice[int] { return base.Without(0) }, []int{4}},
 		{"Filter", func() immutable.Slice[int] { return base.Filter(func(v int) bool { return v == 4 }) }, []int{4}},
 		{"Delete", func() immutable.Slice[int] { return base.Delete(0, 1) }, []int{4}},
 		{"Replace", func() immutable.Slice[int] { return base.Replace(0, 1, 6, 6) }, []int{6, 6, 4}},
 		{"Sub", func() immutable.Slice[int] { return base.Sub(0, 1) }, []int{1}},
-		{"Reversed", base.Reversed, []int{4, 1}},
-		{"SortedFunc", func() immutable.Slice[int] {
-			return base.SortedFunc(func(a, b int) int { return b - a })
-		}, []int{4, 1}},
 		{"CompactFunc", func() immutable.Slice[int] {
 			return base.CompactFunc(func(int, int) bool { return true })
 		}, []int{1}},

--- a/pkg/immutable/slice_test.go
+++ b/pkg/immutable/slice_test.go
@@ -113,6 +113,15 @@ func TestSlice_EqualFunc(t *testing.T) {
 	require.True(t, immutable.Slice[int]{}.EqualFunc(immutable.SliceOf[int](), eq), "empty equals empty")
 }
 
+func TestEqual(t *testing.T) {
+	t.Parallel()
+
+	require.True(t, immutable.Equal(immutable.SliceOf(1, 2, 3), immutable.SliceOf(1, 2, 3)))
+	require.False(t, immutable.Equal(immutable.SliceOf(1, 2, 3), immutable.SliceOf(1, 2)), "different length")
+	require.False(t, immutable.Equal(immutable.SliceOf(1, 2, 3), immutable.SliceOf(1, 2, 4)), "different element")
+	require.True(t, immutable.Equal(immutable.Slice[int]{}, immutable.SliceOf[int]()), "empty equals empty")
+}
+
 func TestSlice_JSONRoundTrip(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Why

A component column stores values and `Get` hands back a copy, but a raw `[]T` inside that copy still shares its backing array with the column. Writing through it changes the live world without a `Set`, which breaks the rule that snapshots only ever hold state that went through `Set`. The world CLI's generator now refuses pointers, maps, plain slices and interfaces in wire types for this reason, and physics genuinely needs unbounded lists (active contact pairs, chain points).

`immutable.Slice[T]` is the sanctioned answer: on the wire it is the same `repeated` field a `[]T` would be, but nothing can write through it, so a column copy sharing memory with the live world is harmless and `Get` stays zero-copy.

## What

- **`pkg/immutable`** — `Slice[T]`, a struct with one unexported backing slice. Constructors copy their input (`SliceOf`), readers return copies (`Len`, `At`, `All`, `Clone`), derivers return a new value (`Append`, `With`), plus `EqualFunc` and JSON as a plain array. There are no in-place mutators; to change one you derive a new Slice and `Set` the component. Every empty Slice is one value, so `reflect.DeepEqual` / `require.Equal` never see a phantom difference between `SliceOf()` and a decoded `[]`.
- **DST** — the random command filler recognises a Slice field and fills it through `UnmarshalJSON`, so commands that carry lists are fuzzed instead of always arriving empty.
- **Docs** — `cardinal/ecs.mdx` gains "What a Component May Hold" (the value-only rule, fixed array + count for bounded lists) and "Lists Without a Bound: `immutable.Slice`" (derive-then-`Set`). `cardinal/snapshots.mdx` cross-references it.

## Not in this PR

- No component in this repo uses `Slice` yet. The physics2d migration (`ActiveContacts.Pairs`, `PhysicsBody2D.Shapes`, `ColliderShape.Vertices` / `ChainPoints`) follows once a CLI with generator support is released — generation is all-or-nothing per package, so all four convert together.
- Generator support (recognise `immutable.Slice[T]`, emit `All` / `SliceOf`, refuse pointers etc. inside it) lives in go-ecs: <link to sdkgen PR>.

## Verification

- `go test ./pkg/immutable ./pkg/cardinal` with `-race`, `golangci-lint` clean.
- End-to-end: a locally built CLI from the go-ecs branch regenerated physics2d with all four fields converted — protobuf output byte-identical, generated Go compiled, all physics suites passed. That migration was then reverted; it lands separately.



---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `immutable.Slice[T]` as the value-only collection for unbounded component lists, preventing a component `Get` from exposing a mutable `[]T` backing array while keeping reads zero-copy. Derivations no longer clone by default: most reuse and modify the backing array immediately, so callers must derive and then `Set`; dropping a result can leave an unrecorded world change.

**New Features**

- The API follows Go’s `slices` package with value-only readers, derivations, comparisons, searches, sorting, mapping, and collection helpers.
- `SliceOf` copies its input; empty Slices compare by elements with `Equal` or `EqualFunc`, not `reflect.DeepEqual`.
- Protobuf uses the same repeated-field wire format as `[]T`; `encoding/json` does not round-trip Slices, and elements must remain wire-safe values.
- DST random filling recognizes nested Slices, populates them through `Append`, and fails loudly for unaddressable values.
- Documentation covers component value rules, bounded-list alternatives, and derive-then-`Set` usage; `cardinal` re-exports `Slice` and `SliceOf`.
- Tests cover the Slice API, write-through behavior, storage isolation, reflection, and DST filling.

**Migration**

- No components use Slice yet; generator support and the physics2d migration remain separate, and components require a World CLI that recognizes `immutable.Slice`.

<sup>Written for commit 79449a33bf10d5397b928d549b4af742592ac62d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Argus-Labs/world-engine/pull/952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

